### PR TITLE
add per-buffer token-bucket rate limiting

### DIFF
--- a/internal/infrastructure/postgres/buffer_repo.go
+++ b/internal/infrastructure/postgres/buffer_repo.go
@@ -251,20 +251,21 @@ func (r *BufferRepository) ListActiveBufferIDs(ctx context.Context, limit int) (
 }
 
 func (r *BufferRepository) ClaimNextItem(ctx context.Context, bufferID, workerID string) (*domain.BufferItem, error) {
-	// The subquery picks the buffer's OLDEST pending item (head of the queue),
-	// regardless of whether it is due, but only while nothing is running for
-	// this buffer. The outer `scheduled_at <= NOW()` then claims it only if the
-	// head is actually due — so a head still in backoff blocks its successors
-	// (strict ordering) rather than letting a later item overtake it.
+	// Claim the buffer's head item, gated by BOTH strict ordering and the
+	// per-buffer token bucket, in one atomic statement:
+	//   candidate — the oldest pending item, but only while nothing is running
+	//               for this buffer (one-in-flight ordering). Locked SKIP LOCKED.
+	//   due       — the candidate, only if it is actually due (a head still in
+	//               backoff blocks its successors instead of being overtaken).
+	//   bucket    — lazily refill tokens (rate_limit/sec, capped at rate_limit)
+	//               and consume one, but ONLY if a due item exists and a token is
+	//               available. No due item => no token spent.
+	// The final claim happens only if a token was consumed, so the rate limit and
+	// the ordering guarantee hold together, and the statement is safe across
+	// multiple scheduler replicas (row locks on both tables).
 	query := `
-		UPDATE buffer_items
-		SET    status       = 'running',
-		       claimed_at   = NOW(),
-		       claimed_by   = $1,
-		       heartbeat_at = NOW(),
-		       updated_at   = NOW()
-		WHERE id = (
-			SELECT id FROM buffer_items
+		WITH candidate AS (
+			SELECT id, scheduled_at FROM buffer_items
 			WHERE  buffer_id = $2
 			  AND  status    = 'pending'
 			  AND  NOT EXISTS (
@@ -275,8 +276,29 @@ func (r *BufferRepository) ClaimNextItem(ctx context.Context, bufferID, workerID
 			ORDER BY created_at ASC
 			LIMIT 1
 			FOR UPDATE SKIP LOCKED
+		),
+		due AS (
+			SELECT id FROM candidate WHERE scheduled_at <= NOW()
+		),
+		bucket AS (
+			UPDATE buffers b
+			SET    tokens = LEAST(b.rate_limit::double precision,
+			                      b.tokens + EXTRACT(EPOCH FROM (NOW() - b.last_refill_at)) * b.rate_limit) - 1,
+			       last_refill_at = NOW()
+			WHERE  b.id = $2
+			  AND  EXISTS (SELECT 1 FROM due)
+			  AND  LEAST(b.rate_limit::double precision,
+			             b.tokens + EXTRACT(EPOCH FROM (NOW() - b.last_refill_at)) * b.rate_limit) >= 1
+			RETURNING b.id
 		)
-		  AND scheduled_at <= NOW()
+		UPDATE buffer_items
+		SET    status       = 'running',
+		       claimed_at   = NOW(),
+		       claimed_by   = $1,
+		       heartbeat_at = NOW(),
+		       updated_at   = NOW()
+		WHERE  id IN (SELECT id FROM due)
+		  AND  EXISTS (SELECT 1 FROM bucket)
 		RETURNING id, buffer_id, user_id, url, method, headers, body,
 		          timeout_seconds, backoff, status, retry_count, max_retries,
 		          scheduled_at, claimed_at, claimed_by, heartbeat_at,

--- a/migrations/20260330000002_buffer_token_bucket.sql
+++ b/migrations/20260330000002_buffer_token_bucket.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+
+-- Per-buffer token bucket for true per-second rate limiting. `tokens` accrues at
+-- `rate_limit` tokens/second up to a capacity of `rate_limit` (burst), refilled
+-- lazily on each claim from `last_refill_at`. Starting at 0 avoids a startup
+-- burst; an idle buffer accrues up to `rate_limit` before its next item.
+ALTER TABLE buffers
+    ADD COLUMN tokens         DOUBLE PRECISION NOT NULL DEFAULT 0,
+    ADD COLUMN last_refill_at TIMESTAMPTZ      NOT NULL DEFAULT NOW();
+
+-- +goose Down
+
+ALTER TABLE buffers
+    DROP COLUMN IF EXISTS tokens,
+    DROP COLUMN IF EXISTS last_refill_at;


### PR DESCRIPTION
Implements the per-second token bucket from the buffer-delivery design doc (#32 / #29). **Stacked on #30** (`feat/buffer-strict-ordering`) — review/merge that first.

**Change:** `rate_limit` now means *deliveries per second* per buffer, not "claims per poll cycle." Each buffer gets `tokens` + `last_refill_at` columns; `ClaimNextItem` becomes a single atomic CTE that:
1. `candidate` — locks the buffer's oldest pending item, only while nothing is running for it (the #30 ordering gate),
2. `due` — keeps it only if actually due,
3. `bucket` — lazily refills tokens (`rate_limit`/sec, capped at `rate_limit`) and consumes one **only if** a due item exists and a token is available,
4. claims the item **only if** a token was consumed.

So no token is wasted on an empty/over-rate cycle, ordering and rate limiting hold together, and it's safe across multiple scheduler replicas (row locks on both tables). Tokens start at 0 to avoid a startup burst; an idle buffer accrues up to `rate_limit` (burst).

**Verification:** built from this branch through the stress harness. Upgraded `rate.js` (on the harness branch #26): 30 items at `rate_limit=5/s` delivered over ~5.9s, `avgPerSec=5.07`, per-window `[6,5,5,5,5,4]`; throttling proven (without the limiter strict-ordering drains the queue in <1s); ordering and completeness unregressed.

Migration `20260330000002_buffer_token_bucket.sql`. `rate_limit` units (per second) should be reflected in the API docs.

Closes #31. Depends on #30 (#35) and the model in #29 (#32).
