### PR TITLE
drop flaky post-deploy smoke test (racy pod wait)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,9 +123,3 @@ jobs:
         run: |
           kubectl rollout status deployment/server -n dist-scheduler --timeout=120s
           kubectl rollout status deployment/scheduler -n dist-scheduler --timeout=120s
-
-      - name: Post-deploy smoke test
-        run: |
-          kubectl wait --for=condition=Ready pods -l app=server -n dist-scheduler --timeout=60s
-          kubectl wait --for=condition=Ready pods -l app=scheduler -n dist-scheduler --timeout=60s
-          echo "All pods ready"


### PR DESCRIPTION
The `Post-deploy smoke test` step (`kubectl wait --for=condition=Ready pods -l app=...`) is racy: its label selector matches the **terminating** old ReplicaSet pods during a rolling restart, which disappear mid-wait → `Error from server (NotFound): pods "..." not found` → the step exits 1 and the whole deploy goes red, even though the rollout succeeded.

This already failed deploys (e.g. 2026-03-30, and the #34 merge deploy) where the app actually deployed fine.

The preceding `Wait for rollout` step (`kubectl rollout status deployment/...`) already blocks until both deployments are fully rolled out and available — a race-free readiness gate. The pod-label `kubectl wait` is redundant and only adds the flake, so this removes it.
