### PR TITLE
feat(auth): add long-lived API tokens for programmatic access

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -59,12 +59,16 @@ func main() {
 	scheduleUsecase := usecase.NewScheduleUsecase(scheduleRepo, jobRepo)
 	scheduleHandler := handler.NewScheduleHandler(scheduleUsecase, logger)
 
+	// API tokens
+	tokenRepo := postgres.NewAPITokenRepository(pool)
+	tokenHandler := handler.NewTokenHandler(tokenRepo, logger)
+
 	metrics.Register()
 	checker := health.NewChecker(pool, logger, prometheus.DefaultRegisterer)
 
 	srv := http.Server{
 		Addr:    ":" + cfg.Port,
-		Handler: httptransport.NewRouter(logger, jobHandler, scheduleHandler, userRepo, cfg.ClerkJWKSURL, []byte(cfg.JWTSecret)),
+		Handler: httptransport.NewRouter(logger, jobHandler, scheduleHandler, tokenHandler, userRepo, tokenRepo, cfg.ClerkJWKSURL, []byte(cfg.JWTSecret)),
 	}
 
 	metricsSrv := metrics.NewServer(":"+cfg.MetricsPort, checker)

--- a/internal/domain/token.go
+++ b/internal/domain/token.go
@@ -1,0 +1,17 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+var ErrTokenNotFound = errors.New("api token not found")
+
+type APIToken struct {
+	ID         string
+	UserID     string
+	Name       string
+	Prefix     string // "fliq_sk_XXXXXXXX" — for display only
+	LastUsedAt *time.Time
+	CreatedAt  time.Time
+}

--- a/internal/http/handler/errors.go
+++ b/internal/http/handler/errors.go
@@ -13,4 +13,6 @@ const (
 	errScheduleNameConflict  = "Schedule with this name already exists"
 	errScheduleAlreadyPaused = "Schedule is already paused"
 	errScheduleNotPaused     = "Schedule is not paused"
+
+	errTokenNotFound = "Token not found"
 )

--- a/internal/http/handler/token.go
+++ b/internal/http/handler/token.go
@@ -1,0 +1,121 @@
+package handler
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
+	"github.com/gin-gonic/gin"
+)
+
+type TokenHandler struct {
+	tokenRepo repository.APITokenRepository
+	logger    *slog.Logger
+}
+
+func NewTokenHandler(tokenRepo repository.APITokenRepository, logger *slog.Logger) *TokenHandler {
+	return &TokenHandler{tokenRepo: tokenRepo, logger: logger.With("component", "token_handler")}
+}
+
+type createTokenRequest struct {
+	Name string `json:"name" binding:"required,max=256"`
+}
+
+type createTokenResponse struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Prefix    string    `json:"prefix"`
+	Token     string    `json:"token"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type listTokenItem struct {
+	ID         string     `json:"id"`
+	Name       string     `json:"name"`
+	Prefix     string     `json:"prefix"`
+	LastUsedAt *time.Time `json:"last_used_at"`
+	CreatedAt  time.Time  `json:"created_at"`
+}
+
+func (h *TokenHandler) Create(ctx *gin.Context) {
+	var req createTokenRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	rawBytes := make([]byte, 32)
+	if _, err := rand.Read(rawBytes); err != nil {
+		h.logger.ErrorContext(ctx.Request.Context(), "generate token bytes", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	rawToken := "fliq_sk_" + hex.EncodeToString(rawBytes)
+	sum := sha256.Sum256([]byte(rawToken))
+	tokenHash := fmt.Sprintf("%x", sum)
+	prefix := rawToken[:16] // "fliq_sk_" (8) + first 8 hex chars
+
+	userID := ctx.GetString("userID")
+	tok, err := h.tokenRepo.Create(ctx.Request.Context(), userID, req.Name, tokenHash, prefix)
+	if err != nil {
+		h.logger.ErrorContext(ctx.Request.Context(), "create api token", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, createTokenResponse{
+		ID:        tok.ID,
+		Name:      tok.Name,
+		Prefix:    tok.Prefix,
+		Token:     rawToken,
+		CreatedAt: tok.CreatedAt,
+	})
+}
+
+func (h *TokenHandler) List(ctx *gin.Context) {
+	userID := ctx.GetString("userID")
+	tokens, err := h.tokenRepo.ListByUserID(ctx.Request.Context(), userID)
+	if err != nil {
+		h.logger.ErrorContext(ctx.Request.Context(), "list api tokens", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	items := make([]listTokenItem, len(tokens))
+	for i, tok := range tokens {
+		items[i] = listTokenItem{
+			ID:         tok.ID,
+			Name:       tok.Name,
+			Prefix:     tok.Prefix,
+			LastUsedAt: tok.LastUsedAt,
+			CreatedAt:  tok.CreatedAt,
+		}
+	}
+	ctx.JSON(http.StatusOK, items)
+}
+
+func (h *TokenHandler) Delete(ctx *gin.Context) {
+	tokenID := ctx.Param("id")
+	userID := ctx.GetString("userID")
+
+	err := h.tokenRepo.Delete(ctx.Request.Context(), tokenID, userID)
+	if err != nil {
+		if errors.Is(err, domain.ErrTokenNotFound) {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errTokenNotFound})
+			return
+		}
+		h.logger.ErrorContext(ctx.Request.Context(), "delete api token", "token_id", tokenID, "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}

--- a/internal/http/middleware/auth.go
+++ b/internal/http/middleware/auth.go
@@ -2,10 +2,13 @@ package middleware
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
 	"github.com/gin-gonic/gin"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
@@ -14,13 +17,13 @@ import (
 
 const errUnauthorized = "Unauthorized"
 
-// Auth validates a Bearer JWT and sets "userID" in the gin context.
+// Auth validates a Bearer token and sets "userID" in the gin context.
 //
-// When jwksURL is non-empty the token is verified against the JWKS endpoint
-// (RS256 — Clerk). The key set is auto-cached and refreshed every 15 minutes.
-//
-// When jwksURL is empty, hmacKey is used for HS256 verification (legacy local dev).
-func Auth(jwksURL string, hmacKey []byte) gin.HandlerFunc {
+// Two token formats are supported:
+//   - fliq_sk_<64 hex chars>: API token — hashed and looked up in the DB via tokenRepo.
+//   - JWT (eyJ...): validated as RS256 via JWKS endpoint (Clerk) when jwksURL is set,
+//     or HS256 with hmacKey for local dev.
+func Auth(jwksURL string, hmacKey []byte, tokenRepo repository.APITokenRepository) gin.HandlerFunc {
 	var cache *jwk.Cache
 
 	if jwksURL != "" {
@@ -40,6 +43,22 @@ func Auth(jwksURL string, hmacKey []byte) gin.HandlerFunc {
 
 		rawToken := strings.TrimPrefix(header, "Bearer ")
 
+		// API token path
+		if strings.HasPrefix(rawToken, "fliq_sk_") {
+			sum := sha256.Sum256([]byte(rawToken))
+			hash := fmt.Sprintf("%x", sum)
+			tok, err := tokenRepo.FindByTokenHash(c.Request.Context(), hash)
+			if err != nil {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": errUnauthorized})
+				return
+			}
+			go tokenRepo.UpdateLastUsed(context.Background(), tok.ID) //nolint:errcheck
+			c.Set("userID", tok.UserID)
+			c.Next()
+			return
+		}
+
+		// JWT path
 		var (
 			tok jwt.Token
 			err error

--- a/internal/http/middleware/auth_test.go
+++ b/internal/http/middleware/auth_test.go
@@ -20,9 +20,10 @@ func init() {
 
 // newEngine builds a minimal gin engine with the Auth middleware protecting GET /protected.
 // The handler writes the userID from context so we can assert it was set.
+// tokenRepo is nil because these tests only exercise the JWT path.
 func newEngine() *gin.Engine {
 	r := gin.New()
-	r.GET("/protected", middleware.Auth("", []byte(testKey)), func(c *gin.Context) {
+	r.GET("/protected", middleware.Auth("", []byte(testKey), nil), func(c *gin.Context) {
 		userID, _ := c.Get("userID")
 		c.String(http.StatusOK, "%v", userID)
 	})

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -3,15 +3,15 @@ package httptransport
 import (
 	"log/slog"
 
-	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/handler"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/middleware"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
 	"github.com/gin-gonic/gin"
 
 	sloggin "github.com/samber/slog-gin"
 )
 
-func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHandler *handler.ScheduleHandler, userRepo repository.UserRepository, jwksURL string, hmacKey []byte) *gin.Engine {
+func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHandler *handler.ScheduleHandler, tokenHandler *handler.TokenHandler, userRepo repository.UserRepository, tokenRepo repository.APITokenRepository, jwksURL string, hmacKey []byte) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
 	r.Use(middleware.RequestID())
@@ -19,7 +19,7 @@ func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHand
 	r.Use(sloggin.New(logger))
 	r.Use(middleware.Metrics())
 
-	authMW := middleware.Auth(jwksURL, hmacKey)
+	authMW := middleware.Auth(jwksURL, hmacKey, tokenRepo)
 	ensureUser := middleware.EnsureUser(userRepo, logger)
 
 	// Protected job routes
@@ -39,6 +39,12 @@ func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHand
 	schedules.POST("/:id/resume", scheduleHandler.Resume)
 	schedules.DELETE("/:id", scheduleHandler.Delete)
 	schedules.GET("/:id/jobs", scheduleHandler.ListJobs)
+
+	// Protected token routes
+	tokens := r.Group("/tokens", authMW, ensureUser)
+	tokens.POST("", tokenHandler.Create)
+	tokens.GET("", tokenHandler.List)
+	tokens.DELETE("/:id", tokenHandler.Delete)
 
 	return r
 }

--- a/internal/infrastructure/postgres/token_repo.go
+++ b/internal/infrastructure/postgres/token_repo.go
@@ -1,0 +1,103 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type APITokenRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewAPITokenRepository(pool *pgxpool.Pool) *APITokenRepository {
+	return &APITokenRepository{pool: pool}
+}
+
+func (r *APITokenRepository) Create(ctx context.Context, userID, name, tokenHash, prefix string) (*domain.APIToken, error) {
+	query := `
+		INSERT INTO api_tokens (user_id, name, token_hash, prefix)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, user_id, name, prefix, last_used_at, created_at`
+
+	row := r.pool.QueryRow(ctx, query, userID, name, tokenHash, prefix)
+	tok, err := scanAPIToken(row)
+	if err != nil {
+		return nil, fmt.Errorf("create api token: %w", err)
+	}
+	return tok, nil
+}
+
+func (r *APITokenRepository) FindByTokenHash(ctx context.Context, tokenHash string) (*domain.APIToken, error) {
+	query := `
+		SELECT id, user_id, name, prefix, last_used_at, created_at
+		FROM api_tokens
+		WHERE token_hash = $1`
+
+	row := r.pool.QueryRow(ctx, query, tokenHash)
+	tok, err := scanAPIToken(row)
+	if err != nil {
+		return nil, err
+	}
+	return tok, nil
+}
+
+func (r *APITokenRepository) ListByUserID(ctx context.Context, userID string) ([]*domain.APIToken, error) {
+	query := `
+		SELECT id, user_id, name, prefix, last_used_at, created_at
+		FROM api_tokens
+		WHERE user_id = $1
+		ORDER BY created_at DESC`
+
+	rows, err := r.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list api tokens: %w", err)
+	}
+	defer rows.Close()
+
+	var tokens []*domain.APIToken
+	for rows.Next() {
+		tok, err := scanAPIToken(rows)
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, tok)
+	}
+	return tokens, nil
+}
+
+func (r *APITokenRepository) Delete(ctx context.Context, id, userID string) error {
+	tag, err := r.pool.Exec(ctx,
+		`DELETE FROM api_tokens WHERE id = $1 AND user_id = $2`,
+		id, userID)
+	if err != nil {
+		return fmt.Errorf("delete api token: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.ErrTokenNotFound
+	}
+	return nil
+}
+
+func (r *APITokenRepository) UpdateLastUsed(ctx context.Context, id string) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE api_tokens SET last_used_at = NOW() WHERE id = $1`,
+		id)
+	return err
+}
+
+func scanAPIToken(row rowScanner) (*domain.APIToken, error) {
+	var tok domain.APIToken
+	err := row.Scan(&tok.ID, &tok.UserID, &tok.Name, &tok.Prefix, &tok.LastUsedAt, &tok.CreatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrTokenNotFound
+		}
+		return nil, fmt.Errorf("scan api token: %w", err)
+	}
+	return &tok, nil
+}

--- a/internal/repository/token.go
+++ b/internal/repository/token.go
@@ -1,0 +1,15 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+)
+
+type APITokenRepository interface {
+	Create(ctx context.Context, userID, name, tokenHash, prefix string) (*domain.APIToken, error)
+	FindByTokenHash(ctx context.Context, tokenHash string) (*domain.APIToken, error)
+	ListByUserID(ctx context.Context, userID string) ([]*domain.APIToken, error)
+	Delete(ctx context.Context, id, userID string) error
+	UpdateLastUsed(ctx context.Context, id string) error
+}

--- a/migrations/20260302000003_api_tokens.sql
+++ b/migrations/20260302000003_api_tokens.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+CREATE TABLE api_tokens (
+    id           TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    user_id      TEXT NOT NULL REFERENCES users(id),
+    name         TEXT NOT NULL,
+    token_hash   TEXT UNIQUE NOT NULL,   -- SHA-256 of the raw token
+    prefix       TEXT NOT NULL,          -- "fliq_sk_XXXXXXXX" for display
+    last_used_at TIMESTAMPTZ,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_api_tokens_user ON api_tokens(user_id);
+
+-- +goose Down
+DROP INDEX idx_api_tokens_user;
+DROP TABLE api_tokens;


### PR DESCRIPTION
## Summary

- Introduces `fliq_sk_<64 hex>` API tokens so developers can authenticate from scripts/servers without a short-lived Clerk JWT
- SHA-256 hash stored in DB; raw token returned once on `POST /tokens`, never again
- Auth middleware now handles two Bearer paths: `fliq_sk_` → hash lookup, `eyJ…` → existing JWT path (unchanged)
- Settings page replaced with token management UI (list, create with one-time copy banner, revoke)

## New endpoints

| Method | Path | Description |
|---|---|---|
| `POST` | `/tokens` | Create token — returns raw token once |
| `GET` | `/tokens` | List tokens (no raw token) |
| `DELETE` | `/tokens/:id` | Revoke token → 204 |

## Notes

Replaces PR #13 (`chore/cleanup-post-clerk-migration`) which had a merge conflict and an accidental commit of a compiled binary. The cleanup commits from that PR are already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)