### PR TITLE
Add buffers: rate-limited HTTP request queues

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -71,6 +71,17 @@ func main() {
 	dispatcher := scheduler.NewDispatcher(scheduleRepo, creditRepo, logger, time.Duration(cfg.DispatchIntervalSec)*time.Second)
 	go dispatcher.Start(ctx)
 
+	bufferRepo := postgres.NewBufferRepository(pool)
+	drainer := scheduler.NewBufferDrainer(
+		bufferRepo, creditRepo, signingRepo, notifier, logger,
+		time.Duration(cfg.DrainerPollIntervalSec)*time.Second,
+		cfg.DrainerConcurrency,
+	)
+	go drainer.Start(ctx)
+
+	bufferReaper := scheduler.NewBufferReaper(bufferRepo, logger, 30*time.Second, 30*time.Second)
+	go bufferReaper.Start(ctx)
+
 	metricsSrv := metrics.NewServer(":"+cfg.MetricsPort, checker)
 	go func() {
 		logger.Info("metrics server started", "port", cfg.MetricsPort)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -87,6 +87,11 @@ func main() {
 	signingRepo := postgres.NewSigningSecretRepository(pool)
 	signingHandler := handler.NewSigningHandler(signingRepo, logger)
 
+	// Buffers
+	bufferRepo := postgres.NewBufferRepository(pool)
+	bufferUsecase := usecase.NewBufferUsecase(bufferRepo, creditRepo)
+	bufferHandler := handler.NewBufferHandler(bufferUsecase, logger)
+
 	metrics.Register()
 	checker := health.NewChecker(pool, logger, prometheus.DefaultRegisterer)
 
@@ -95,7 +100,7 @@ func main() {
 
 	srv := http.Server{
 		Addr:    ":" + cfg.Port,
-		Handler: httptransport.NewRouter(logger, jobHandler, scheduleHandler, tokenHandler, billingHandler, signingHandler, userRepo, creditRepo, tokenRepo, cfg.ClerkJWKSURL, []byte(cfg.JWTSecret), cfg.CORSAllowedOrigins, rateLimiter),
+		Handler: httptransport.NewRouter(logger, jobHandler, scheduleHandler, tokenHandler, billingHandler, signingHandler, bufferHandler, userRepo, creditRepo, tokenRepo, cfg.ClerkJWKSURL, []byte(cfg.JWTSecret), cfg.CORSAllowedOrigins, rateLimiter),
 	}
 
 	metricsSrv := metrics.NewServer(":"+cfg.MetricsPort, checker)

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,9 @@ type Config struct {
 	DatabaseURL        string `env:"DATABASE_URL,required" validate:"required"`
 	WorkerCount        int    `env:"WORKER_COUNT" envDefault:"5" validate:"min=1,max=100"`
 	PollIntervalSec    int    `env:"POLL_INTERVAL_SEC" envDefault:"1" validate:"min=1,max=60"`
-	DispatchIntervalSec int   `env:"DISPATCH_INTERVAL_SEC" envDefault:"5" validate:"min=1,max=60"`
+	DispatchIntervalSec  int  `env:"DISPATCH_INTERVAL_SEC" envDefault:"5" validate:"min=1,max=60"`
+	DrainerConcurrency   int  `env:"DRAINER_CONCURRENCY" envDefault:"10" validate:"min=1,max=100"`
+	DrainerPollIntervalSec int `env:"DRAINER_POLL_INTERVAL_SEC" envDefault:"1" validate:"min=1,max=10"`
 
 	MetricsPort string `env:"METRICS_PORT" envDefault:"9090"`
 	LogLevel    string `env:"LOG_LEVEL" envDefault:"info" validate:"required,oneof=debug info warn error"`

--- a/internal/domain/billing.go
+++ b/internal/domain/billing.go
@@ -26,9 +26,10 @@ type CreditBalance struct {
 type CreditTxType string
 
 const (
-	CreditTxJobExecution CreditTxType = "job_execution"
-	CreditTxDailyGrant   CreditTxType = "daily_grant"
-	CreditTxStripeTopup  CreditTxType = "stripe_topup"
+	CreditTxJobExecution    CreditTxType = "job_execution"
+	CreditTxBufferExecution CreditTxType = "buffer_execution"
+	CreditTxDailyGrant      CreditTxType = "daily_grant"
+	CreditTxStripeTopup     CreditTxType = "stripe_topup"
 )
 
 type CreditTransaction struct {

--- a/internal/domain/buffer.go
+++ b/internal/domain/buffer.go
@@ -1,0 +1,68 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	ErrBufferNotFound      = errors.New("buffer not found")
+	ErrBufferNameConflict  = errors.New("buffer with this name already exists")
+	ErrBufferAlreadyPaused = errors.New("buffer is already paused")
+	ErrBufferNotPaused     = errors.New("buffer is not paused")
+	ErrBufferItemNotFound  = errors.New("buffer item not found")
+)
+
+type BufferItemStatus string
+
+const (
+	BufferItemPending   BufferItemStatus = "pending"
+	BufferItemRunning   BufferItemStatus = "running"
+	BufferItemCompleted BufferItemStatus = "completed"
+	BufferItemFailed    BufferItemStatus = "failed"
+)
+
+type Buffer struct {
+	ID             string
+	UserID         string
+	Name           string
+	URL            string
+	Method         string
+	Headers        map[string]string
+	TimeoutSeconds int
+	RateLimit      int
+	MaxRetries     int
+	Backoff        Backoff
+	Paused         bool
+	WebhookURL     *string
+	WebhookHeaders map[string]string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+type BufferItem struct {
+	ID             string
+	BufferID       string
+	UserID         string
+	URL            string
+	Method         string
+	Headers        map[string]string
+	Body           *string
+	TimeoutSeconds int
+	Backoff        Backoff
+
+	Status     BufferItemStatus
+	RetryCount int
+	MaxRetries int
+
+	ScheduledAt time.Time
+	ClaimedAt   *time.Time
+	ClaimedBy   *string
+	HeartbeatAt *time.Time
+	CompletedAt *time.Time
+	LastError   *string
+	StatusCode  *int
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}

--- a/internal/http/handler/buffer.go
+++ b/internal/http/handler/buffer.go
@@ -1,0 +1,333 @@
+package handler
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
+	"github.com/gin-gonic/gin"
+)
+
+type BufferHandler struct {
+	uc     *usecase.BufferUsecase
+	logger *slog.Logger
+}
+
+func NewBufferHandler(uc *usecase.BufferUsecase, logger *slog.Logger) *BufferHandler {
+	return &BufferHandler{uc: uc, logger: logger.With("component", "buffer_handler")}
+}
+
+// ── Request / Response types ─────────────────────────────────────────────────
+
+type createBufferRequest struct {
+	Name           string            `json:"name"            binding:"required,max=256"`
+	URL            string            `json:"url"             binding:"required,url,max=2048"`
+	Method         string            `json:"method"          binding:"omitempty,oneof=GET POST PUT PATCH DELETE"`
+	Headers        map[string]string `json:"headers"`
+	TimeoutSeconds int               `json:"timeout_seconds" binding:"omitempty,min=1,max=3600"`
+	RateLimit      int               `json:"rate_limit"      binding:"omitempty,min=1,max=1000"`
+	MaxRetries     *int              `json:"max_retries"     binding:"omitempty,min=0,max=20"`
+	Backoff        domain.Backoff    `json:"backoff"         binding:"omitempty,oneof=exponential linear"`
+	WebhookURL     *string           `json:"webhook_url"     binding:"omitempty,url,max=2048"`
+	WebhookHeaders map[string]string `json:"webhook_headers"`
+}
+
+type bufferResponse struct {
+	ID             string         `json:"id"`
+	Name           string         `json:"name"`
+	URL            string         `json:"url"`
+	Method         string         `json:"method"`
+	TimeoutSeconds int            `json:"timeout_seconds"`
+	RateLimit      int            `json:"rate_limit"`
+	MaxRetries     int            `json:"max_retries"`
+	Backoff        domain.Backoff `json:"backoff"`
+	Paused         bool           `json:"paused"`
+	WebhookURL     *string        `json:"webhook_url,omitempty"`
+	CreatedAt      time.Time      `json:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at"`
+}
+
+func toBufferResponse(b *domain.Buffer) bufferResponse {
+	return bufferResponse{
+		ID:             b.ID,
+		Name:           b.Name,
+		URL:            b.URL,
+		Method:         b.Method,
+		TimeoutSeconds: b.TimeoutSeconds,
+		RateLimit:      b.RateLimit,
+		MaxRetries:     b.MaxRetries,
+		Backoff:        b.Backoff,
+		Paused:         b.Paused,
+		WebhookURL:     b.WebhookURL,
+		CreatedAt:      b.CreatedAt,
+		UpdatedAt:      b.UpdatedAt,
+	}
+}
+
+type pushItemRequest struct {
+	Body    *string           `json:"body"`
+	Headers map[string]string `json:"headers"`
+}
+
+type bufferItemResponse struct {
+	ID          string                `json:"id"`
+	BufferID    string                `json:"buffer_id"`
+	Status      domain.BufferItemStatus `json:"status"`
+	StatusCode  *int                  `json:"status_code,omitempty"`
+	RetryCount  int                   `json:"retry_count"`
+	MaxRetries  int                   `json:"max_retries"`
+	LastError   *string               `json:"last_error,omitempty"`
+	CreatedAt   time.Time             `json:"created_at"`
+	CompletedAt *time.Time            `json:"completed_at,omitempty"`
+}
+
+func toBufferItemResponse(item *domain.BufferItem) bufferItemResponse {
+	return bufferItemResponse{
+		ID:          item.ID,
+		BufferID:    item.BufferID,
+		Status:      item.Status,
+		StatusCode:  item.StatusCode,
+		RetryCount:  item.RetryCount,
+		MaxRetries:  item.MaxRetries,
+		LastError:   item.LastError,
+		CreatedAt:   item.CreatedAt,
+		CompletedAt: item.CompletedAt,
+	}
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+func (h *BufferHandler) Create(ctx *gin.Context) {
+	var req createBufferRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": formatValidationError(err)})
+		return
+	}
+
+	method := req.Method
+	if method == "" {
+		method = "POST"
+	}
+
+	b, err := h.uc.CreateBuffer(ctx.Request.Context(), usecase.CreateBufferInput{
+		UserID:         ctx.GetString("userID"),
+		Name:           req.Name,
+		URL:            req.URL,
+		Method:         method,
+		Headers:        req.Headers,
+		TimeoutSeconds: req.TimeoutSeconds,
+		RateLimit:      req.RateLimit,
+		MaxRetries:     req.MaxRetries,
+		Backoff:        req.Backoff,
+		WebhookURL:     req.WebhookURL,
+		WebhookHeaders: req.WebhookHeaders,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrBufferNameConflict):
+			ctx.JSON(http.StatusConflict, gin.H{"error": errBufferNameConflict})
+		default:
+			h.logger.ErrorContext(ctx.Request.Context(), "create buffer", "error", err)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		}
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, toBufferResponse(b))
+}
+
+func (h *BufferHandler) List(ctx *gin.Context) {
+	limit, err := parseLimit(ctx.Query("limit"))
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidLimit})
+		return
+	}
+
+	result, err := h.uc.ListBuffers(ctx.Request.Context(), usecase.ListBuffersInput{
+		UserID: ctx.GetString("userID"),
+		Cursor: ctx.Query("cursor"),
+		Limit:  limit,
+	})
+	if err != nil {
+		h.logger.ErrorContext(ctx.Request.Context(), "list buffers", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	items := make([]bufferResponse, len(result.Buffers))
+	for i, b := range result.Buffers {
+		items[i] = toBufferResponse(b)
+	}
+	ctx.JSON(http.StatusOK, gin.H{
+		"buffers":     items,
+		"next_cursor": result.NextCursor,
+	})
+}
+
+func (h *BufferHandler) GetByID(ctx *gin.Context) {
+	id := ctx.Param("id")
+
+	b, err := h.uc.GetBuffer(ctx.Request.Context(), id, ctx.GetString("userID"))
+	if err != nil {
+		if errors.Is(err, domain.ErrBufferNotFound) {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errBufferNotFound})
+			return
+		}
+		h.logger.ErrorContext(ctx.Request.Context(), "get buffer", "buffer_id", id, "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, toBufferResponse(b))
+}
+
+func (h *BufferHandler) Pause(ctx *gin.Context) {
+	id := ctx.Param("id")
+
+	err := h.uc.PauseBuffer(ctx.Request.Context(), id, ctx.GetString("userID"))
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrBufferNotFound):
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errBufferNotFound})
+		case errors.Is(err, domain.ErrBufferAlreadyPaused):
+			ctx.JSON(http.StatusConflict, gin.H{"error": errBufferAlreadyPaused})
+		default:
+			h.logger.ErrorContext(ctx.Request.Context(), "pause buffer", "buffer_id", id, "error", err)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		}
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+func (h *BufferHandler) Resume(ctx *gin.Context) {
+	id := ctx.Param("id")
+
+	err := h.uc.ResumeBuffer(ctx.Request.Context(), id, ctx.GetString("userID"))
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrBufferNotFound):
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errBufferNotFound})
+		case errors.Is(err, domain.ErrBufferNotPaused):
+			ctx.JSON(http.StatusConflict, gin.H{"error": errBufferNotPaused})
+		default:
+			h.logger.ErrorContext(ctx.Request.Context(), "resume buffer", "buffer_id", id, "error", err)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		}
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+func (h *BufferHandler) Delete(ctx *gin.Context) {
+	id := ctx.Param("id")
+
+	err := h.uc.DeleteBuffer(ctx.Request.Context(), id, ctx.GetString("userID"))
+	if err != nil {
+		if errors.Is(err, domain.ErrBufferNotFound) {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errBufferNotFound})
+			return
+		}
+		h.logger.ErrorContext(ctx.Request.Context(), "delete buffer", "buffer_id", id, "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+func (h *BufferHandler) PushItem(ctx *gin.Context) {
+	bufferID := ctx.Param("id")
+
+	var req pushItemRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": formatValidationError(err)})
+		return
+	}
+
+	item, err := h.uc.PushItem(ctx.Request.Context(), usecase.PushBufferItemInput{
+		UserID:   ctx.GetString("userID"),
+		BufferID: bufferID,
+		Body:     req.Body,
+		Headers:  req.Headers,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrBufferNotFound):
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errBufferNotFound})
+		case errors.Is(err, domain.ErrInsufficientCredits):
+			ctx.JSON(http.StatusPaymentRequired, gin.H{"error": errInsufficientCredits})
+		default:
+			h.logger.ErrorContext(ctx.Request.Context(), "push buffer item", "buffer_id", bufferID, "error", err)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		}
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, toBufferItemResponse(item))
+}
+
+func (h *BufferHandler) ListItems(ctx *gin.Context) {
+	bufferID := ctx.Param("id")
+
+	limit, err := parseLimit(ctx.Query("limit"))
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidLimit})
+		return
+	}
+
+	result, err := h.uc.ListItems(ctx.Request.Context(), usecase.ListBufferItemsInput{
+		BufferID: bufferID,
+		UserID:   ctx.GetString("userID"),
+		Status:   ctx.Query("status"),
+		Cursor:   ctx.Query("cursor"),
+		Limit:    limit,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrBufferNotFound):
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errBufferNotFound})
+		case errors.Is(err, domain.ErrInvalidStatus):
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidStatus})
+		default:
+			h.logger.ErrorContext(ctx.Request.Context(), "list buffer items", "buffer_id", bufferID, "error", err)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		}
+		return
+	}
+
+	items := make([]bufferItemResponse, len(result.Items))
+	for i, item := range result.Items {
+		items[i] = toBufferItemResponse(item)
+	}
+	ctx.JSON(http.StatusOK, gin.H{
+		"items":       items,
+		"next_cursor": result.NextCursor,
+	})
+}
+
+func (h *BufferHandler) GetItem(ctx *gin.Context) {
+	bufferID := ctx.Param("id")
+	itemID := ctx.Param("itemId")
+
+	item, err := h.uc.GetItem(ctx.Request.Context(), itemID, bufferID, ctx.GetString("userID"))
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrBufferNotFound):
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errBufferNotFound})
+		case errors.Is(err, domain.ErrBufferItemNotFound):
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errBufferItemNotFound})
+		default:
+			h.logger.ErrorContext(ctx.Request.Context(), "get buffer item", "buffer_id", bufferID, "item_id", itemID, "error", err)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		}
+		return
+	}
+
+	ctx.JSON(http.StatusOK, toBufferItemResponse(item))
+}

--- a/internal/http/handler/errors.go
+++ b/internal/http/handler/errors.go
@@ -20,5 +20,11 @@ const (
 
 	errSigningSecretNotFound = "No signing secret found to rotate"
 
+	errBufferNotFound      = "Buffer not found"
+	errBufferNameConflict  = "Buffer with this name already exists"
+	errBufferAlreadyPaused = "Buffer is already paused"
+	errBufferNotPaused     = "Buffer is not paused"
+	errBufferItemNotFound  = "Buffer item not found"
+
 	errInvalidLimit = "limit must be between 1 and 100"
 )

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -11,7 +11,7 @@ import (
 	sloggin "github.com/samber/slog-gin"
 )
 
-func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHandler *handler.ScheduleHandler, tokenHandler *handler.TokenHandler, billingHandler *handler.BillingHandler, signingHandler *handler.SigningHandler, userRepo repository.UserRepository, creditRepo repository.CreditRepository, tokenRepo repository.APITokenRepository, jwksURL string, hmacKey []byte, corsAllowedOrigins string, rateLimiter *middleware.RateLimiter) *gin.Engine {
+func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHandler *handler.ScheduleHandler, tokenHandler *handler.TokenHandler, billingHandler *handler.BillingHandler, signingHandler *handler.SigningHandler, bufferHandler *handler.BufferHandler, userRepo repository.UserRepository, creditRepo repository.CreditRepository, tokenRepo repository.APITokenRepository, jwksURL string, hmacKey []byte, corsAllowedOrigins string, rateLimiter *middleware.RateLimiter) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
 	r.Use(middleware.RequestID())
@@ -40,6 +40,18 @@ func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHand
 	schedules.POST("/:id/resume", scheduleHandler.Resume)
 	schedules.DELETE("/:id", scheduleHandler.Delete)
 	schedules.GET("/:id/jobs", scheduleHandler.ListJobs)
+
+	// Protected buffer routes
+	buffers := r.Group("/buffers", authMW, ensureUser, rateLimiter.Middleware())
+	buffers.POST("", bufferHandler.Create)
+	buffers.GET("", bufferHandler.List)
+	buffers.GET("/:id", bufferHandler.GetByID)
+	buffers.POST("/:id/pause", bufferHandler.Pause)
+	buffers.POST("/:id/resume", bufferHandler.Resume)
+	buffers.DELETE("/:id", bufferHandler.Delete)
+	buffers.POST("/:id/items", bufferHandler.PushItem)
+	buffers.GET("/:id/items", bufferHandler.ListItems)
+	buffers.GET("/:id/items/:itemId", bufferHandler.GetItem)
 
 	// Protected token routes
 	tokens := r.Group("/tokens", authMW, ensureUser, rateLimiter.Middleware())

--- a/internal/infrastructure/postgres/buffer_repo.go
+++ b/internal/infrastructure/postgres/buffer_repo.go
@@ -1,0 +1,405 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type BufferRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewBufferRepository(pool *pgxpool.Pool) *BufferRepository {
+	return &BufferRepository{pool: pool}
+}
+
+// ── Buffer CRUD ──────────────────────────────────────────────────────────────
+
+func (r *BufferRepository) Create(ctx context.Context, b *domain.Buffer) (*domain.Buffer, error) {
+	query := `
+		INSERT INTO buffers (
+			user_id, name, url, method, headers, timeout_seconds,
+			rate_limit, max_retries, backoff, paused, webhook_url, webhook_headers
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		RETURNING id, user_id, name, url, method, headers, timeout_seconds,
+		          rate_limit, max_retries, backoff, paused,
+		          webhook_url, webhook_headers, created_at, updated_at`
+
+	row := r.pool.QueryRow(ctx, query,
+		b.UserID, b.Name, b.URL, b.Method, b.Headers, b.TimeoutSeconds,
+		b.RateLimit, b.MaxRetries, b.Backoff, b.Paused, b.WebhookURL, b.WebhookHeaders,
+	)
+
+	created, err := scanBuffer(row)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, domain.ErrBufferNameConflict
+		}
+		return nil, err
+	}
+	return created, nil
+}
+
+func (r *BufferRepository) GetByID(ctx context.Context, id, userID string) (*domain.Buffer, error) {
+	query := `
+		SELECT id, user_id, name, url, method, headers, timeout_seconds,
+		       rate_limit, max_retries, backoff, paused,
+		       webhook_url, webhook_headers, created_at, updated_at
+		FROM buffers
+		WHERE id = $1 AND user_id = $2`
+
+	row := r.pool.QueryRow(ctx, query, id, userID)
+	return scanBuffer(row)
+}
+
+func (r *BufferRepository) GetByIDInternal(ctx context.Context, id string) (*domain.Buffer, error) {
+	query := `
+		SELECT id, user_id, name, url, method, headers, timeout_seconds,
+		       rate_limit, max_retries, backoff, paused,
+		       webhook_url, webhook_headers, created_at, updated_at
+		FROM buffers
+		WHERE id = $1`
+
+	row := r.pool.QueryRow(ctx, query, id)
+	return scanBuffer(row)
+}
+
+func (r *BufferRepository) List(ctx context.Context, input repository.ListBuffersInput) ([]*domain.Buffer, error) {
+	args := []any{input.UserID}
+	where := []string{"user_id = $1"}
+
+	if input.CursorTime != nil {
+		args = append(args, *input.CursorTime, input.CursorID)
+		where = append(where, fmt.Sprintf("(created_at, id) < ($%d, $%d)", len(args)-1, len(args)))
+	}
+	args = append(args, input.Limit)
+
+	query := fmt.Sprintf(`
+		SELECT id, user_id, name, url, method, headers, timeout_seconds,
+		       rate_limit, max_retries, backoff, paused,
+		       webhook_url, webhook_headers, created_at, updated_at
+		FROM buffers
+		WHERE %s
+		ORDER BY created_at DESC, id DESC
+		LIMIT $%d`,
+		strings.Join(where, " AND "), len(args))
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list buffers: %w", err)
+	}
+	defer rows.Close()
+
+	var buffers []*domain.Buffer
+	for rows.Next() {
+		b, scanErr := scanBuffer(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		buffers = append(buffers, b)
+	}
+	return buffers, nil
+}
+
+func (r *BufferRepository) SetPaused(ctx context.Context, id, userID string, paused bool) error {
+	tag, err := r.pool.Exec(ctx,
+		`UPDATE buffers SET paused = $3, updated_at = NOW()
+		 WHERE id = $1 AND user_id = $2 AND paused = $4`,
+		id, userID, paused, !paused)
+	if err != nil {
+		return fmt.Errorf("set paused: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		if _, err := r.GetByID(ctx, id, userID); err != nil {
+			return err
+		}
+		if paused {
+			return domain.ErrBufferAlreadyPaused
+		}
+		return domain.ErrBufferNotPaused
+	}
+	return nil
+}
+
+func (r *BufferRepository) Delete(ctx context.Context, id, userID string) error {
+	tag, err := r.pool.Exec(ctx,
+		`DELETE FROM buffers WHERE id = $1 AND user_id = $2`,
+		id, userID)
+	if err != nil {
+		return fmt.Errorf("delete buffer: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.ErrBufferNotFound
+	}
+	return nil
+}
+
+// ── Item CRUD ────────────────────────────────────────────────────────────────
+
+func (r *BufferRepository) CreateItem(ctx context.Context, item *domain.BufferItem) (*domain.BufferItem, error) {
+	query := `
+		INSERT INTO buffer_items (
+			buffer_id, user_id, url, method, headers, body,
+			timeout_seconds, backoff, status, max_retries, scheduled_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		RETURNING id, buffer_id, user_id, url, method, headers, body,
+		          timeout_seconds, backoff, status, retry_count, max_retries,
+		          scheduled_at, claimed_at, claimed_by, heartbeat_at,
+		          completed_at, last_error, status_code, created_at, updated_at`
+
+	row := r.pool.QueryRow(ctx, query,
+		item.BufferID, item.UserID, item.URL, item.Method, item.Headers, item.Body,
+		item.TimeoutSeconds, item.Backoff, item.Status, item.MaxRetries, item.ScheduledAt,
+	)
+
+	return scanBufferItem(row)
+}
+
+func (r *BufferRepository) GetItemByID(ctx context.Context, itemID, bufferID string) (*domain.BufferItem, error) {
+	query := `
+		SELECT id, buffer_id, user_id, url, method, headers, body,
+		       timeout_seconds, backoff, status, retry_count, max_retries,
+		       scheduled_at, claimed_at, claimed_by, heartbeat_at,
+		       completed_at, last_error, status_code, created_at, updated_at
+		FROM buffer_items
+		WHERE id = $1 AND buffer_id = $2`
+
+	row := r.pool.QueryRow(ctx, query, itemID, bufferID)
+	return scanBufferItem(row)
+}
+
+func (r *BufferRepository) ListItems(ctx context.Context, input repository.ListBufferItemsInput) ([]*domain.BufferItem, error) {
+	args := []any{input.BufferID}
+	where := []string{"buffer_id = $1"}
+
+	if input.Status != "" {
+		args = append(args, input.Status)
+		where = append(where, fmt.Sprintf("status = $%d", len(args)))
+	}
+	if input.CursorTime != nil {
+		args = append(args, *input.CursorTime, input.CursorID)
+		where = append(where, fmt.Sprintf("(created_at, id) < ($%d, $%d)", len(args)-1, len(args)))
+	}
+	args = append(args, input.Limit)
+
+	query := fmt.Sprintf(`
+		SELECT id, buffer_id, user_id, url, method, headers, body,
+		       timeout_seconds, backoff, status, retry_count, max_retries,
+		       scheduled_at, claimed_at, claimed_by, heartbeat_at,
+		       completed_at, last_error, status_code, created_at, updated_at
+		FROM buffer_items
+		WHERE %s
+		ORDER BY created_at DESC, id DESC
+		LIMIT $%d`,
+		strings.Join(where, " AND "), len(args))
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list buffer items: %w", err)
+	}
+	defer rows.Close()
+
+	var items []*domain.BufferItem
+	for rows.Next() {
+		item, scanErr := scanBufferItem(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+// ── Drainer-facing ───────────────────────────────────────────────────────────
+
+func (r *BufferRepository) ListActiveBufferIDs(ctx context.Context, limit int) ([]string, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT DISTINCT b.id
+		FROM buffers b
+		WHERE NOT b.paused
+		  AND EXISTS (
+			SELECT 1 FROM buffer_items bi
+			WHERE bi.buffer_id = b.id
+			  AND bi.status = 'pending'
+			  AND bi.scheduled_at <= NOW()
+		  )
+		LIMIT $1`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list active buffer ids: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan buffer id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func (r *BufferRepository) ClaimItems(ctx context.Context, bufferID, workerID string, limit int) ([]*domain.BufferItem, error) {
+	query := `
+		UPDATE buffer_items
+		SET    status       = 'running',
+		       claimed_at   = NOW(),
+		       claimed_by   = $1,
+		       heartbeat_at = NOW(),
+		       updated_at   = NOW()
+		WHERE id IN (
+			SELECT id FROM buffer_items
+			WHERE  buffer_id    = $2
+			  AND  status       = 'pending'
+			  AND  scheduled_at <= NOW()
+			ORDER BY created_at ASC
+			LIMIT $3
+			FOR UPDATE SKIP LOCKED
+		)
+		RETURNING id, buffer_id, user_id, url, method, headers, body,
+		          timeout_seconds, backoff, status, retry_count, max_retries,
+		          scheduled_at, claimed_at, claimed_by, heartbeat_at,
+		          completed_at, last_error, status_code, created_at, updated_at`
+
+	rows, err := r.pool.Query(ctx, query, workerID, bufferID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("claim buffer items: %w", err)
+	}
+	defer rows.Close()
+
+	var items []*domain.BufferItem
+	for rows.Next() {
+		item, scanErr := scanBufferItem(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+func (r *BufferRepository) UpdateItemHeartbeat(ctx context.Context, itemID string) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE buffer_items SET heartbeat_at = NOW(), updated_at = NOW()
+		WHERE id = $1 AND status = 'running'`, itemID)
+	return err
+}
+
+func (r *BufferRepository) CompleteItem(ctx context.Context, itemID string, statusCode int) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE buffer_items SET status = 'completed', status_code = $2, completed_at = NOW(), updated_at = NOW()
+		WHERE id = $1`, itemID, statusCode)
+	return err
+}
+
+func (r *BufferRepository) FailItem(ctx context.Context, itemID string, lastError string, statusCode *int) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE buffer_items SET status = 'failed', last_error = $2, status_code = $3, completed_at = NOW(), updated_at = NOW()
+		WHERE id = $1`, itemID, lastError, statusCode)
+	return err
+}
+
+func (r *BufferRepository) RescheduleItem(ctx context.Context, itemID string, lastError string, statusCode *int, retryAt time.Time) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE buffer_items
+		SET    status       = 'pending',
+		       retry_count  = retry_count + 1,
+		       last_error   = $2,
+		       status_code  = $3,
+		       scheduled_at = $4,
+		       claimed_at   = NULL,
+		       claimed_by   = NULL,
+		       heartbeat_at = NULL,
+		       updated_at   = NOW()
+		WHERE id = $1`, itemID, lastError, statusCode, retryAt)
+	return err
+}
+
+// ── Reaper methods ───────────────────────────────────────────────────────────
+
+func (r *BufferRepository) RescheduleStaleItems(ctx context.Context, staleCutoff time.Time, limit int) (int, error) {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE buffer_items
+		SET    status       = 'pending',
+		       retry_count  = retry_count + 1,
+		       last_error   = 'worker timeout',
+		       claimed_at   = NULL,
+		       claimed_by   = NULL,
+		       heartbeat_at = NULL,
+		       updated_at   = NOW()
+		WHERE id IN (
+			SELECT id FROM buffer_items
+			WHERE  status       = 'running'
+			  AND  heartbeat_at < $1
+			  AND  retry_count  < max_retries
+			ORDER BY heartbeat_at ASC
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		)`, staleCutoff, limit)
+	return int(tag.RowsAffected()), err
+}
+
+func (r *BufferRepository) FailStaleItems(ctx context.Context, staleCutoff time.Time, limit int) (int, error) {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE buffer_items
+		SET    status      = 'failed',
+		       last_error  = 'worker timeout: max retries exceeded',
+		       completed_at = NOW(),
+		       updated_at  = NOW()
+		WHERE id IN (
+			SELECT id FROM buffer_items
+			WHERE  status       = 'running'
+			  AND  heartbeat_at < $1
+			  AND  retry_count  >= max_retries
+			ORDER BY heartbeat_at ASC
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		)`, staleCutoff, limit)
+	return int(tag.RowsAffected()), err
+}
+
+// ── Scan helpers ─────────────────────────────────────────────────────────────
+
+func scanBuffer(row rowScanner) (*domain.Buffer, error) {
+	var b domain.Buffer
+	err := row.Scan(
+		&b.ID, &b.UserID, &b.Name, &b.URL, &b.Method, &b.Headers, &b.TimeoutSeconds,
+		&b.RateLimit, &b.MaxRetries, &b.Backoff, &b.Paused,
+		&b.WebhookURL, &b.WebhookHeaders, &b.CreatedAt, &b.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrBufferNotFound
+		}
+		return nil, fmt.Errorf("scan buffer: %w", err)
+	}
+	return &b, nil
+}
+
+func scanBufferItem(row rowScanner) (*domain.BufferItem, error) {
+	var item domain.BufferItem
+	err := row.Scan(
+		&item.ID, &item.BufferID, &item.UserID, &item.URL, &item.Method, &item.Headers, &item.Body,
+		&item.TimeoutSeconds, &item.Backoff, &item.Status, &item.RetryCount, &item.MaxRetries,
+		&item.ScheduledAt, &item.ClaimedAt, &item.ClaimedBy, &item.HeartbeatAt,
+		&item.CompletedAt, &item.LastError, &item.StatusCode, &item.CreatedAt, &item.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrBufferItemNotFound
+		}
+		return nil, fmt.Errorf("scan buffer item: %w", err)
+	}
+	return &item, nil
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -97,6 +97,40 @@ var (
 		Buckets:   []float64{.01, .05, .1, .25, .5, 1, 2.5, 5, 10},
 	})
 
+	// Buffer drainer metrics
+
+	BufferItemsInFlight = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "scheduler",
+		Name:      "buffer_items_in_flight",
+		Help:      "Number of buffer items currently being executed by the drainer.",
+	})
+
+	BufferItemsCompletedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "scheduler",
+		Name:      "buffer_items_completed_total",
+		Help:      "Total buffer items finished, by outcome.",
+	}, []string{"outcome"})
+
+	BufferDrainerCycleDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "scheduler",
+		Name:      "buffer_drainer_cycle_duration_seconds",
+		Help:      "Time taken for one drainer cycle.",
+		Buckets:   prometheus.DefBuckets,
+	})
+
+	BufferReaperRescuedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "scheduler",
+		Name:      "buffer_reaper_rescued_total",
+		Help:      "Total stale buffer items handled by the buffer reaper.",
+	}, []string{"action"})
+
+	BufferReaperCycleDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "scheduler",
+		Name:      "buffer_reaper_cycle_duration_seconds",
+		Help:      "Time taken for one buffer reaper cycle.",
+		Buckets:   prometheus.DefBuckets,
+	})
+
 	// Rate limiting
 
 	RateLimitExceededTotal = prometheus.NewCounter(prometheus.CounterOpts{
@@ -120,6 +154,11 @@ func Register() {
 		HTTPRequestsTotal,
 		WebhookDeliveriesTotal,
 		WebhookDuration,
+		BufferItemsInFlight,
+		BufferItemsCompletedTotal,
+		BufferDrainerCycleDuration,
+		BufferReaperRescuedTotal,
+		BufferReaperCycleDuration,
 		RateLimitExceededTotal,
 	)
 }

--- a/internal/repository/buffer.go
+++ b/internal/repository/buffer.go
@@ -1,0 +1,51 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+)
+
+type ListBuffersInput struct {
+	UserID     string
+	CursorTime *time.Time
+	CursorID   string
+	Limit      int
+}
+
+type ListBufferItemsInput struct {
+	BufferID   string
+	Status     domain.BufferItemStatus // empty = all
+	CursorTime *time.Time
+	CursorID   string
+	Limit      int
+}
+
+type BufferRepository interface {
+	// CRUD
+	Create(ctx context.Context, b *domain.Buffer) (*domain.Buffer, error)
+	GetByID(ctx context.Context, id, userID string) (*domain.Buffer, error)
+	GetByIDInternal(ctx context.Context, id string) (*domain.Buffer, error)
+	List(ctx context.Context, input ListBuffersInput) ([]*domain.Buffer, error)
+	SetPaused(ctx context.Context, id, userID string, paused bool) error
+	Delete(ctx context.Context, id, userID string) error
+
+	// Item CRUD
+	CreateItem(ctx context.Context, item *domain.BufferItem) (*domain.BufferItem, error)
+	GetItemByID(ctx context.Context, itemID, bufferID string) (*domain.BufferItem, error)
+	ListItems(ctx context.Context, input ListBufferItemsInput) ([]*domain.BufferItem, error)
+
+	// Drainer-facing: find non-paused buffers that have pending items with scheduled_at <= now
+	ListActiveBufferIDs(ctx context.Context, limit int) ([]string, error)
+	// ClaimItems claims up to limit pending items for a buffer, FIFO order.
+	ClaimItems(ctx context.Context, bufferID, workerID string, limit int) ([]*domain.BufferItem, error)
+	UpdateItemHeartbeat(ctx context.Context, itemID string) error
+	CompleteItem(ctx context.Context, itemID string, statusCode int) error
+	FailItem(ctx context.Context, itemID string, lastError string, statusCode *int) error
+	RescheduleItem(ctx context.Context, itemID string, lastError string, statusCode *int, retryAt time.Time) error
+
+	// Reaper methods — recover items from crashed drainers
+	RescheduleStaleItems(ctx context.Context, staleCutoff time.Time, limit int) (int, error)
+	FailStaleItems(ctx context.Context, staleCutoff time.Time, limit int) (int, error)
+}

--- a/internal/scheduler/buffer_reaper.go
+++ b/internal/scheduler/buffer_reaper.go
@@ -1,0 +1,69 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/metrics"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
+)
+
+// BufferReaper recovers buffer items stuck in "running" due to crashed drainers.
+type BufferReaper struct {
+	repo             repository.BufferRepository
+	logger           *slog.Logger
+	interval         time.Duration
+	heartbeatTimeout time.Duration
+}
+
+func NewBufferReaper(repo repository.BufferRepository, logger *slog.Logger, interval time.Duration, heartbeatTimeout time.Duration) *BufferReaper {
+	return &BufferReaper{
+		repo:             repo,
+		logger:           logger.With("component", "buffer_reaper"),
+		interval:         interval,
+		heartbeatTimeout: heartbeatTimeout,
+	}
+}
+
+func (r *BufferReaper) Start(ctx context.Context) {
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	r.logger.InfoContext(ctx, "buffer reaper started", "interval", r.interval, "heartbeat_timeout", r.heartbeatTimeout)
+
+	for {
+		select {
+		case <-ctx.Done():
+			r.logger.InfoContext(ctx, "buffer reaper shut down")
+			return
+		case <-ticker.C:
+			r.reap(ctx)
+		}
+	}
+}
+
+func (r *BufferReaper) reap(ctx context.Context) {
+	start := time.Now()
+	defer func() {
+		metrics.BufferReaperCycleDuration.Observe(time.Since(start).Seconds())
+	}()
+
+	staleCutoff := time.Now().Add(-r.heartbeatTimeout)
+
+	rescheduled, err := r.repo.RescheduleStaleItems(ctx, staleCutoff, 100)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "reschedule stale buffer items", "error", err)
+	} else if rescheduled > 0 {
+		metrics.BufferReaperRescuedTotal.WithLabelValues("rescheduled").Add(float64(rescheduled))
+		r.logger.InfoContext(ctx, "rescheduled stale buffer items", "count", rescheduled)
+	}
+
+	failed, err := r.repo.FailStaleItems(ctx, staleCutoff, 100)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "fail stale buffer items", "error", err)
+	} else if failed > 0 {
+		metrics.BufferReaperRescuedTotal.WithLabelValues("failed").Add(float64(failed))
+		r.logger.InfoContext(ctx, "permanently failed stale buffer items", "count", failed)
+	}
+}

--- a/internal/scheduler/drainer.go
+++ b/internal/scheduler/drainer.go
@@ -1,0 +1,264 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/metrics"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
+)
+
+const defaultRetryAfter = 60 * time.Second
+
+// BufferDrainer polls for active buffers and drains their pending items at
+// each buffer's configured rate limit.
+type BufferDrainer struct {
+	id             string
+	repo           repository.BufferRepository
+	credits        repository.CreditRepository
+	signingSecrets repository.SigningSecretRepository
+	executor       *Executor
+	notifier       *WebhookNotifier
+	logger         *slog.Logger
+	pollInterval   time.Duration
+	concurrency    int
+	sem            chan struct{}
+}
+
+func NewBufferDrainer(
+	repo repository.BufferRepository,
+	credits repository.CreditRepository,
+	signingSecrets repository.SigningSecretRepository,
+	notifier *WebhookNotifier,
+	logger *slog.Logger,
+	pollInterval time.Duration,
+	concurrency int,
+) *BufferDrainer {
+	hostname, _ := os.Hostname()
+	id := fmt.Sprintf("drainer-%s-%d", hostname, os.Getpid())
+	return &BufferDrainer{
+		id:             id,
+		repo:           repo,
+		credits:        credits,
+		signingSecrets: signingSecrets,
+		executor:       NewExecutor(logger),
+		notifier:       notifier,
+		logger:         logger.With("component", "buffer_drainer", "worker_id", id),
+		pollInterval:   pollInterval,
+		concurrency:    concurrency,
+		sem:            make(chan struct{}, concurrency),
+	}
+}
+
+func (d *BufferDrainer) Start(ctx context.Context) {
+	ticker := time.NewTicker(d.pollInterval)
+	defer ticker.Stop()
+
+	d.logger.InfoContext(ctx, "buffer drainer started", "concurrency", d.concurrency, "poll_interval", d.pollInterval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			d.logger.InfoContext(ctx, "buffer drainer shut down")
+			return
+		case <-ticker.C:
+			d.drain(ctx)
+		}
+	}
+}
+
+func (d *BufferDrainer) drain(ctx context.Context) {
+	start := time.Now()
+	defer func() {
+		metrics.BufferDrainerCycleDuration.Observe(time.Since(start).Seconds())
+	}()
+
+	bufferIDs, err := d.repo.ListActiveBufferIDs(ctx, 100)
+	if err != nil {
+		d.logger.ErrorContext(ctx, "list active buffers", "error", err)
+		return
+	}
+
+	for _, bufferID := range bufferIDs {
+		d.sem <- struct{}{}
+		go func(bid string) {
+			defer func() { <-d.sem }()
+			d.drainBuffer(ctx, bid)
+		}(bufferID)
+	}
+}
+
+func (d *BufferDrainer) drainBuffer(ctx context.Context, bufferID string) {
+	buf, err := d.repo.GetByIDInternal(ctx, bufferID)
+	if err != nil {
+		d.logger.ErrorContext(ctx, "get buffer for draining", "buffer_id", bufferID, "error", err)
+		return
+	}
+
+	items, err := d.repo.ClaimItems(ctx, bufferID, d.id, buf.RateLimit)
+	if err != nil {
+		d.logger.ErrorContext(ctx, "claim buffer items", "buffer_id", bufferID, "error", err)
+		return
+	}
+
+	if len(items) == 0 {
+		return
+	}
+
+	d.logger.InfoContext(ctx, "claimed buffer items", "buffer_id", bufferID, "count", len(items))
+
+	for _, item := range items {
+		metrics.BufferItemsInFlight.Inc()
+		d.runItem(ctx, buf, item)
+		metrics.BufferItemsInFlight.Dec()
+	}
+}
+
+func (d *BufferDrainer) runItem(ctx context.Context, buf *domain.Buffer, item *domain.BufferItem) {
+	// Credit gate
+	ok, err := d.credits.HasCredits(ctx, item.UserID)
+	if err != nil {
+		d.logger.WarnContext(ctx, "credit check failed, proceeding anyway", "item_id", item.ID, "error", err)
+	} else if !ok {
+		errMsg := "insufficient credits"
+		if failErr := d.repo.FailItem(ctx, item.ID, errMsg, nil); failErr != nil {
+			d.logger.ErrorContext(ctx, "fail item (no credits)", "item_id", item.ID, "error", failErr)
+		}
+		metrics.BufferItemsCompletedTotal.WithLabelValues("failed").Inc()
+		d.notifyBufferItem(ctx, buf, item, domain.BufferItemFailed, nil, &errMsg)
+		return
+	}
+
+	heartbeatCtx, cancelHeartbeat := context.WithCancel(ctx)
+	defer cancelHeartbeat()
+	go d.heartbeat(heartbeatCtx, item.ID)
+
+	var signingSecret string
+	secret, secretErr := d.signingSecrets.GetActive(ctx, item.UserID)
+	if secretErr != nil && !errors.Is(secretErr, domain.ErrSigningSecretNotFound) {
+		d.logger.WarnContext(ctx, "fetch signing secret failed", "item_id", item.ID, "error", secretErr)
+	} else if secretErr == nil {
+		signingSecret = secret.Secret
+	}
+
+	// Build a temporary Job for the executor
+	job := &domain.Job{
+		ID:             item.ID,
+		UserID:         item.UserID,
+		URL:            item.URL,
+		Method:         item.Method,
+		Headers:        item.Headers,
+		Body:           item.Body,
+		TimeoutSeconds: item.TimeoutSeconds,
+	}
+
+	result := d.executor.Run(ctx, job, signingSecret)
+
+	// Deduct credit
+	if deductErr := d.credits.Deduct(ctx, item.UserID, item.ID); deductErr != nil {
+		d.logger.WarnContext(ctx, "credit deduction failed", "item_id", item.ID, "error", deductErr)
+	}
+
+	// 429 — rate limited by target API
+	if result.StatusCode == http.StatusTooManyRequests {
+		retryAfter := defaultRetryAfter
+		if result.RetryAfter != nil {
+			retryAfter = *result.RetryAfter
+		}
+		retryAt := time.Now().Add(retryAfter)
+		errMsg := fmt.Sprintf("rate limited (429), retry after %s", retryAfter)
+		statusCode := result.StatusCode
+		if reschedErr := d.repo.RescheduleItem(ctx, item.ID, errMsg, &statusCode, retryAt); reschedErr != nil {
+			d.logger.ErrorContext(ctx, "reschedule rate-limited item", "item_id", item.ID, "error", reschedErr)
+		}
+		metrics.BufferItemsCompletedTotal.WithLabelValues("rate_limited").Inc()
+		d.logger.InfoContext(ctx, "buffer item rate-limited, rescheduled",
+			"item_id", item.ID, "buffer_id", item.BufferID, "retry_at", retryAt)
+		return
+	}
+
+	// Success
+	if result.Err == nil && result.StatusCode >= 200 && result.StatusCode < 300 {
+		if completeErr := d.repo.CompleteItem(ctx, item.ID, result.StatusCode); completeErr != nil {
+			d.logger.ErrorContext(ctx, "complete buffer item", "item_id", item.ID, "error", completeErr)
+		}
+		metrics.BufferItemsCompletedTotal.WithLabelValues("success").Inc()
+		d.notifyBufferItem(ctx, buf, item, domain.BufferItemCompleted, &result.StatusCode, nil)
+		d.logger.InfoContext(ctx, "buffer item completed", "item_id", item.ID, "duration", result.Duration)
+		return
+	}
+
+	// Failure
+	errMsg := ""
+	if result.Err != nil {
+		errMsg = result.Err.Error()
+	} else {
+		errMsg = fmt.Sprintf("unexpected status code: %d", result.StatusCode)
+	}
+
+	var statusCode *int
+	if result.StatusCode != 0 {
+		statusCode = &result.StatusCode
+	}
+
+	if item.RetryCount < item.MaxRetries {
+		retryAt := time.Now().Add(retryDelay(item.Backoff, item.RetryCount))
+		if reschedErr := d.repo.RescheduleItem(ctx, item.ID, errMsg, statusCode, retryAt); reschedErr != nil {
+			d.logger.ErrorContext(ctx, "reschedule buffer item", "item_id", item.ID, "error", reschedErr)
+		}
+		metrics.BufferItemsCompletedTotal.WithLabelValues("retry").Inc()
+		d.logger.WarnContext(ctx, "buffer item failed, will retry",
+			"item_id", item.ID, "error", errMsg,
+			"attempt", item.RetryCount+1, "max_retries", item.MaxRetries)
+	} else {
+		if failErr := d.repo.FailItem(ctx, item.ID, errMsg, statusCode); failErr != nil {
+			d.logger.ErrorContext(ctx, "fail buffer item", "item_id", item.ID, "error", failErr)
+		}
+		metrics.BufferItemsCompletedTotal.WithLabelValues("failed").Inc()
+		d.notifyBufferItem(ctx, buf, item, domain.BufferItemFailed, statusCode, &errMsg)
+		d.logger.WarnContext(ctx, "buffer item permanently failed", "item_id", item.ID, "error", errMsg)
+	}
+}
+
+func (d *BufferDrainer) heartbeat(ctx context.Context, itemID string) {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := d.repo.UpdateItemHeartbeat(ctx, itemID); err != nil {
+				d.logger.WarnContext(ctx, "buffer item heartbeat failed", "item_id", itemID, "error", err)
+			}
+		}
+	}
+}
+
+// notifyBufferItem sends a webhook if the buffer has one configured.
+func (d *BufferDrainer) notifyBufferItem(ctx context.Context, buf *domain.Buffer, item *domain.BufferItem, status domain.BufferItemStatus, statusCode *int, lastError *string) {
+	if buf.WebhookURL == nil {
+		return
+	}
+
+	// Construct a temporary Job so we can reuse the existing WebhookNotifier.
+	job := &domain.Job{
+		ID:             item.ID,
+		UserID:         item.UserID,
+		Status:         domain.Status(status),
+		WebhookURL:     buf.WebhookURL,
+		WebhookHeaders: buf.WebhookHeaders,
+		LastError:      lastError,
+		RetryCount:     item.RetryCount,
+	}
+	now := time.Now()
+	job.CompletedAt = &now
+
+	d.notifier.notifyAsync(ctx, job, statusCode)
+}

--- a/internal/scheduler/executor.go
+++ b/internal/scheduler/executor.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -63,6 +64,7 @@ type ExecutionResult struct {
 	StatusCode int
 	Err        error
 	Duration   time.Duration
+	RetryAfter *time.Duration // populated when status is 429 and Retry-After header is present
 }
 
 func (e *Executor) Run(ctx context.Context, job *domain.Job, signingSecret string) ExecutionResult {
@@ -124,5 +126,22 @@ func (e *Executor) Run(ctx context.Context, job *domain.Job, signingSecret strin
 		"duration", duration,
 	)
 
-	return ExecutionResult{StatusCode: resp.StatusCode, Duration: duration}
+	result := ExecutionResult{StatusCode: resp.StatusCode, Duration: duration}
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if seconds, parseErr := strconv.Atoi(ra); parseErr == nil {
+				d := time.Duration(seconds) * time.Second
+				result.RetryAfter = &d
+			} else if t, parseErr := http.ParseTime(ra); parseErr == nil {
+				d := time.Until(t)
+				if d < 0 {
+					d = 0
+				}
+				result.RetryAfter = &d
+			}
+		}
+	}
+
+	return result
 }

--- a/internal/usecase/buffer.go
+++ b/internal/usecase/buffer.go
@@ -1,0 +1,317 @@
+package usecase
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
+)
+
+type BufferUsecase struct {
+	repo    repository.BufferRepository
+	credits repository.CreditRepository
+}
+
+func NewBufferUsecase(repo repository.BufferRepository, credits repository.CreditRepository) *BufferUsecase {
+	return &BufferUsecase{repo: repo, credits: credits}
+}
+
+type CreateBufferInput struct {
+	UserID         string
+	Name           string
+	URL            string
+	Method         string
+	Headers        map[string]string
+	TimeoutSeconds int
+	RateLimit      int
+	MaxRetries     *int
+	Backoff        domain.Backoff
+	WebhookURL     *string
+	WebhookHeaders map[string]string
+}
+
+func (u *BufferUsecase) CreateBuffer(ctx context.Context, input CreateBufferInput) (*domain.Buffer, error) {
+	if input.Headers == nil {
+		input.Headers = make(map[string]string)
+	}
+	if input.WebhookHeaders == nil {
+		input.WebhookHeaders = make(map[string]string)
+	}
+	if input.TimeoutSeconds == 0 {
+		input.TimeoutSeconds = 30
+	}
+	if input.MaxRetries == nil {
+		defaultRetries := 3
+		input.MaxRetries = &defaultRetries
+	}
+	if input.Backoff == "" {
+		input.Backoff = domain.BackoffExponential
+	}
+	if input.RateLimit == 0 {
+		input.RateLimit = 10
+	}
+
+	b := &domain.Buffer{
+		UserID:         input.UserID,
+		Name:           input.Name,
+		URL:            input.URL,
+		Method:         input.Method,
+		Headers:        input.Headers,
+		TimeoutSeconds: input.TimeoutSeconds,
+		RateLimit:      input.RateLimit,
+		MaxRetries:     *input.MaxRetries,
+		Backoff:        input.Backoff,
+		Paused:         false,
+		WebhookURL:     input.WebhookURL,
+		WebhookHeaders: input.WebhookHeaders,
+	}
+
+	created, err := u.repo.Create(ctx, b)
+	if err != nil {
+		return nil, fmt.Errorf("create buffer: %w", err)
+	}
+	return created, nil
+}
+
+func (u *BufferUsecase) GetBuffer(ctx context.Context, id, userID string) (*domain.Buffer, error) {
+	b, err := u.repo.GetByID(ctx, id, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get buffer: %w", err)
+	}
+	return b, nil
+}
+
+type ListBuffersInput struct {
+	UserID string
+	Cursor string
+	Limit  int
+}
+
+type ListBuffersResult struct {
+	Buffers    []*domain.Buffer
+	NextCursor *string
+}
+
+type bufferCursor struct {
+	CreatedAt time.Time `json:"c"`
+	ID        string    `json:"i"`
+}
+
+func decodeBufferCursor(s string) (*time.Time, string, error) {
+	b, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return nil, "", fmt.Errorf("decode cursor: %w", err)
+	}
+	var c bufferCursor
+	if err := json.Unmarshal(b, &c); err != nil {
+		return nil, "", fmt.Errorf("unmarshal cursor: %w", err)
+	}
+	return &c.CreatedAt, c.ID, nil
+}
+
+func encodeBufferCursor(createdAt time.Time, id string) string {
+	b, _ := json.Marshal(bufferCursor{CreatedAt: createdAt, ID: id})
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func (u *BufferUsecase) ListBuffers(ctx context.Context, input ListBuffersInput) (ListBuffersResult, error) {
+	limit := input.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	repoInput := repository.ListBuffersInput{
+		UserID: input.UserID,
+		Limit:  limit + 1,
+	}
+
+	if input.Cursor != "" {
+		cursorTime, cursorID, err := decodeBufferCursor(input.Cursor)
+		if err != nil {
+			return ListBuffersResult{}, fmt.Errorf("bad cursor: %w", err)
+		}
+		repoInput.CursorTime = cursorTime
+		repoInput.CursorID = cursorID
+	}
+
+	buffers, err := u.repo.List(ctx, repoInput)
+	if err != nil {
+		return ListBuffersResult{}, fmt.Errorf("list buffers: %w", err)
+	}
+
+	var nextCursor *string
+	if len(buffers) == limit+1 {
+		last := buffers[limit]
+		s := encodeBufferCursor(last.CreatedAt, last.ID)
+		nextCursor = &s
+		buffers = buffers[:limit]
+	}
+
+	return ListBuffersResult{Buffers: buffers, NextCursor: nextCursor}, nil
+}
+
+func (u *BufferUsecase) PauseBuffer(ctx context.Context, id, userID string) error {
+	if err := u.repo.SetPaused(ctx, id, userID, true); err != nil {
+		return fmt.Errorf("pause buffer: %w", err)
+	}
+	return nil
+}
+
+func (u *BufferUsecase) ResumeBuffer(ctx context.Context, id, userID string) error {
+	if err := u.repo.SetPaused(ctx, id, userID, false); err != nil {
+		return fmt.Errorf("resume buffer: %w", err)
+	}
+	return nil
+}
+
+func (u *BufferUsecase) DeleteBuffer(ctx context.Context, id, userID string) error {
+	if err := u.repo.Delete(ctx, id, userID); err != nil {
+		return fmt.Errorf("delete buffer: %w", err)
+	}
+	return nil
+}
+
+// ── Items ────────────────────────────────────────────────────────────────────
+
+type PushBufferItemInput struct {
+	UserID   string
+	BufferID string
+	Body     *string
+	Headers  map[string]string
+}
+
+func (u *BufferUsecase) PushItem(ctx context.Context, input PushBufferItemInput) (*domain.BufferItem, error) {
+	ok, err := u.credits.HasCredits(ctx, input.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("check credits: %w", err)
+	}
+	if !ok {
+		return nil, domain.ErrInsufficientCredits
+	}
+
+	buf, err := u.repo.GetByID(ctx, input.BufferID, input.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("get buffer: %w", err)
+	}
+
+	// Merge headers: buffer defaults + per-item overrides
+	merged := make(map[string]string, len(buf.Headers)+len(input.Headers))
+	for k, v := range buf.Headers {
+		merged[k] = v
+	}
+	for k, v := range input.Headers {
+		merged[k] = v
+	}
+
+	item := &domain.BufferItem{
+		BufferID:       buf.ID,
+		UserID:         input.UserID,
+		URL:            buf.URL,
+		Method:         buf.Method,
+		Headers:        merged,
+		Body:           input.Body,
+		TimeoutSeconds: buf.TimeoutSeconds,
+		Backoff:        buf.Backoff,
+		Status:         domain.BufferItemPending,
+		MaxRetries:     buf.MaxRetries,
+		ScheduledAt:    time.Now(),
+	}
+
+	created, err := u.repo.CreateItem(ctx, item)
+	if err != nil {
+		return nil, fmt.Errorf("create buffer item: %w", err)
+	}
+	return created, nil
+}
+
+func (u *BufferUsecase) GetItem(ctx context.Context, itemID, bufferID, userID string) (*domain.BufferItem, error) {
+	// Verify buffer ownership
+	if _, err := u.repo.GetByID(ctx, bufferID, userID); err != nil {
+		return nil, fmt.Errorf("get buffer: %w", err)
+	}
+	item, err := u.repo.GetItemByID(ctx, itemID, bufferID)
+	if err != nil {
+		return nil, fmt.Errorf("get buffer item: %w", err)
+	}
+	return item, nil
+}
+
+type ListBufferItemsInput struct {
+	BufferID string
+	UserID   string
+	Status   string
+	Cursor   string
+	Limit    int
+}
+
+type ListBufferItemsResult struct {
+	Items      []*domain.BufferItem
+	NextCursor *string
+}
+
+var validBufferItemStatuses = map[domain.BufferItemStatus]struct{}{
+	domain.BufferItemPending:   {},
+	domain.BufferItemRunning:   {},
+	domain.BufferItemCompleted: {},
+	domain.BufferItemFailed:    {},
+}
+
+func (u *BufferUsecase) ListItems(ctx context.Context, input ListBufferItemsInput) (ListBufferItemsResult, error) {
+	// Verify buffer ownership
+	if _, err := u.repo.GetByID(ctx, input.BufferID, input.UserID); err != nil {
+		return ListBufferItemsResult{}, fmt.Errorf("get buffer: %w", err)
+	}
+
+	limit := input.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	var status domain.BufferItemStatus
+	if input.Status != "" {
+		status = domain.BufferItemStatus(input.Status)
+		if _, ok := validBufferItemStatuses[status]; !ok {
+			return ListBufferItemsResult{}, domain.ErrInvalidStatus
+		}
+	}
+
+	repoInput := repository.ListBufferItemsInput{
+		BufferID: input.BufferID,
+		Status:   status,
+		Limit:    limit + 1,
+	}
+
+	if input.Cursor != "" {
+		cursorTime, cursorID, err := decodeBufferCursor(input.Cursor)
+		if err != nil {
+			return ListBufferItemsResult{}, fmt.Errorf("bad cursor: %w", err)
+		}
+		repoInput.CursorTime = cursorTime
+		repoInput.CursorID = cursorID
+	}
+
+	items, err := u.repo.ListItems(ctx, repoInput)
+	if err != nil {
+		return ListBufferItemsResult{}, fmt.Errorf("list buffer items: %w", err)
+	}
+
+	var nextCursor *string
+	if len(items) == limit+1 {
+		last := items[limit]
+		s := encodeBufferCursor(last.CreatedAt, last.ID)
+		nextCursor = &s
+		items = items[:limit]
+	}
+
+	return ListBufferItemsResult{Items: items, NextCursor: nextCursor}, nil
+}

--- a/migrations/20260330000000_buffers.sql
+++ b/migrations/20260330000000_buffers.sql
@@ -1,0 +1,59 @@
+-- +goose Up
+
+CREATE TABLE buffers (
+    id              TEXT        PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    user_id         TEXT        NOT NULL REFERENCES users(id),
+    name            TEXT        NOT NULL,
+    url             TEXT        NOT NULL,
+    method          TEXT        NOT NULL DEFAULT 'POST',
+    headers         JSONB       NOT NULL DEFAULT '{}',
+    timeout_seconds INT         NOT NULL DEFAULT 30,
+    rate_limit      INT         NOT NULL DEFAULT 10,
+    max_retries     INT         NOT NULL DEFAULT 3,
+    backoff         TEXT        NOT NULL DEFAULT 'exponential',
+    paused          BOOLEAN     NOT NULL DEFAULT FALSE,
+    webhook_url     TEXT,
+    webhook_headers JSONB       NOT NULL DEFAULT '{}',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT buffers_user_name_unique UNIQUE (user_id, name)
+);
+
+CREATE INDEX idx_buffers_user ON buffers (user_id, created_at DESC, id DESC);
+
+CREATE TABLE buffer_items (
+    id              TEXT        PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    buffer_id       TEXT        NOT NULL REFERENCES buffers(id) ON DELETE CASCADE,
+    user_id         TEXT        NOT NULL REFERENCES users(id),
+    url             TEXT        NOT NULL,
+    method          TEXT        NOT NULL,
+    headers         JSONB       NOT NULL DEFAULT '{}',
+    body            TEXT,
+    timeout_seconds INT         NOT NULL DEFAULT 30,
+    backoff         TEXT        NOT NULL DEFAULT 'exponential',
+    status          TEXT        NOT NULL DEFAULT 'pending',
+    retry_count     INT         NOT NULL DEFAULT 0,
+    max_retries     INT         NOT NULL DEFAULT 3,
+    scheduled_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    claimed_at      TIMESTAMPTZ,
+    claimed_by      TEXT,
+    heartbeat_at    TIMESTAMPTZ,
+    completed_at    TIMESTAMPTZ,
+    last_error      TEXT,
+    status_code     INT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_buffer_items_drainable ON buffer_items (buffer_id, created_at ASC)
+    WHERE status = 'pending';
+
+CREATE INDEX idx_buffer_items_stale ON buffer_items (heartbeat_at)
+    WHERE status = 'running';
+
+CREATE INDEX idx_buffer_items_buffer ON buffer_items (buffer_id, created_at DESC, id DESC);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS buffer_items;
+DROP TABLE IF EXISTS buffers;


### PR DESCRIPTION
## Summary
- **New feature: Buffers** — rate-limited HTTP request queues for calling third-party APIs with strict rate limits (Stripe, OpenAI, etc.)
- Users create a buffer with a target URL and rate limit (req/s), push requests into it, and the system fires them at the configured rate with automatic 429 Retry-After handling
- Full implementation across all layers: domain types, DB migration, repository, usecase, 9 HTTP endpoints, BufferDrainer scheduler, BufferReaper crash recovery, Prometheus metrics

## New endpoints
```
POST   /buffers              — Create buffer
GET    /buffers              — List buffers
GET    /buffers/:id          — Get buffer
POST   /buffers/:id/pause    — Pause draining
POST   /buffers/:id/resume   — Resume draining
DELETE /buffers/:id          — Delete (cascades items)
POST   /buffers/:id/items    — Push item into buffer
GET    /buffers/:id/items    — List items (filterable by status)
GET    /buffers/:id/items/:itemId — Get item
```

## Key design decisions
- **Rate pacing**: BufferDrainer polls on 1s tick, claims up to rate_limit items per buffer per tick via FOR UPDATE SKIP LOCKED (FIFO order)
- **429 handling**: Parses Retry-After header (seconds or HTTP-date), reschedules item with scheduled_at = now + retry_after (default 60s fallback)
- **Denormalization**: Buffer items copy URL/method/timeout/backoff from parent buffer at creation time — drainer needs no joins
- **Crash recovery**: BufferReaper (30s interval) finds stale running items via heartbeat timeout, same pattern as job Reaper
- **Credits**: Each item execution deducts 1 credit, with creation-time and execution-time gates

## Test plan
- [ ] Run migration: goose -dir ./migrations postgres "$DATABASE_URL" up
- [ ] Create buffer via POST /buffers, push items, verify items drain at configured rate
- [ ] Test 429 handling with a mock endpoint returning Retry-After
- [ ] Kill scheduler mid-execution, verify reaper recovers stale items
- [ ] Verify pause/resume stops/starts draining
- [ ] Run golangci-lint run ./... and go test -race ./...

🤖 Generated with [Claude Code](https://claude.com/claude-code)