### PR TITLE
enforce strict per-buffer ordering

### DIFF
--- a/internal/infrastructure/postgres/buffer_repo.go
+++ b/internal/infrastructure/postgres/buffer_repo.go
@@ -250,7 +250,12 @@ func (r *BufferRepository) ListActiveBufferIDs(ctx context.Context, limit int) (
 	return ids, nil
 }
 
-func (r *BufferRepository) ClaimItems(ctx context.Context, bufferID, workerID string, limit int) ([]*domain.BufferItem, error) {
+func (r *BufferRepository) ClaimNextItem(ctx context.Context, bufferID, workerID string) (*domain.BufferItem, error) {
+	// The subquery picks the buffer's OLDEST pending item (head of the queue),
+	// regardless of whether it is due, but only while nothing is running for
+	// this buffer. The outer `scheduled_at <= NOW()` then claims it only if the
+	// head is actually due — so a head still in backoff blocks its successors
+	// (strict ordering) rather than letting a later item overtake it.
 	query := `
 		UPDATE buffer_items
 		SET    status       = 'running',
@@ -258,35 +263,33 @@ func (r *BufferRepository) ClaimItems(ctx context.Context, bufferID, workerID st
 		       claimed_by   = $1,
 		       heartbeat_at = NOW(),
 		       updated_at   = NOW()
-		WHERE id IN (
+		WHERE id = (
 			SELECT id FROM buffer_items
-			WHERE  buffer_id    = $2
-			  AND  status       = 'pending'
-			  AND  scheduled_at <= NOW()
+			WHERE  buffer_id = $2
+			  AND  status    = 'pending'
+			  AND  NOT EXISTS (
+				SELECT 1 FROM buffer_items running
+				WHERE  running.buffer_id = $2
+				  AND  running.status    = 'running'
+			  )
 			ORDER BY created_at ASC
-			LIMIT $3
+			LIMIT 1
 			FOR UPDATE SKIP LOCKED
 		)
+		  AND scheduled_at <= NOW()
 		RETURNING id, buffer_id, user_id, url, method, headers, body,
 		          timeout_seconds, backoff, status, retry_count, max_retries,
 		          scheduled_at, claimed_at, claimed_by, heartbeat_at,
 		          completed_at, last_error, status_code, created_at, updated_at`
 
-	rows, err := r.pool.Query(ctx, query, workerID, bufferID, limit)
+	item, err := scanBufferItem(r.pool.QueryRow(ctx, query, workerID, bufferID))
 	if err != nil {
-		return nil, fmt.Errorf("claim buffer items: %w", err)
-	}
-	defer rows.Close()
-
-	var items []*domain.BufferItem
-	for rows.Next() {
-		item, scanErr := scanBufferItem(rows)
-		if scanErr != nil {
-			return nil, scanErr
+		if errors.Is(err, domain.ErrBufferItemNotFound) {
+			return nil, nil // nothing claimable right now
 		}
-		items = append(items, item)
+		return nil, fmt.Errorf("claim next buffer item: %w", err)
 	}
-	return items, nil
+	return item, nil
 }
 
 func (r *BufferRepository) UpdateItemHeartbeat(ctx context.Context, itemID string) error {

--- a/internal/repository/buffer.go
+++ b/internal/repository/buffer.go
@@ -38,8 +38,12 @@ type BufferRepository interface {
 
 	// Drainer-facing: find non-paused buffers that have pending items with scheduled_at <= now
 	ListActiveBufferIDs(ctx context.Context, limit int) ([]string, error)
-	// ClaimItems claims up to limit pending items for a buffer, FIFO order.
-	ClaimItems(ctx context.Context, bufferID, workerID string, limit int) ([]*domain.BufferItem, error)
+	// ClaimNextItem claims the single oldest due item for a buffer, but only if
+	// the buffer has no item currently running. This enforces strict per-buffer
+	// (per-client) ordering: at most one item in flight, and a retrying item
+	// (pending with a future scheduled_at) blocks its successors until terminal.
+	// Returns (nil, nil) when there is nothing to claim.
+	ClaimNextItem(ctx context.Context, bufferID, workerID string) (*domain.BufferItem, error)
 	UpdateItemHeartbeat(ctx context.Context, itemID string) error
 	CompleteItem(ctx context.Context, itemID string, statusCode int) error
 	FailItem(ctx context.Context, itemID string, lastError string, statusCode *int) error

--- a/internal/scheduler/drainer.go
+++ b/internal/scheduler/drainer.go
@@ -101,19 +101,24 @@ func (d *BufferDrainer) drainBuffer(ctx context.Context, bufferID string) {
 		return
 	}
 
-	items, err := d.repo.ClaimItems(ctx, bufferID, d.id, buf.RateLimit)
-	if err != nil {
-		d.logger.ErrorContext(ctx, "claim buffer items", "buffer_id", bufferID, "error", err)
-		return
-	}
+	// Drain strictly in order: one item at a time, each to a terminal state
+	// before the next is claimed. ClaimNextItem returns nil when the head is not
+	// yet due (in backoff) or nothing is pending — either way we stop and let the
+	// next poll cycle resume. This preserves per-buffer (per-client) ordering.
+	for {
+		if ctx.Err() != nil {
+			return
+		}
 
-	if len(items) == 0 {
-		return
-	}
+		item, err := d.repo.ClaimNextItem(ctx, bufferID, d.id)
+		if err != nil {
+			d.logger.ErrorContext(ctx, "claim next buffer item", "buffer_id", bufferID, "error", err)
+			return
+		}
+		if item == nil {
+			return
+		}
 
-	d.logger.InfoContext(ctx, "claimed buffer items", "buffer_id", bufferID, "count", len(items))
-
-	for _, item := range items {
 		metrics.BufferItemsInFlight.Inc()
 		d.runItem(ctx, buf, item)
 		metrics.BufferItemsInFlight.Dec()


### PR DESCRIPTION
Implements the ordering model from the buffer-delivery design doc (#32 / #29).

**Change:** the drainer no longer batch-claims `rate_limit` items and runs them in a loop. `ClaimItems` is replaced by `ClaimNextItem`, which claims a buffer's single oldest **due** item, and only while nothing is running for that buffer. `drainBuffer` drains one item at a time to a terminal state.

**Effects:**
- At most one item per buffer in flight (no overlapping-cycle concurrency).
- A retrying item (pending + future `scheduled_at`) blocks its successors — the claim picks the head regardless of due-ness, then only claims if due, so a later item cannot overtake a predecessor in backoff.
- A permanently-failed item becomes `failed` (terminal) and the stream advances — skip-after-permanent-fail.
- Reaper unchanged: rescued items keep `created_at`, so order survives a crash.

**Verification:** built from this branch and run through the stress harness — a new `ordering.js` spec (forces an early item to fail+retry) confirms acked deliveries arrive in exact push order `[0,1,2,3,4]` while the retried item really retried; `completeness.js` unregressed (10/10). The `ordering.js` spec is added on the harness branch (#26), not here.

Closes #30. Depends on the model in #29 (#32).
