### PR TITLE
add buffer stress & chaos test harness

### DIFF
--- a/tests/stress/Makefile
+++ b/tests/stress/Makefile
@@ -1,0 +1,41 @@
+# Buffer stress harness. Black-box over the public HTTP API; light by default.
+#
+#   make up        # build + start the SUT (postgres, migrate, server, scheduler, sink)
+#   make tracer    # run the tracer-bullet spec
+#   make down      # tear everything down (incl. volumes)
+#
+# Override numbers via env, e.g.:  ITEMS=50 RATE_LIMIT=20 make completeness
+
+COMPOSE := docker compose -f docker-compose.stress.yml
+K6_ENV  := $(if $(ITEMS),-e ITEMS=$(ITEMS),) $(if $(RATE_LIMIT),-e RATE_LIMIT=$(RATE_LIMIT),)
+
+.PHONY: up down logs ps migrate tracer completeness rate retry crash k6-%
+
+up:
+	$(COMPOSE) build
+	$(COMPOSE) run --rm migrate
+	$(COMPOSE) up -d postgres sink server scheduler
+	@echo "SUT up. server:8080  sink:9000"
+
+down:
+	$(COMPOSE) down -v
+
+logs:
+	$(COMPOSE) logs -f server scheduler sink
+
+ps:
+	$(COMPOSE) ps
+
+# Run any spec by name: make k6-tracer, make k6-completeness, ...
+k6-%:
+	$(COMPOSE) run --rm $(K6_ENV) k6 run /scripts/$*.js
+
+tracer:        ; $(MAKE) k6-tracer
+completeness:  ; $(MAKE) k6-completeness
+rate:          ; $(MAKE) k6-rate
+retry:         ; $(MAKE) k6-retry
+
+# Crash recovery is orchestrated (kills the scheduler mid-run), so it has its
+# own script rather than a plain k6 invocation.
+crash:
+	./scripts/crash-run.sh

--- a/tests/stress/README.md
+++ b/tests/stress/README.md
@@ -1,0 +1,87 @@
+# Buffer stress & chaos harness
+
+A **black-box** stress/chaos harness for core-api **buffers**. It speaks only the
+public HTTP API + a controllable sink — zero imports of `internal/` — so it
+survives the architecture churn underneath. Built to grow into the final
+SLA-gate step of CI/CD.
+
+## What it proves
+
+| Spec | Promise under test | Gate |
+|---|---|---|
+| `tracer.js` | end-to-end: push → execute → deliver → record | item completes, sink sees it once |
+| `completeness.js` | no loss | all N items `completed`, each delivered+acked exactly once |
+| `rate.js` | rate limiting | `rate_limit` caps per-poll-cycle dispatch (characterized) |
+| `retry.js` | retry + backoff | retries N times, completes, gaps match the ~30s backoff |
+| `crash.js` | crash recovery | SIGKILL scheduler mid-flight → reaper rescues all (no loss) |
+
+## How it's wired
+
+```
+            docker-compose.stress.yml  (one reproducible env)
+  postgres ── migrate ── server ── scheduler        ← system under test
+                                       │ executes (real TLS dial)
+                                       ▼
+                          https://stress-sink.night.enkiduck.com   ← sink (public via Traefik)
+                                       ▲
+                                       │ introspection (internal http://sink:9000)
+                                      k6  ← drives BASE_URL, asserts, exit-codes for CI
+```
+
+**Why the sink is public:** the executor's SSRF guard (`internal/safedialer`)
+blocks all private IP ranges with no escape hatch, so a sink on the Docker subnet
+is unreachable. Exposing it via Traefik at a public host lets the executor accept
+it — and exercises the *real* dial/TLS path (closer to prod). k6 itself reads the
+sink over the internal network (it isn't subject to the guard).
+
+**Auth:** k6 mints a local HS256 JWT (mirrors `scripts/gentoken.go`); the server's
+`EnsureUser` upserts the user and grants daily free credits on first call. No
+Clerk, no seeding.
+
+**The sink** (`sink/main.go`, stdlib only) records every delivery keyed by the
+`X-Stress-Token` header and answers per a configurable policy
+(`ok` / `fail_n` / `always_fail` / `sleep` / `status`), settable per-token or as a
+global default via `/control/*`. Introspect at `/deliveries?token=` and `/stats`.
+
+## Running
+
+```bash
+make up            # build + start the SUT (postgres, migrate, server, scheduler, sink)
+make tracer        # smallest end-to-end proof
+make completeness  # no-loss
+make rate          # rate-limit characterization
+make retry         # retry + backoff (~40s)
+make crash         # crash recovery chaos (~40s)
+make down          # tear down (incl. volumes)
+```
+
+Everything is **light by default** (single-digit/low-tens items, 1 VU) so it's
+safe on a shared box. Crank it on a beefier machine via env:
+
+```bash
+ITEMS=500 RATE_LIMIT=50 make completeness
+RATE_ITEMS=400 RATE_LIMIT=50 make rate
+RETRIES=3 make retry                         # deeper exponential-backoff curve
+CRASH_ITEMS=200 CRASH_SLEEP_MS=15000 make crash
+```
+
+## Targeting a remote (staging/prod) later
+
+The specs take `BASE_URL`; point them at any reachable deployment. Caveat: the
+sink must be reachable **from that deployment** (a public sink URL via
+`SINK_TARGET_URL`) and you'll need a real token instead of the local HS256 mint.
+
+## Findings surfaced so far (core-api, not harness bugs)
+
+1. **Buffer executions are never billed.** `credits.Deduct` inserts a
+   `credit_transactions` row FK'd to `jobs`, but buffer item IDs live in
+   `buffer_items` → `credit_transactions_job_id_fkey` violation every run
+   (logged WARN, swallowed). See `internal/scheduler/drainer.go`.
+2. **At-least-once, not exactly-once, under crash.** A crash after delivery but
+   before `CompleteItem` re-fires the target on recovery (`crash.js` reports
+   `dupAck`). Fine as a semantic — but it contradicts "exactly-once" framing.
+3. **Head-of-line blocking within a buffer.** Items in a claimed batch execute
+   sequentially, so one slow item stalls the rest of its batch.
+4. **`rate_limit` is "claims per poll cycle," not items/sec.** Observed dispatch
+   ≈ `rate_limit` per `DRAINER_POLL_INTERVAL_SEC` (default 1s). `rate.js`
+   reports the real per-window distribution.

--- a/tests/stress/docker-compose.stress.yml
+++ b/tests/stress/docker-compose.stress.yml
@@ -1,0 +1,103 @@
+# Single reproducible env for buffer stress testing.
+#
+#   postgres  -> server + scheduler (the system under test, built from core-api)
+#   sink      -> controllable target the buffers point at
+#   k6        -> runs the specs (profile "k6"; invoked via `docker compose run`)
+#
+# Build contexts: the core-api images build from the repo root (../..); the sink
+# builds from ./sink. Numbers are kept light by the specs themselves.
+
+name: fliq-stress
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: scheduler
+      POSTGRES_PASSWORD: scheduler
+      POSTGRES_DB: scheduler
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U scheduler"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+
+  migrate:
+    build:
+      context: ../..
+      dockerfile: Dockerfile.migrate
+    command: ["postgres://scheduler:scheduler@postgres:5432/scheduler?sslmode=disable", "up"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    profiles: [migrate]
+
+  server:
+    build:
+      context: ../..
+      dockerfile: Dockerfile.server
+    environment:
+      ENV: local
+      PORT: "8080"
+      DATABASE_URL: postgres://scheduler:scheduler@postgres:5432/scheduler?sslmode=disable
+      JWT_SECRET: stress-harness-local-secret-0123456789abcdef
+      LOG_LEVEL: info
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  scheduler:
+    build:
+      context: ../..
+      dockerfile: Dockerfile.scheduler
+    environment:
+      ENV: local
+      DATABASE_URL: postgres://scheduler:scheduler@postgres:5432/scheduler?sslmode=disable
+      LOG_LEVEL: info
+      # Light drainer settings; override on a beefier box.
+      DRAINER_POLL_INTERVAL_SEC: "1"
+      DRAINER_CONCURRENCY: "5"
+      WORKER_COUNT: "5"
+      POLL_INTERVAL_SEC: "1"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  # The sink sits on BOTH networks:
+  #   - web (Traefik): the core-api executor must reach it at a PUBLIC address,
+  #     because its SSRF guard (internal/safedialer) blocks private ranges. The
+  #     scheduler dials https://stress-sink.night.enkiduck.com -> public IP ->
+  #     Traefik -> here. This also exercises the real TLS/dial path (prod-like).
+  #   - default: k6 reads introspection directly (it isn't subject to the guard).
+  sink:
+    build:
+      context: ./sink
+    environment:
+      PORT: "9000"
+    networks: [default, web]
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.stresssink.rule=Host(`stress-sink.night.enkiduck.com`)"
+      - traefik.http.routers.stresssink.entrypoints=websecure
+      - traefik.http.routers.stresssink.tls.certresolver=le
+      - traefik.http.services.stresssink.loadbalancer.server.port=9000
+
+  k6:
+    image: grafana/k6:latest
+    profiles: [k6]
+    environment:
+      BASE_URL: http://server:8080
+      SINK_URL: http://sink:9000
+      # Public URL the core-api executor will accept (passes the SSRF guard).
+      SINK_TARGET_URL: https://stress-sink.night.enkiduck.com/ingest
+      JWT_SECRET: stress-harness-local-secret-0123456789abcdef
+      USER_ID: user_stress_local
+    volumes:
+      - ./k6:/scripts:ro
+    # Invoked via: docker compose run --rm k6 run /scripts/<spec>.js
+
+networks:
+  web:
+    external: true

--- a/tests/stress/k6/completeness.js
+++ b/tests/stress/k6/completeness.js
@@ -1,0 +1,70 @@
+// Completeness / no-loss: push N items to a healthy buffer; every one must
+// reach `completed`, and the sink must have received each exactly once (no
+// loss, no spurious duplicates) with a 2xx ack.
+//
+// Light by default (ITEMS=10). Override: ITEMS=200 make completeness
+
+import { check } from "k6";
+import { mintJWT } from "./lib/auth.js";
+import * as buffers from "./lib/buffers.js";
+import * as sink from "./lib/sink.js";
+import { SINK_TARGET_URL, USER_ID, ITEMS, RATE_LIMIT, stamp } from "./lib/config.js";
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: { checks: ["rate==1.0"] },
+};
+
+export default function () {
+  const token = mintJWT(USER_ID);
+  sink.reset();
+
+  const name = stamp("completeness");
+  const buf = buffers.createBuffer(token, {
+    name,
+    url: SINK_TARGET_URL,
+    rate_limit: RATE_LIMIT,
+    max_retries: 3,
+  });
+
+  // Push N items, each carrying a unique token.
+  const ids = [];
+  const tokens = [];
+  for (let i = 0; i < ITEMS; i++) {
+    const itemToken = `${name}-item-${i}`;
+    tokens.push(itemToken);
+    const item = buffers.pushItem(token, buf.id, {
+      headers: { "X-Stress-Token": itemToken },
+      body: itemToken,
+    });
+    ids.push(item.id);
+  }
+
+  const final = buffers.pollItemsUntilTerminal(token, buf.id, ids, {
+    timeoutMs: 90000,
+    intervalMs: 500,
+  });
+
+  const completed = Object.values(final).filter((it) => it.status === "completed").length;
+  check(null, {
+    "all items reached terminal": () => Object.keys(final).length === ITEMS,
+    "all items completed": () => completed === ITEMS,
+  });
+
+  // No loss, no duplicate acked delivery: each token delivered, exactly one 2xx.
+  let missing = 0;
+  let multiAck = 0;
+  for (const t of tokens) {
+    const ds = sink.deliveries(t);
+    const acks = ds.filter((d) => d.status >= 200 && d.status < 300).length;
+    if (acks === 0) missing++;
+    if (acks > 1) multiAck++;
+  }
+  check(null, {
+    "no item lost (every token acked once)": () => missing === 0,
+    "no item acked more than once": () => multiAck === 0,
+  });
+
+  console.log(`completeness: ${completed}/${ITEMS} completed, missing=${missing}, multiAck=${multiAck}`);
+}

--- a/tests/stress/k6/crash.js
+++ b/tests/stress/k6/crash.js
@@ -1,0 +1,105 @@
+// Crash recovery + at-most-once, driven by scripts/crash-run.sh.
+//
+//   PHASE=load   : sink holds every connection open (sleep), buffer pushes N
+//                  items so they all sit in `running`. The orchestrator then
+//                  SIGKILLs the scheduler mid-flight and restarts it.
+//   PHASE=verify : flip the sink fast, wait for the buffer reaper to rescue the
+//                  orphaned `running` items, and assert every item reaches
+//                  `completed` (no loss). Separately REPORT duplicate target
+//                  executions — a crash after delivery-before-complete re-fires
+//                  the target, so this characterizes the at-least-once edge.
+//
+// Hard gate: recovery (no item lost). Duplicate acks are reported, not gated —
+// they reveal whether "exactly-once" holds under crash.
+
+import { check, sleep } from "k6";
+import { Counter } from "k6/metrics";
+import { mintJWT } from "./lib/auth.js";
+import * as buffers from "./lib/buffers.js";
+import * as sink from "./lib/sink.js";
+import { SINK_TARGET_URL, USER_ID } from "./lib/config.js";
+
+const PHASE = __ENV.PHASE;
+const RUN = __ENV.CRASH_RUN;
+const N = parseInt(__ENV.CRASH_ITEMS || "10", 10);
+const SLEEP_MS = parseInt(__ENV.CRASH_SLEEP_MS || "8000", 10);
+
+export const options = { vus: 1, iterations: 1, thresholds: { checks: ["rate==1.0"] } };
+
+const duplicateAcks = new Counter("duplicate_acks");
+
+export default function () {
+  if (!RUN) throw new Error("CRASH_RUN must be set");
+  const token = mintJWT(USER_ID);
+  if (PHASE === "load") return loadPhase(token);
+  if (PHASE === "verify") return verifyPhase(token);
+  throw new Error("PHASE must be 'load' or 'verify'");
+}
+
+function loadPhase(token) {
+  sink.reset();
+  // Every delivery hangs for SLEEP_MS so items stay `running` long enough to be
+  // caught mid-flight by the kill.
+  sink.setDefault({ mode: "sleep", sleep_ms: SLEEP_MS });
+
+  const buf = buffers.createBuffer(token, {
+    name: RUN,
+    url: SINK_TARGET_URL,
+    rate_limit: N, // claim them all in one cycle -> all in-flight together
+    max_retries: 5,
+  });
+
+  for (let i = 0; i < N; i++) {
+    const t = `${RUN}-item-${i}`;
+    buffers.pushItem(token, buf.id, { headers: { "X-Stress-Token": t }, body: t });
+  }
+  console.log(`crash/load: pushed ${N} items to buffer ${buf.id}, sink sleeping ${SLEEP_MS}ms`);
+}
+
+function verifyPhase(token) {
+  sink.setDefault({ mode: "ok" }); // recovered redeliveries complete fast
+
+  const buf = buffers.findBufferByName(token, RUN);
+  check(buf, { "buffer survived restart": (b) => b !== null });
+  if (!buf) return;
+
+  // Wait for the reaper (heartbeat_timeout 30s + interval 30s) to rescue the
+  // orphaned items and the drainer to finish them.
+  const deadline = Date.now() + 150000;
+  let items = [];
+  let completed = 0;
+  while (Date.now() < deadline) {
+    items = buffers.listAllItems(token, buf.id);
+    completed = items.filter((it) => it.status === "completed").length;
+    const terminal = items.filter((it) => buffers.isTerminal(it)).length;
+    if (items.length >= N && terminal === items.length) break;
+    sleep(2);
+  }
+
+  // Duplicate analysis from the sink's record.
+  const all = sink.deliveries("");
+  const byToken = {};
+  for (const d of all) (byToken[d.token] = byToken[d.token] || []).push(d);
+  let dupDelivered = 0;
+  let dupAck = 0;
+  for (let i = 0; i < N; i++) {
+    const ds = byToken[`${RUN}-item-${i}`] || [];
+    const acks = ds.filter((d) => d.status >= 200 && d.status < 300).length;
+    if (ds.length > 1) dupDelivered++;
+    if (acks > 1) {
+      dupAck++;
+      duplicateAcks.add(acks - 1);
+    }
+  }
+
+  console.log(
+    `crash/verify: items=${N} completed=${completed} ` +
+      `dupDelivered=${dupDelivered} dupAck=${dupAck} ` +
+      `(dupAck>0 => at-least-once: target re-fired on recovery)`,
+  );
+
+  // Hard gate: recovery / no loss.
+  check(null, {
+    "all items recovered to completed (no loss)": () => completed === N,
+  });
+}

--- a/tests/stress/k6/lib/auth.js
+++ b/tests/stress/k6/lib/auth.js
@@ -1,0 +1,21 @@
+// Mint a local-dev HS256 JWT — mirrors core-api's scripts/gentoken.go.
+// The server (CLERK_JWKS_URL unset) validates it with JWT_SECRET and reads the
+// `sub` claim as the user ID. EnsureUser then upserts the user + grants credits
+// on the first authed request, so no Clerk and no seeding are required.
+
+import crypto from "k6/crypto";
+import encoding from "k6/encoding";
+import { JWT_SECRET } from "./config.js";
+
+function b64url(obj) {
+  return encoding.b64encode(JSON.stringify(obj), "rawurl");
+}
+
+export function mintJWT(userID, ttlSeconds = 3600) {
+  const now = Math.floor(Date.now() / 1000);
+  const header = b64url({ alg: "HS256", typ: "JWT" });
+  const payload = b64url({ sub: userID, iat: now, exp: now + ttlSeconds });
+  const signingInput = `${header}.${payload}`;
+  const sig = crypto.hmac("sha256", JWT_SECRET, signingInput, "base64rawurl");
+  return `${signingInput}.${sig}`;
+}

--- a/tests/stress/k6/lib/buffers.js
+++ b/tests/stress/k6/lib/buffers.js
@@ -1,0 +1,135 @@
+// Thin black-box driver for the core-api buffers HTTP API. No knowledge of
+// internals — just the public REST surface. If the implementation changes
+// shape, only this file moves.
+
+import http from "k6/http";
+import { sleep, fail } from "k6";
+import { BASE_URL } from "./config.js";
+
+function authHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+function expect(res, want, what) {
+  if (res.status !== want) {
+    fail(`${what}: expected ${want}, got ${res.status} — ${res.body}`);
+  }
+  return res.json();
+}
+
+export function createBuffer(token, input) {
+  const res = http.post(`${BASE_URL}/buffers`, JSON.stringify(input), {
+    headers: authHeaders(token),
+  });
+  return expect(res, 201, "createBuffer");
+}
+
+export function pushItem(token, bufferId, { body, headers } = {}) {
+  const payload = {};
+  if (body !== undefined) payload.body = body;
+  if (headers !== undefined) payload.headers = headers;
+  const res = http.post(
+    `${BASE_URL}/buffers/${bufferId}/items`,
+    JSON.stringify(payload),
+    { headers: authHeaders(token) },
+  );
+  return expect(res, 201, "pushItem");
+}
+
+export function getItem(token, bufferId, itemId) {
+  const res = http.get(`${BASE_URL}/buffers/${bufferId}/items/${itemId}`, {
+    headers: authHeaders(token),
+  });
+  return expect(res, 200, "getItem");
+}
+
+export function listBuffers(token, { limit = 100, cursor = "" } = {}) {
+  const q = `?limit=${limit}${cursor ? `&cursor=${cursor}` : ""}`;
+  const res = http.get(`${BASE_URL}/buffers${q}`, { headers: authHeaders(token) });
+  return expect(res, 200, "listBuffers");
+}
+
+// Find a buffer by exact name (paginates). Returns the buffer or null.
+export function findBufferByName(token, name) {
+  let cursor = "";
+  for (let page = 0; page < 50; page++) {
+    const { buffers: page_, next_cursor } = listBuffers(token, { cursor });
+    const hit = (page_ || []).find((b) => b.name === name);
+    if (hit) return hit;
+    if (!next_cursor) return null;
+    cursor = next_cursor;
+  }
+  return null;
+}
+
+// List all items in a buffer (paginates). Returns the full array.
+export function listAllItems(token, bufferId) {
+  const out = [];
+  let cursor = "";
+  for (let page = 0; page < 200; page++) {
+    const q = `?limit=100${cursor ? `&cursor=${cursor}` : ""}`;
+    const res = http.get(`${BASE_URL}/buffers/${bufferId}/items${q}`, {
+      headers: authHeaders(token),
+    });
+    const body = expect(res, 200, "listItems");
+    out.push(...(body.items || []));
+    if (!body.next_cursor) break;
+    cursor = body.next_cursor;
+  }
+  return out;
+}
+
+const TERMINAL = ["completed", "failed"];
+
+export function isTerminal(item) {
+  return TERMINAL.includes(item.status);
+}
+
+// Poll a single item until it reaches a terminal state or the timeout elapses.
+export function pollUntilTerminal(token, bufferId, itemId, { timeoutMs = 30000, intervalMs = 500 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let item = getItem(token, bufferId, itemId);
+  while (!isTerminal(item) && Date.now() < deadline) {
+    sleep(intervalMs / 1000);
+    item = getItem(token, bufferId, itemId);
+  }
+  return item;
+}
+
+// Poll many items until all are terminal (or timeout). Returns the final items
+// keyed by id. Polls the per-item endpoint; fine for the light item counts here.
+export function pollItemsUntilTerminal(token, bufferId, itemIds, { timeoutMs = 60000, intervalMs = 500 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  const final = {};
+  let pending = itemIds.slice();
+  while (pending.length > 0 && Date.now() < deadline) {
+    const still = [];
+    for (const id of pending) {
+      const item = getItem(token, bufferId, id);
+      if (isTerminal(item)) final[id] = item;
+      else still.push(id);
+    }
+    pending = still;
+    if (pending.length > 0) sleep(intervalMs / 1000);
+  }
+  // Record whatever is left as its last-seen state.
+  for (const id of pending) final[id] = getItem(token, bufferId, id);
+  return final;
+}
+
+export function pauseBuffer(token, bufferId) {
+  const res = http.post(`${BASE_URL}/buffers/${bufferId}/pause`, null, {
+    headers: authHeaders(token),
+  });
+  if (res.status !== 204) fail(`pauseBuffer: expected 204, got ${res.status} — ${res.body}`);
+}
+
+export function resumeBuffer(token, bufferId) {
+  const res = http.post(`${BASE_URL}/buffers/${bufferId}/resume`, null, {
+    headers: authHeaders(token),
+  });
+  if (res.status !== 204) fail(`resumeBuffer: expected 204, got ${res.status} — ${res.body}`);
+}

--- a/tests/stress/k6/lib/config.js
+++ b/tests/stress/k6/lib/config.js
@@ -1,0 +1,39 @@
+// Central config — everything is env-overridable so the same specs can run
+// against the local compose env or, later, a remote BASE_URL (staging/prod).
+//
+// Defaults are deliberately LIGHT — this box runs other workloads. Crank the
+// numbers (ITEMS, RATE_LIMIT, VUS) via env on a beefier machine.
+
+function env(name, fallback) {
+  const v = __ENV[name];
+  return v === undefined || v === "" ? fallback : v;
+}
+
+function envInt(name, fallback) {
+  const v = env(name, undefined);
+  return v === undefined ? fallback : parseInt(v, 10);
+}
+
+// core-api public API (what k6 drives). In compose: the server service.
+export const BASE_URL = env("BASE_URL", "http://server:8080");
+
+// Sink introspection URL (as seen by k6).
+export const SINK_URL = env("SINK_URL", "http://sink:9000");
+
+// Sink ingest URL (as seen by the core-api scheduler when it executes items).
+// In compose this is the same host; against a remote BASE_URL it must be a
+// sink reachable FROM that deployment.
+export const SINK_TARGET_URL = env("SINK_TARGET_URL", "http://sink:9000/ingest");
+
+// Auth: HS256 JWT signed with the secret the server is configured with.
+export const JWT_SECRET = env("JWT_SECRET", "stress-harness-local-secret-0123456789abcdef");
+export const USER_ID = env("USER_ID", "user_stress_local");
+
+// Light defaults for the load-shaped specs.
+export const ITEMS = envInt("ITEMS", 10);
+export const RATE_LIMIT = envInt("RATE_LIMIT", 5);
+
+// A unique-ish, deterministic-per-run label (k6 has Date.now()).
+export function stamp(prefix) {
+  return `${prefix}-${Date.now()}`;
+}

--- a/tests/stress/k6/lib/sink.js
+++ b/tests/stress/k6/lib/sink.js
@@ -1,0 +1,44 @@
+// Client for the controllable sink service — the target the buffers point at.
+// k6 uses this to reset state, configure per-token response policies, and read
+// back the deliveries the scheduler actually made.
+
+import http from "k6/http";
+import { fail } from "k6";
+import { SINK_URL } from "./config.js";
+
+export function reset() {
+  const res = http.post(`${SINK_URL}/control/reset`);
+  if (res.status !== 200) fail(`sink.reset: got ${res.status} — ${res.body}`);
+}
+
+// policy: { mode: "ok"|"fail_n"|"always_fail"|"sleep"|"status", n, sleep_ms, status, retry_after }
+export function setPolicy(token, policy) {
+  const res = http.post(
+    `${SINK_URL}/control/policy`,
+    JSON.stringify({ token, ...policy }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+  if (res.status !== 200) fail(`sink.setPolicy: got ${res.status} — ${res.body}`);
+}
+
+// Set the global default policy (applied to tokens with no explicit policy).
+export function setDefault(policy) {
+  const res = http.post(`${SINK_URL}/control/default`, JSON.stringify(policy), {
+    headers: { "Content-Type": "application/json" },
+  });
+  if (res.status !== 200) fail(`sink.setDefault: got ${res.status} — ${res.body}`);
+}
+
+// All recorded deliveries for a token, oldest first: [{ token, ts_ms, status, method }]
+export function deliveries(token) {
+  const res = http.get(`${SINK_URL}/deliveries?token=${encodeURIComponent(token)}`);
+  if (res.status !== 200) fail(`sink.deliveries: got ${res.status} — ${res.body}`);
+  return res.json("deliveries");
+}
+
+// Aggregate stats across all tokens.
+export function stats() {
+  const res = http.get(`${SINK_URL}/stats`);
+  if (res.status !== 200) fail(`sink.stats: got ${res.status} — ${res.body}`);
+  return res.json();
+}

--- a/tests/stress/k6/ordering.js
+++ b/tests/stress/k6/ordering.js
@@ -1,0 +1,63 @@
+// Strict per-buffer ordering (issue #30).
+//
+// Push N items in order. Force an early item to fail once so it must retry
+// (with backoff) — under strict ordering, NO later item may be delivered until
+// that item finally succeeds. Assert the acked deliveries arrive in exact push
+// order (0,1,2,...,N-1), and that the retried item really did retry.
+//
+// Light by default (N=5). The retried item adds one ~30s backoff wait.
+
+import { check, sleep } from "k6";
+import { mintJWT } from "./lib/auth.js";
+import * as buffers from "./lib/buffers.js";
+import * as sink from "./lib/sink.js";
+import { SINK_TARGET_URL, USER_ID, stamp } from "./lib/config.js";
+
+const N = parseInt(__ENV.ORDER_ITEMS || "5", 10);
+const FAIL_INDEX = parseInt(__ENV.ORDER_FAIL_INDEX || "1", 10); // which item retries once
+
+export const options = { vus: 1, iterations: 1, thresholds: { checks: ["rate==1.0"] } };
+
+function idxOf(name, token) {
+  return parseInt(token.slice(`${name}-i`.length), 10);
+}
+
+export default function () {
+  const token = mintJWT(USER_ID);
+  sink.reset();
+
+  const name = stamp("ordering");
+  const buf = buffers.createBuffer(token, {
+    name,
+    url: SINK_TARGET_URL,
+    rate_limit: 100, // high: ordering, not rate, is what we're testing here
+    max_retries: 3,
+    backoff: "exponential",
+  });
+
+  const ids = [];
+  for (let i = 0; i < N; i++) {
+    const t = `${name}-i${String(i).padStart(3, "0")}`;
+    if (i === FAIL_INDEX) sink.setPolicy(t, { mode: "fail_n", n: 1 }); // one 500 then 200
+    const item = buffers.pushItem(token, buf.id, { headers: { "X-Stress-Token": t }, body: t });
+    ids.push(item.id);
+  }
+
+  buffers.pollItemsUntilTerminal(token, buf.id, ids, { timeoutMs: 120000, intervalMs: 1000 });
+
+  const all = sink.deliveries("").sort((a, b) => a.ts_ms - b.ts_ms);
+  const ackedIdx = all.filter((d) => d.status >= 200 && d.status < 300).map((d) => idxOf(name, d.token));
+  const failedForFailIndex = all.filter(
+    (d) => idxOf(name, d.token) === FAIL_INDEX && d.status >= 500,
+  ).length;
+
+  const expected = Array.from({ length: N }, (_, i) => i);
+  const inOrder = JSON.stringify(ackedIdx) === JSON.stringify(expected);
+
+  console.log(`ordering: acked sequence = [${ackedIdx.join(",")}] expected [${expected.join(",")}] retried=${failedForFailIndex}`);
+
+  check(null, {
+    "acked deliveries arrive in exact push order": () => inOrder,
+    "the forced-fail item actually retried": () => failedForFailIndex >= 1,
+  });
+}

--- a/tests/stress/k6/rate.js
+++ b/tests/stress/k6/rate.js
@@ -1,0 +1,75 @@
+// Rate-limit adherence (characterization).
+//
+// The drainer claims up to `rate_limit` items per poll cycle (default poll =
+// 1s), so the *advertised* "rate-limited endpoint" really means ~rate_limit
+// dispatches per poll interval. This spec pushes a burst at a healthy sink,
+// then reconstructs the per-second dispatch distribution from the sink's
+// delivery timestamps and:
+//   - reports the real distribution (so the human sees actual behavior)
+//   - asserts rate_limit acts as an upper bound (no window blows past it)
+//
+// Light by default. Override RATE_LIMIT / WINDOW_MS / RATE_ITEMS via env.
+
+import { check } from "k6";
+import { mintJWT } from "./lib/auth.js";
+import * as buffers from "./lib/buffers.js";
+import * as sink from "./lib/sink.js";
+import { SINK_TARGET_URL, USER_ID, RATE_LIMIT, stamp } from "./lib/config.js";
+
+const WINDOW_MS = parseInt(__ENV.WINDOW_MS || "1000", 10); // = drainer poll interval
+const ITEMS = parseInt(__ENV.RATE_ITEMS || String(RATE_LIMIT * 4), 10);
+// Boundary jitter can split/merge cycles across a window edge; allow a little slack.
+const SLACK = parseInt(__ENV.RATE_SLACK || "1", 10);
+
+export const options = { vus: 1, iterations: 1, thresholds: { checks: ["rate==1.0"] } };
+
+export default function () {
+  const token = mintJWT(USER_ID);
+  sink.reset();
+
+  const name = stamp("rate");
+  const buf = buffers.createBuffer(token, {
+    name,
+    url: SINK_TARGET_URL,
+    rate_limit: RATE_LIMIT,
+    max_retries: 3,
+  });
+
+  const ids = [];
+  for (let i = 0; i < ITEMS; i++) {
+    const itemToken = `${name}-item-${i}`;
+    const item = buffers.pushItem(token, buf.id, {
+      headers: { "X-Stress-Token": itemToken },
+      body: itemToken,
+    });
+    ids.push(item.id);
+  }
+
+  buffers.pollItemsUntilTerminal(token, buf.id, ids, { timeoutMs: 120000, intervalMs: 500 });
+
+  // Reconstruct dispatch timeline from acked deliveries.
+  const all = sink.deliveries("").filter((d) => d.status >= 200 && d.status < 300);
+  all.sort((a, b) => a.ts_ms - b.ts_ms);
+
+  const t0 = all.length ? all[0].ts_ms : 0;
+  const windows = {};
+  for (const d of all) {
+    const w = Math.floor((d.ts_ms - t0) / WINDOW_MS);
+    windows[w] = (windows[w] || 0) + 1;
+  }
+  const counts = Object.values(windows);
+  const maxWindow = counts.length ? Math.max(...counts) : 0;
+  const spanMs = all.length ? all[all.length - 1].ts_ms - t0 : 0;
+  const avgPerWindow = spanMs > 0 ? (all.length / (spanMs / WINDOW_MS)).toFixed(2) : all.length;
+
+  console.log(
+    `rate: items=${ITEMS} rate_limit=${RATE_LIMIT} window=${WINDOW_MS}ms ` +
+      `delivered=${all.length} span=${spanMs}ms maxPerWindow=${maxWindow} avgPerWindow=${avgPerWindow}`,
+  );
+  console.log(`rate: per-window counts = [${counts.join(", ")}]`);
+
+  check(null, {
+    "all items dispatched": () => all.length === ITEMS,
+    "rate_limit is an upper bound per window": () => maxWindow <= RATE_LIMIT + SLACK,
+  });
+}

--- a/tests/stress/k6/rate.js
+++ b/tests/stress/k6/rate.js
@@ -1,14 +1,13 @@
-// Rate-limit adherence (characterization).
+// Rate-limit adherence — per-second token bucket (issue #31).
 //
-// The drainer claims up to `rate_limit` items per poll cycle (default poll =
-// 1s), so the *advertised* "rate-limited endpoint" really means ~rate_limit
-// dispatches per poll interval. This spec pushes a burst at a healthy sink,
-// then reconstructs the per-second dispatch distribution from the sink's
-// delivery timestamps and:
-//   - reports the real distribution (so the human sees actual behavior)
-//   - asserts rate_limit acts as an upper bound (no window blows past it)
+// With the token bucket, rate_limit means "max deliveries per second" (burst up
+// to rate_limit). Push a burst at a healthy sink and verify:
+//   - sustained throughput stays at/below rate_limit per second
+//   - the limiter actually slowed delivery (without it, strict-ordering drains
+//     the whole queue in well under a second)
+//   - no per-second window blows past the burst bound (capacity + 1s refill)
 //
-// Light by default. Override RATE_LIMIT / WINDOW_MS / RATE_ITEMS via env.
+// Light by default. Override RATE_LIMIT / RATE_ITEMS / WINDOW_MS.
 
 import { check } from "k6";
 import { mintJWT } from "./lib/auth.js";
@@ -16,10 +15,9 @@ import * as buffers from "./lib/buffers.js";
 import * as sink from "./lib/sink.js";
 import { SINK_TARGET_URL, USER_ID, RATE_LIMIT, stamp } from "./lib/config.js";
 
-const WINDOW_MS = parseInt(__ENV.WINDOW_MS || "1000", 10); // = drainer poll interval
-const ITEMS = parseInt(__ENV.RATE_ITEMS || String(RATE_LIMIT * 4), 10);
-// Boundary jitter can split/merge cycles across a window edge; allow a little slack.
-const SLACK = parseInt(__ENV.RATE_SLACK || "1", 10);
+const WINDOW_MS = parseInt(__ENV.WINDOW_MS || "1000", 10);
+const ITEMS = parseInt(__ENV.RATE_ITEMS || String(RATE_LIMIT * 6), 10);
+const RATE_TOLERANCE = parseFloat(__ENV.RATE_TOLERANCE || "0.35");
 
 export const options = { vus: 1, iterations: 1, thresholds: { checks: ["rate==1.0"] } };
 
@@ -37,17 +35,13 @@ export default function () {
 
   const ids = [];
   for (let i = 0; i < ITEMS; i++) {
-    const itemToken = `${name}-item-${i}`;
-    const item = buffers.pushItem(token, buf.id, {
-      headers: { "X-Stress-Token": itemToken },
-      body: itemToken,
-    });
+    const t = `${name}-item-${i}`;
+    const item = buffers.pushItem(token, buf.id, { headers: { "X-Stress-Token": t }, body: t });
     ids.push(item.id);
   }
 
-  buffers.pollItemsUntilTerminal(token, buf.id, ids, { timeoutMs: 120000, intervalMs: 500 });
+  buffers.pollItemsUntilTerminal(token, buf.id, ids, { timeoutMs: 180000, intervalMs: 500 });
 
-  // Reconstruct dispatch timeline from acked deliveries.
   const all = sink.deliveries("").filter((d) => d.status >= 200 && d.status < 300);
   all.sort((a, b) => a.ts_ms - b.ts_ms);
 
@@ -60,16 +54,24 @@ export default function () {
   const counts = Object.values(windows);
   const maxWindow = counts.length ? Math.max(...counts) : 0;
   const spanMs = all.length ? all[all.length - 1].ts_ms - t0 : 0;
-  const avgPerWindow = spanMs > 0 ? (all.length / (spanMs / WINDOW_MS)).toFixed(2) : all.length;
+  const spanSec = spanMs / 1000 || 1;
+  const avgPerSec = all.length / spanSec;
+
+  // Throttling proof: at rate_limit/sec, ITEMS deliveries take ~ITEMS/rate_limit
+  // seconds. Without the limiter, strict-ordering drains the queue in << 1s.
+  const expectedSec = ITEMS / RATE_LIMIT;
 
   console.log(
-    `rate: items=${ITEMS} rate_limit=${RATE_LIMIT} window=${WINDOW_MS}ms ` +
-      `delivered=${all.length} span=${spanMs}ms maxPerWindow=${maxWindow} avgPerWindow=${avgPerWindow}`,
+    `rate: items=${ITEMS} rate_limit=${RATE_LIMIT}/s delivered=${all.length} ` +
+      `spanMs=${spanMs} avgPerSec=${avgPerSec.toFixed(2)} maxWindow=${maxWindow} ` +
+      `expected~${expectedSec.toFixed(1)}s`,
   );
   console.log(`rate: per-window counts = [${counts.join(", ")}]`);
 
   check(null, {
-    "all items dispatched": () => all.length === ITEMS,
-    "rate_limit is an upper bound per window": () => maxWindow <= RATE_LIMIT + SLACK,
+    "all items delivered": () => all.length === ITEMS,
+    "sustained throughput <= rate_limit/sec": () => avgPerSec <= RATE_LIMIT * (1 + RATE_TOLERANCE),
+    "limiter actually throttled (span ~ items/rate)": () => spanSec >= expectedSec * 0.6,
+    "no window exceeds burst bound (capacity + 1s refill)": () => maxWindow <= RATE_LIMIT * 2 + 1,
   });
 }

--- a/tests/stress/k6/retry.js
+++ b/tests/stress/k6/retry.js
@@ -1,0 +1,71 @@
+// Retry & backoff.
+//
+// Configure the sink to fail an item's first RETRIES deliveries (500), then
+// succeed. Assert the drainer retries the right number of times, the item
+// finally completes, and the spacing between deliveries reflects the backoff
+// (base 30s, exponential with jitter — so the first gap lands in ~[18s,45s]).
+//
+// Default RETRIES=1 keeps this ~30-40s. On a beefier box: RETRIES=2 make retry
+// (≈90s) also checks that gaps GROW (exponential), not just that one exists.
+
+import { check } from "k6";
+import { mintJWT } from "./lib/auth.js";
+import * as buffers from "./lib/buffers.js";
+import * as sink from "./lib/sink.js";
+import { SINK_TARGET_URL, USER_ID, stamp } from "./lib/config.js";
+
+const RETRIES = parseInt(__ENV.RETRIES || "1", 10);
+
+export const options = { vus: 1, iterations: 1, thresholds: { checks: ["rate==1.0"] } };
+
+export default function () {
+  const token = mintJWT(USER_ID);
+  sink.reset();
+
+  const name = stamp("retry");
+  const buf = buffers.createBuffer(token, {
+    name,
+    url: SINK_TARGET_URL,
+    rate_limit: 5,
+    max_retries: RETRIES + 2, // headroom so the success isn't cut off
+    backoff: "exponential",
+  });
+
+  const itemToken = `${name}-item-0`;
+  // Fail the first RETRIES deliveries, then 200.
+  sink.setPolicy(itemToken, { mode: "fail_n", n: RETRIES });
+
+  const item = buffers.pushItem(token, buf.id, {
+    headers: { "X-Stress-Token": itemToken },
+    body: itemToken,
+  });
+
+  const final = buffers.pollUntilTerminal(token, buf.id, item.id, {
+    timeoutMs: (RETRIES + 1) * 60000 + 30000,
+    intervalMs: 1000,
+  });
+
+  const ds = sink.deliveries(itemToken).sort((a, b) => a.ts_ms - b.ts_ms);
+  const fails = ds.filter((d) => d.status >= 500).length;
+  const acks = ds.filter((d) => d.status >= 200 && d.status < 300).length;
+
+  const gaps = [];
+  for (let i = 1; i < ds.length; i++) gaps.push(ds[i].ts_ms - ds[i - 1].ts_ms);
+
+  console.log(
+    `retry: status=${final.status} retry_count=${final.retry_count} ` +
+      `deliveries=${ds.length} fails=${fails} acks=${acks} gaps_ms=[${gaps.join(", ")}]`,
+  );
+
+  check(null, {
+    "item eventually completed": () => final.status === "completed",
+    "retried exactly RETRIES times": () => final.retry_count === RETRIES,
+    "delivered RETRIES failures + 1 success": () =>
+      fails === RETRIES && acks === 1 && ds.length === RETRIES + 1,
+    "first retry waited out the backoff (~30s band)": () =>
+      gaps.length >= 1 && gaps[0] >= 18000 && gaps[0] <= 50000,
+    // Only meaningful with >=2 gaps: exponential => later gaps grow.
+    "backoff grows (exponential)": () =>
+      gaps.length < 2 || gaps[gaps.length - 1] > gaps[0],
+  });
+}

--- a/tests/stress/k6/tracer.js
+++ b/tests/stress/k6/tracer.js
@@ -1,0 +1,57 @@
+// Tracer bullet: the smallest end-to-end proof that the harness works.
+//
+// Push ONE item to a buffer pointed at the sink, wait for it to reach a
+// terminal state, and assert:
+//   1. the item completed
+//   2. the sink received exactly one delivery of that item's token
+//
+// If this passes, the whole pipe is wired: auth -> create buffer -> push ->
+// drainer executes -> sink records -> introspection -> assertions.
+
+import { check } from "k6";
+import { mintJWT } from "./lib/auth.js";
+import * as buffers from "./lib/buffers.js";
+import * as sink from "./lib/sink.js";
+import { SINK_TARGET_URL, USER_ID, stamp } from "./lib/config.js";
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  // Any failed check fails the whole run (non-zero exit) — this is the CI gate.
+  thresholds: { checks: ["rate==1.0"] },
+};
+
+export default function () {
+  const token = mintJWT(USER_ID);
+  sink.reset();
+
+  const name = stamp("tracer");
+  const buf = buffers.createBuffer(token, {
+    name,
+    url: SINK_TARGET_URL,
+    rate_limit: 5,
+    max_retries: 3,
+  });
+
+  const itemToken = `${name}-item-1`;
+  const item = buffers.pushItem(token, buf.id, {
+    headers: { "X-Stress-Token": itemToken },
+    body: itemToken,
+  });
+
+  const final = buffers.pollUntilTerminal(token, buf.id, item.id, {
+    timeoutMs: 30000,
+    intervalMs: 500,
+  });
+
+  check(final, {
+    "item reached completed": (it) => it.status === "completed",
+  });
+
+  const deliveries = sink.deliveries(itemToken);
+  check(deliveries, {
+    "sink received exactly one delivery": (d) => d.length === 1,
+    "delivery was acknowledged 2xx": (d) =>
+      d.length > 0 && d[0].status >= 200 && d[0].status < 300,
+  });
+}

--- a/tests/stress/scripts/crash-run.sh
+++ b/tests/stress/scripts/crash-run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Crash-recovery chaos run: load items behind a stalling sink, SIGKILL the
+# scheduler mid-flight, restart it, then verify the reaper rescues every item.
+#
+# Knobs: CRASH_ITEMS (default 10), CRASH_SLEEP_MS (default 8000),
+#        KILL_AFTER_SEC (default 3).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+COMPOSE="docker compose -f docker-compose.stress.yml"
+RUN="crash-$(date +%s)"
+N="${CRASH_ITEMS:-10}"
+SLEEP_MS="${CRASH_SLEEP_MS:-8000}"
+KILL_AFTER="${KILL_AFTER_SEC:-3}"
+
+echo "[crash] run=$RUN items=$N sleep_ms=$SLEEP_MS kill_after=${KILL_AFTER}s"
+
+echo "[crash] phase 1: load (sink stalls so items sit in 'running')"
+$COMPOSE run --rm \
+  -e PHASE=load -e CRASH_RUN="$RUN" -e CRASH_ITEMS="$N" -e CRASH_SLEEP_MS="$SLEEP_MS" \
+  k6 run /scripts/crash.js
+
+echo "[crash] waiting ${KILL_AFTER}s for the drainer to claim the batch..."
+sleep "$KILL_AFTER"
+
+echo "[crash] >>> SIGKILL scheduler (simulated crash) <<<"
+$COMPOSE kill scheduler
+
+echo "[crash] restarting scheduler"
+$COMPOSE up -d scheduler
+
+echo "[crash] phase 3: verify recovery (reaper rescue can take ~30-60s)"
+$COMPOSE run --rm \
+  -e PHASE=verify -e CRASH_RUN="$RUN" -e CRASH_ITEMS="$N" \
+  k6 run /scripts/crash.js

--- a/tests/stress/sink/Dockerfile
+++ b/tests/stress/sink/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY go.mod ./
+COPY main.go ./
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /app/sink .
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=builder /app/sink /sink
+EXPOSE 9000
+ENTRYPOINT ["/sink"]

--- a/tests/stress/sink/go.mod
+++ b/tests/stress/sink/go.mod
@@ -1,0 +1,3 @@
+module github.com/fliq-sh/stress-sink
+
+go 1.26

--- a/tests/stress/sink/main.go
+++ b/tests/stress/sink/main.go
@@ -1,0 +1,248 @@
+// Command sink is a controllable HTTP target + recorder for buffer stress
+// tests. The buffers under test point their URL at /ingest; the scheduler's
+// executor calls it for every (re)delivery. The sink records each delivery
+// keyed by the X-Stress-Token header and answers per a per-token policy that
+// k6 configures over /control/*.
+//
+// It is intentionally dependency-free (stdlib only) and knows nothing about
+// core-api internals — it is part of the harness, not the system under test.
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const tokenHeader = "X-Stress-Token"
+
+type delivery struct {
+	Token  string `json:"token"`
+	TsMs   int64  `json:"ts_ms"`
+	Status int    `json:"status"`
+	Method string `json:"method"`
+}
+
+// policy controls how the sink responds to a given token.
+//
+//	mode "ok"          -> always 200
+//	mode "always_fail" -> always 500
+//	mode "fail_n"      -> first N deliveries 500, then 200 (exercises retry->success)
+//	mode "sleep"       -> sleep SleepMs then return Status (default 200); exercises timeouts
+//	mode "status"      -> return Status verbatim (e.g. 429 with Retry-After)
+type policy struct {
+	Mode       string `json:"mode"`
+	N          int    `json:"n"`
+	SleepMs    int    `json:"sleep_ms"`
+	Status     int    `json:"status"`
+	RetryAfter int    `json:"retry_after"`
+}
+
+type store struct {
+	mu          sync.Mutex
+	deliveries  []delivery
+	policies    map[string]policy
+	defaultPol  policy // applied when a token has no explicit policy
+	seen        map[string]int // token -> times delivered (drives fail_n)
+}
+
+func newStore() *store {
+	return &store{
+		policies:   map[string]policy{},
+		defaultPol: policy{Mode: "ok"},
+		seen:       map[string]int{},
+	}
+}
+
+func (s *store) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deliveries = nil
+	s.policies = map[string]policy{}
+	s.defaultPol = policy{Mode: "ok"}
+	s.seen = map[string]int{}
+}
+
+func (s *store) setDefault(p policy) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.defaultPol = p
+}
+
+// decide records the delivery and returns the status to respond with, plus any
+// Retry-After seconds (0 = none).
+func (s *store) decide(token, method string) (int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.seen[token]++
+	n := s.seen[token]
+	p, ok := s.policies[token]
+	if !ok {
+		p = s.defaultPol
+	}
+
+	status := http.StatusOK
+	retryAfter := 0
+	sleepMs := 0
+
+	switch p.Mode {
+	case "", "ok":
+		status = http.StatusOK
+	case "always_fail":
+		status = http.StatusInternalServerError
+	case "fail_n":
+		if n <= p.N {
+			status = http.StatusInternalServerError
+		} else {
+			status = http.StatusOK
+		}
+	case "sleep":
+		sleepMs = p.SleepMs
+		status = p.Status
+		if status == 0 {
+			status = http.StatusOK
+		}
+	case "status":
+		status = p.Status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		retryAfter = p.RetryAfter
+	default:
+		status = http.StatusOK
+	}
+
+	s.deliveries = append(s.deliveries, delivery{
+		Token:  token,
+		TsMs:   time.Now().UnixMilli(),
+		Status: status,
+		Method: method,
+	})
+
+	// Sleep outside the lock would be better, but keeping the critical section
+	// simple is fine for light loads; release then sleep.
+	if sleepMs > 0 {
+		s.mu.Unlock()
+		time.Sleep(time.Duration(sleepMs) * time.Millisecond)
+		s.mu.Lock()
+	}
+
+	return status, retryAfter
+}
+
+func (s *store) deliveriesFor(token string) []delivery {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := []delivery{}
+	for _, d := range s.deliveries {
+		if token == "" || d.Token == token {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+func (s *store) setPolicy(token string, p policy) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.policies[token] = p
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "9000"
+	}
+	s := newStore()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/ingest", func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get(tokenHeader)
+		if token == "" {
+			// Fall back to the body so callers that can't set headers still work.
+			b, _ := io.ReadAll(io.LimitReader(r.Body, 1<<16))
+			token = string(b)
+		}
+		status, retryAfter := s.decide(token, r.Method)
+		if retryAfter > 0 {
+			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+		}
+		w.WriteHeader(status)
+	})
+
+	mux.HandleFunc("/control/reset", func(w http.ResponseWriter, r *http.Request) {
+		s.reset()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/control/policy", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Token string `json:"token"`
+			policy
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if body.Token == "" {
+			http.Error(w, "token required", http.StatusBadRequest)
+			return
+		}
+		s.setPolicy(body.Token, body.policy)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/control/default", func(w http.ResponseWriter, r *http.Request) {
+		var p policy
+		if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		s.setDefault(p)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.HandleFunc("/deliveries", func(w http.ResponseWriter, r *http.Request) {
+		token := r.URL.Query().Get("token")
+		ds := s.deliveriesFor(token)
+		writeJSON(w, map[string]any{"token": token, "count": len(ds), "deliveries": ds})
+	})
+
+	mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
+		all := s.deliveriesFor("")
+		perToken := map[string]int{}
+		ack := map[string]int{} // 2xx acks per token
+		for _, d := range all {
+			perToken[d.Token]++
+			if d.Status >= 200 && d.Status < 300 {
+				ack[d.Token]++
+			}
+		}
+		writeJSON(w, map[string]any{
+			"total_deliveries": len(all),
+			"distinct_tokens":  len(perToken),
+			"per_token":        perToken,
+			"acks_per_token":   ack,
+		})
+	})
+
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	log.Printf("sink listening on :%s", port)
+	if err := http.ListenAndServe(":"+port, mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}


### PR DESCRIPTION
## What

A black-box stress & chaos harness for **buffers**, under `tests/stress/`. It
speaks only the public HTTP API plus a controllable sink — **zero imports of
`internal/`** — so it survives refactors of the buffer internals. Designed to
grow into the final SLA-gate step of CI/CD.

## Specs (all green locally)

| `make …` | verifies |
|---|---|
| `tracer` | end-to-end: push → execute → deliver → record |
| `completeness` | no loss — all N items `completed`, each delivered+acked once |
| `rate` | `rate_limit` caps per-poll-cycle dispatch (characterized) |
| `retry` | retries the right number of times, completes, backoff spacing matches |
| `crash` | SIGKILL the scheduler mid-flight → reaper rescues every item (no loss) |

## How it's wired

- One reproducible `docker-compose.stress.yml`: postgres + migrate + server +
  scheduler (the SUT) + a sink + k6.
- **Sink** (`sink/main.go`, stdlib only) is the target buffers point at: records
  deliveries by `X-Stress-Token`, serves configurable policies
  (`ok`/`fail_n`/`always_fail`/`sleep`/`status`) per-token or as a global
  default, and exposes `/deliveries` + `/stats` for assertions.
- The sink is exposed via Traefik at a **public** host because the executor's
  SSRF guard (`internal/safedialer`) blocks private ranges — this also exercises
  the real dial/TLS path. k6 reads the sink over the internal network.
- **Auth**: k6 mints a local HS256 JWT (mirrors `scripts/gentoken.go`);
  `EnsureUser` upserts the user + grants credits on first call. No Clerk, no seed.
- Takes `BASE_URL`, so the same specs can later run against staging/prod (needs a
  sink reachable from that deployment + a real token).

## Light by default

Single-digit/low-tens items, 1 VU — safe on a shared box. Crank via env:
`ITEMS=500 RATE_LIMIT=50 make completeness`, `RETRIES=3 make retry`,
`CRASH_ITEMS=200 make crash`, etc.

## Findings surfaced — see #25

Running the harness turned up four behaviors, tracked in #25. Headline: **buffer
executions are never billed** (a `credit_transactions` FK violation on every
delivery). The harness README documents all four.

## Notes for reviewers

- All new files under `tests/stress/`; nothing in `internal/` or the build is
  touched.
- `crash` and `retry` take ~30–40s each (real 30s backoff / reaper timeouts).
- The public sink host (`stress-sink.night.enkiduck.com`) is tied to the dev box;
  parameterize it for other environments.
