### PR TITLE
Forward stable X-Fliq-Delivery-Id header for delivery dedupe

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Stop reinventing cron. Fliq lets you schedule one-off HTTP calls and recurring c
 
 **For startups** — Ship faster. Don't burn a sprint building a job queue. POST a job, move on. Fliq handles delivery, retries, and failure visibility out of the box.
 
-**For developers** — No SDKs, no magic. A clean REST API, API token auth (`fliq_sk_*`), idempotency keys, and full execution history per job. Works with any HTTP endpoint.
+**For developers** — No SDKs, no magic. A clean REST API, API token auth (`fliq_sk_*`), idempotency keys, and full execution history per job. Works with any HTTP endpoint. Delivery is at-least-once — every outbound request carries a stable `X-Fliq-Delivery-Id` header so your endpoint can dedupe.
 
-**For engineering leaders** — One less piece of infrastructure to own. Postgres-native, no Redis or Kafka required. Sub-2s pickup latency. Exactly-once execution via row-level locking. Designed to scale.
+**For engineering leaders** — One less piece of infrastructure to own. Postgres-native, no Redis or Kafka required. Sub-2s pickup latency. At-least-once execution with crash-safe retries via row-level locking. Designed to scale.
 
 ---
 
@@ -33,7 +33,7 @@ No seat fees. No contracts. Pay only for what you execute.
 |---|---|
 | One-off job scheduling — create, claim, execute, retry | ✅ Done |
 | Cron schedules — recurring jobs with pause/resume | ✅ Done |
-| Exactly-once execution (FOR UPDATE SKIP LOCKED + reaper) | ✅ Done |
+| At-least-once execution (FOR UPDATE SKIP LOCKED + reaper) | ✅ Done |
 | Crash recovery (heartbeat + reaper process) | ✅ Done |
 | API token auth (`fliq_sk_*`) + Clerk JWT | ✅ Done |
 | Per-user job isolation (ownership enforced at query level) | ✅ Done |
@@ -95,7 +95,7 @@ See `CLAUDE.md` for the full local setup guide and coding conventions.
 ### Phase 1 — Core backend ✅
 - Job CRUD, worker, reaper, retry with backoff
 - Cron schedules with pause/resume
-- Exactly-once execution via Postgres row-level locking
+- At-least-once execution with crash-safe retries via Postgres row-level locking
 - API token auth + Clerk JWT; jobs scoped to authenticated users
 - Credit system: free tier (5k/day) + pay-as-you-go via Stripe
 - CI: lint + test + migrations on every PR

--- a/internal/scheduler/executor.go
+++ b/internal/scheduler/executor.go
@@ -87,6 +87,10 @@ func (e *Executor) Run(ctx context.Context, job *domain.Job, signingSecret strin
 		req.Header.Set(k, v)
 	}
 
+	// Set after user headers so it cannot be clobbered. Stable across retries
+	// and post-crash redeliveries; lets targets dedupe at-least-once deliveries.
+	req.Header.Set("X-Fliq-Delivery-Id", job.ID)
+
 	if signingSecret != "" {
 		var bodyBytes []byte
 		if job.Body != nil {

--- a/internal/scheduler/executor_test.go
+++ b/internal/scheduler/executor_test.go
@@ -139,6 +139,30 @@ func TestExecutor_Run_SetsRequestID(t *testing.T) {
 	}
 }
 
+func TestExecutor_Run_SetsDeliveryID(t *testing.T) {
+	var gotDeliveryID string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotDeliveryID = r.Header.Get("X-Fliq-Delivery-Id")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	exec := testExecutor()
+	job := testutil.NewJob(testutil.WithURL(srv.URL), testutil.WithMethod("POST"))
+	// A user-supplied header for the same key must not win.
+	job.Headers = map[string]string{"X-Fliq-Delivery-Id": "attacker-controlled"}
+
+	result := exec.Run(context.Background(), job, "")
+
+	if result.Err != nil {
+		t.Fatalf("Run() error = %v, want nil", result.Err)
+	}
+	if gotDeliveryID != job.ID {
+		t.Errorf("X-Fliq-Delivery-Id = %q, want %q (job ID)", gotDeliveryID, job.ID)
+	}
+}
+
 func TestExecutor_Run_BlocksSSRF(t *testing.T) {
 	// Use the production executor (with safe dialer) to verify SSRF blocking.
 	exec := scheduler.NewExecutor(slog.Default())


### PR DESCRIPTION
Buffer delivery is at-least-once, not exactly-once: a crash after a delivery reaches the target but before the item is marked complete causes the reaper to reschedule and re-fire it. Nothing helped the target dedupe.

## Changes
- **Executor:** set `X-Fliq-Delivery-Id: job.ID` on every outbound request, *after* user headers are applied so a user cannot clobber it. The drainer builds a temp `domain.Job` per buffer item with `ID = item.ID`, so this key is stable across retries and across post-crash redeliveries of the same item (and stable for regular jobs too). Signing is unaffected — the HMAC is over `ts.method.url.body`, not headers.
- **Docs:** corrected the "exactly-once" claims in README to "at-least-once with crash-safe retries", and added a one-line note recommending consumers dedupe on `X-Fliq-Delivery-Id`.
- **Test:** verifies the header equals the job ID even when the user supplies their own `X-Fliq-Delivery-Id`.

Closes #28