### PR TITLE
add public /health endpoint

### DIFF
--- a/internal/http/handler/health.go
+++ b/internal/http/handler/health.go
@@ -1,0 +1,26 @@
+package handler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Version is the build version, overridable at link time via
+// -ldflags "-X .../handler.Version=<sha>". Defaults to "dev".
+var Version = "dev"
+
+// Health is a public, unauthenticated liveness endpoint. It takes no
+// dependencies (it does not touch Postgres) so it answers even while the
+// scheduler or DB is degraded — it reports that the API process is serving.
+// The public uptime widget and external monitors poll this.
+//
+// GET /health
+func Health(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"status":  "ok",
+		"version": Version,
+		"time":    time.Now().UTC().Format(time.RFC3339),
+	})
+}

--- a/internal/http/handler/health_test.go
+++ b/internal/http/handler/health_test.go
@@ -1,0 +1,42 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/handler"
+	"github.com/gin-gonic/gin"
+)
+
+func TestHealth_OK(t *testing.T) {
+	r := gin.New()
+	r.GET("/health", handler.Health)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var body struct {
+		Status  string `json:"status"`
+		Version string `json:"version"`
+		Time    string `json:"time"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Errorf("expected status ok, got %q", body.Status)
+	}
+	if body.Version == "" {
+		t.Error("expected non-empty version")
+	}
+	if body.Time == "" {
+		t.Error("expected non-empty time")
+	}
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -73,5 +73,10 @@ func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHand
 	// Webhook has no auth middleware — verified by Stripe signature
 	r.POST("/billing/webhook", billingHandler.HandleWebhook)
 
+	// Public, unauthenticated liveness endpoint. Polled by the marketing
+	// site's uptime widget and external monitors. No auth, no rate limit,
+	// no DB — reports that the API process is serving.
+	r.GET("/health", handler.Health)
+
 	return r
 }


### PR DESCRIPTION
## What

Adds a public, unauthenticated `GET /health` endpoint to the API server.

Returns `200 {status:"ok", version, time}`. No auth, no rate limit, no DB — it reports that the API *process* is serving, so it answers even while the scheduler or Postgres is degraded.

## Why

The marketing site is adding a **live uptime tracker** (frontend PR in `fliq-sh/frontend`). The widget pings this endpoint from the browser for real-time status + latency; an external monitor (BetterStack) will watch it for historical uptime. `/healthz` and `/readyz` already exist but live on the internal metrics port, which isn't publicly routed.

## Notes

- Registered as a root route next to the Stripe webhook (also unauth). Global CORS already allows `https://fliq.sh`, so the browser widget can call it cross-origin.
- `version` is overridable at link time via `-ldflags "-X .../handler.Version=<sha>"`, defaults to `dev`.
- ⚠️ `cmd/server` scales to zero — an external monitor pinging `/health` every ~30s keeps one replica warm. Acceptable, but worth knowing for cost.

## Test

`go test ./internal/http/handler/ -run TestHealth` (added `health_test.go`).