### PR TITLE
fix: DELETE /buffers/:id 500s for any executed buffer (credit_tx FK)

### DIFF
--- a/migrations/20260330000003_credit_tx_buffer_item_ondelete.sql
+++ b/migrations/20260330000003_credit_tx_buffer_item_ondelete.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+
+-- The buffer_item_id FK added in 20260330000001 had no ON DELETE action. Deleting
+-- a buffer cascades to its buffer_items (see 20260330000000), but any item that was
+-- billed has a credit_transactions row referencing it, so the cascade hits a FK
+-- violation (SQLSTATE 23503) and DELETE /buffers/:id 500s for every buffer that ever
+-- executed. credit_transactions is an immutable billing ledger — detach rather than
+-- delete: ON DELETE SET NULL preserves the charge record and still satisfies the
+-- credit_tx_one_ref CHECK (num_nonnulls(job_id, buffer_item_id) <= 1).
+ALTER TABLE credit_transactions
+    DROP CONSTRAINT credit_transactions_buffer_item_id_fkey,
+    ADD CONSTRAINT credit_transactions_buffer_item_id_fkey
+        FOREIGN KEY (buffer_item_id) REFERENCES buffer_items(id) ON DELETE SET NULL;
+
+-- +goose Down
+
+ALTER TABLE credit_transactions
+    DROP CONSTRAINT credit_transactions_buffer_item_id_fkey,
+    ADD CONSTRAINT credit_transactions_buffer_item_id_fkey
+        FOREIGN KEY (buffer_item_id) REFERENCES buffer_items(id);


### PR DESCRIPTION
Found via the prod buffer stress harness while cleaning up test buffers — `DELETE /buffers/:id` returns **500 for every buffer that has ever executed**.

## Root cause

`20260330000001_credit_tx_buffer_item.sql` (the #34 billing fix) added:

```sql
ALTER TABLE credit_transactions ADD COLUMN buffer_item_id TEXT REFERENCES buffer_items(id);
```

— with **no `ON DELETE` action**. Deleting a buffer cascades to its `buffer_items` (`ON DELETE CASCADE`, migration `…0000`), but any item that was billed has a `credit_transactions` row referencing it, so the cascade hits:

```
ERROR: update or delete on table "buffer_items" violates foreign key constraint
"credit_transactions_buffer_item_id_fkey" ... Key (id)=(item2) is still referenced
```

The handler maps that to a 500. Only unexecuted (unbilled) buffers are deletable.

## Fix

New migration `…0003` re-creates the FK with **`ON DELETE SET NULL`**. `credit_transactions` is an immutable billing ledger — deleting a buffer must not erase records of executions the user was charged for. SET NULL drops the dangling item link, keeps the ledger row, and still satisfies the `credit_tx_one_ref` CHECK (`num_nonnulls(job_id, buffer_item_id) <= 1`).

`job_id` has the same missing `ON DELETE`, but jobs are never row-deleted via the API (`jobs.DELETE` is *Cancel*), so that FK is latent — left untouched to keep this scoped.

## Test

Applied all migrations to a throwaway Postgres 17, then:

- **before fix** (old FK): insert buffer + billed item + ledger row → `DELETE buffers` → FK violation (reproduces the prod 500).
- **after fix**: same setup → `DELETE buffers` succeeds; `buffer_items` cascades away; the `credit_transactions` row **survives with `buffer_item_id = NULL`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
