### PR TITLE
fix(infra): allow migrate job to reach postgres through network policy

### DIFF
--- a/infra/k8s/migrate-job.yaml
+++ b/infra/k8s/migrate-job.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   backoffLimit: 3
   template:
+    metadata:
+      labels:
+        app: migrate
     spec:
       restartPolicy: OnFailure
       imagePullSecrets:

--- a/infra/k8s/network-policies.yaml
+++ b/infra/k8s/network-policies.yaml
@@ -50,6 +50,9 @@ spec:
         - podSelector:
             matchLabels:
               app: scheduler
+        - podSelector:
+            matchLabels:
+              app: migrate
       ports:
         - port: 5432
           protocol: TCP

--- a/infra/k8s/secrets.yaml
+++ b/infra/k8s/secrets.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: dist-scheduler
 type: Opaque
 stringData:
-  POSTGRES_USER: root
-  POSTGRES_PASSWORD: root
+  POSTGRES_USER: scheduler
+  POSTGRES_PASSWORD: scheduler
   POSTGRES_DB: scheduler
-  DATABASE_URL: "postgres://root:root@postgres:5432/scheduler?sslmode=disable"
+  DATABASE_URL: "postgres://scheduler:scheduler@postgres:5432/scheduler?sslmode=disable"
   JWT_SECRET: 3f6ef4a9b68cd6bb42988901c8b70548ddfbeaefdf6528f938fc4bf201a92ba4
   RESEND_API_KEY: CHANGE_ME
   RESEND_FROM: noreply@enkiduck.com


### PR DESCRIPTION
Migrate pods had no labels, so the default-deny-ingress NetworkPolicy blocked their connections to Postgres. Added app: migrate label to the job pod template, allowed it in the postgres ingress policy, and switched DB credentials from root to scheduler.