### PR TITLE
fence in-flight execution when heartbeat lease is lost

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -67,6 +67,15 @@ var (
 		Help:      "Number of times the worker has shut down.",
 	})
 
+	// LeaseLostTotal counts in-flight jobs aborted because the worker could not
+	// refresh its heartbeat lease (DB partition). A non-zero rate means a worker
+	// was fenced off so the reaper could safely re-run the job elsewhere.
+	LeaseLostTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "scheduler",
+		Name:      "worker_lease_lost_total",
+		Help:      "Number of in-flight executions (jobs or buffer items) aborted after losing the heartbeat lease.",
+	})
+
 	// HTTP metrics
 
 	HTTPRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -150,6 +159,7 @@ func Register() {
 		ReaperCycleDuration,
 		WorkerStartTime,
 		WorkerShutdownsTotal,
+		LeaseLostTotal,
 		HTTPRequestDuration,
 		HTTPRequestsTotal,
 		WebhookDeliveriesTotal,

--- a/internal/scheduler/drainer.go
+++ b/internal/scheduler/drainer.go
@@ -140,9 +140,15 @@ func (d *BufferDrainer) runItem(ctx context.Context, buf *domain.Buffer, item *d
 		return
 	}
 
+	// execCtx is fenced (cancelled with errLeaseLost) if we can no longer prove
+	// we hold this item — see heartbeat(). Critical for buffers: the strict
+	// one-in-flight-per-buffer invariant is only safe if a partitioned drainer
+	// stops executing before the reaper hands the item to another drainer.
+	execCtx, cancelExec := context.WithCancelCause(ctx)
+	defer cancelExec(nil)
 	heartbeatCtx, cancelHeartbeat := context.WithCancel(ctx)
 	defer cancelHeartbeat()
-	go d.heartbeat(heartbeatCtx, item.ID)
+	go d.heartbeat(heartbeatCtx, item.ID, func() { cancelExec(errLeaseLost) })
 
 	var signingSecret string
 	secret, secretErr := d.signingSecrets.GetActive(ctx, item.UserID)
@@ -163,7 +169,15 @@ func (d *BufferDrainer) runItem(ctx context.Context, buf *domain.Buffer, item *d
 		TimeoutSeconds: item.TimeoutSeconds,
 	}
 
-	result := d.executor.Run(ctx, job, signingSecret)
+	result := d.executor.Run(execCtx, job, signingSecret)
+
+	// Lost our lease mid-flight: the reaper now owns this item. Relinquish
+	// without writing any outcome — the reaper recovers it, preserving the
+	// one-in-flight invariant. The open item stays for the reaper to reschedule.
+	if errors.Is(context.Cause(execCtx), errLeaseLost) {
+		d.logger.ErrorContext(ctx, "relinquished buffer item after lease loss; reaper will recover", "item_id", item.ID)
+		return
+	}
 
 	// Deduct credit
 	if deductErr := d.credits.DeductForBufferItem(ctx, item.UserID, item.ID); deductErr != nil {
@@ -231,16 +245,31 @@ func (d *BufferDrainer) runItem(ctx context.Context, buf *domain.Buffer, item *d
 	}
 }
 
-func (d *BufferDrainer) heartbeat(ctx context.Context, itemID string) {
-	ticker := time.NewTicker(10 * time.Second)
+// heartbeat keeps the item's heartbeat_at fresh. If it can't update for
+// heartbeatLeaseTimeout it calls onLeaseLost to fence the in-flight execution
+// before the reaper reschedules the item (see worker.go for the shared
+// constants and the lease/reaper-cutoff relationship).
+func (d *BufferDrainer) heartbeat(ctx context.Context, itemID string, onLeaseLost func()) {
+	ticker := time.NewTicker(heartbeatInterval)
 	defer ticker.Stop()
+	lastSuccess := time.Now()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			if err := d.repo.UpdateItemHeartbeat(ctx, itemID); err != nil {
-				d.logger.WarnContext(ctx, "buffer item heartbeat failed", "item_id", itemID, "error", err)
+				staleFor := time.Since(lastSuccess)
+				d.logger.WarnContext(ctx, "buffer item heartbeat failed", "item_id", itemID, "stale_for", staleFor, "error", err)
+				if staleFor >= heartbeatLeaseTimeout {
+					d.logger.ErrorContext(ctx, "buffer item heartbeat lease lost, fencing in-flight execution",
+						"item_id", itemID, "stale_for", staleFor)
+					metrics.LeaseLostTotal.Inc()
+					onLeaseLost()
+					return
+				}
+			} else {
+				lastSuccess = time.Now()
 			}
 		}
 	}

--- a/internal/scheduler/worker.go
+++ b/internal/scheduler/worker.go
@@ -146,9 +146,14 @@ func (w *Worker) runJob(ctx context.Context, job *domain.Job) {
 		return
 	}
 
+	// execCtx is the context the HTTP call runs under. The heartbeat goroutine
+	// fences it (cancels with errLeaseLost) if we can no longer prove we still
+	// hold this job — see heartbeat().
+	execCtx, cancelExec := context.WithCancelCause(ctx)
+	defer cancelExec(nil)
 	heartbeatCtx, cancelHeartbeat := context.WithCancel(ctx)
 	defer cancelHeartbeat()
-	go w.heartbeat(heartbeatCtx, job.ID)
+	go w.heartbeat(heartbeatCtx, job.ID, func() { cancelExec(errLeaseLost) })
 
 	var signingSecret string
 	secret, err := w.signingSecrets.GetActive(ctx, job.UserID)
@@ -161,8 +166,18 @@ func (w *Worker) runJob(ctx context.Context, job *domain.Job) {
 
 	w.logger.InfoContext(ctx, "executing job", "job_id", job.ID, "method", job.Method, "url", job.URL)
 
-	result := w.executor.Run(ctx, job, signingSecret)
+	result := w.executor.Run(execCtx, job, signingSecret)
 	durationMS := time.Since(startedAt).Milliseconds()
+
+	// If we lost our heartbeat lease mid-flight, the reaper now owns this job and
+	// may already have handed it to another worker. Relinquish silently: writing
+	// any outcome here would race the reaper and could double-increment
+	// retry_count or stomp another worker's result. The open attempt row stays
+	// completed_at=NULL — identical to a crash, and the reaper recovers the job.
+	if errors.Is(context.Cause(execCtx), errLeaseLost) {
+		w.logger.ErrorContext(ctx, "relinquished job after lease loss; reaper will recover", "job_id", job.ID)
+		return
+	}
 
 	// Deduct 1 credit for this execution attempt, regardless of outcome.
 	// Placed here (after HTTP call, before outcome branch) so we always charge
@@ -232,16 +247,45 @@ func (w *Worker) closeAttempt(ctx context.Context, attempt *domain.JobAttempt, s
 	}
 }
 
-func (w *Worker) heartbeat(ctx context.Context, jobID string) {
-	ticker := time.NewTicker(10 * time.Second)
+const (
+	heartbeatInterval = 10 * time.Second
+	// heartbeatLeaseTimeout is how long we keep executing without a successful
+	// heartbeat before fencing ourselves off. It must be < the reaper's stale
+	// cutoff (30s, see cmd/scheduler/main.go) so the current owner relinquishes
+	// the job BEFORE the reaper hands it to another worker — otherwise the target
+	// endpoint can get two concurrent deliveries. It also rides out brief blips
+	// (e.g. a Postgres failover, normally a few seconds) without aborting.
+	heartbeatLeaseTimeout = 20 * time.Second
+)
+
+// errLeaseLost is the cancellation cause when a worker fences its own in-flight
+// execution after failing to refresh the heartbeat lease.
+var errLeaseLost = errors.New("heartbeat lease lost")
+
+// heartbeat keeps heartbeat_at fresh so the reaper doesn't reschedule a job
+// we're still running. If it can't update for heartbeatLeaseTimeout, it calls
+// onLeaseLost to fence the in-flight execution and stops.
+func (w *Worker) heartbeat(ctx context.Context, jobID string, onLeaseLost func()) {
+	ticker := time.NewTicker(heartbeatInterval)
 	defer ticker.Stop()
+	lastSuccess := time.Now()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			if err := w.repo.UpdateHeartbeat(ctx, jobID); err != nil {
-				w.logger.WarnContext(ctx, "heartbeat failed", "job_id", jobID, "error", err)
+				staleFor := time.Since(lastSuccess)
+				w.logger.WarnContext(ctx, "heartbeat failed", "job_id", jobID, "stale_for", staleFor, "error", err)
+				if staleFor >= heartbeatLeaseTimeout {
+					w.logger.ErrorContext(ctx, "heartbeat lease lost, fencing in-flight execution to avoid duplicate delivery",
+						"job_id", jobID, "stale_for", staleFor)
+					metrics.LeaseLostTotal.Inc()
+					onLeaseLost()
+					return
+				}
+			} else {
+				lastSuccess = time.Now()
 			}
 		}
 	}

--- a/internal/scheduler/worker_test.go
+++ b/internal/scheduler/worker_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync/atomic"
 	"testing"
@@ -132,7 +133,7 @@ func TestWorker_Heartbeat_FiresEvery10s(t *testing.T) {
 		}
 
 		ctx, cancel := context.WithCancel(t.Context())
-		go w.heartbeat(ctx, "job-123")
+		go w.heartbeat(ctx, "job-123", func() {})
 
 		// First heartbeat at 10s.
 		time.Sleep(10 * time.Second)
@@ -160,5 +161,70 @@ func TestWorker_Heartbeat_FiresEvery10s(t *testing.T) {
 
 		cancel()
 		synctest.Wait()
+	})
+}
+
+// When the heartbeat can't reach the DB for heartbeatLeaseTimeout, the worker
+// must fence its own in-flight execution (call onLeaseLost) so the reaper can
+// safely re-run the job elsewhere without a duplicate concurrent delivery.
+func TestWorker_Heartbeat_FencesOnLeaseLoss(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var fenced atomic.Bool
+
+		repo := &testutil.MockJobRepository{
+			UpdateHeartbeatFn: func(ctx context.Context, jobID string) error {
+				return errors.New("db unreachable")
+			},
+		}
+
+		w := &Worker{repo: repo, logger: slog.Default()}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go w.heartbeat(ctx, "job-123", func() { fenced.Store(true) })
+
+		// At 10s: first failed beat, stale=10s < 20s lease → not yet fenced.
+		time.Sleep(10 * time.Second)
+		synctest.Wait()
+		if fenced.Load() {
+			t.Fatal("fenced after 10s; want fence only once the 20s lease expires")
+		}
+
+		// At 20s: stale=20s ≥ 20s lease → fenced.
+		time.Sleep(10 * time.Second)
+		synctest.Wait()
+		if !fenced.Load() {
+			t.Fatal("not fenced after 20s of failed heartbeats; want fenced")
+		}
+	})
+}
+
+// A single transient heartbeat failure (e.g. a few seconds of Postgres failover)
+// must NOT fence the execution — the next successful beat resets the lease.
+func TestWorker_Heartbeat_RidesOutTransientBlip(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var fenced atomic.Bool
+		var calls atomic.Int32
+
+		repo := &testutil.MockJobRepository{
+			UpdateHeartbeatFn: func(ctx context.Context, jobID string) error {
+				if calls.Add(1) == 1 {
+					return errors.New("transient blip")
+				}
+				return nil
+			},
+		}
+
+		w := &Worker{repo: repo, logger: slog.Default()}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go w.heartbeat(ctx, "job-123", func() { fenced.Store(true) })
+
+		time.Sleep(45 * time.Second)
+		synctest.Wait()
+		if fenced.Load() {
+			t.Fatal("fenced after a single transient failure; should ride out brief blips")
+		}
 	})
 }


### PR DESCRIPTION
## Why
On a worker↔Postgres partition the heartbeat goroutine stops refreshing `heartbeat_at`, but the in-flight HTTP execution kept running on the parent context. After the reaper's 30s stale cutoff it would re-run the job on another worker → **two concurrent deliveries**. For buffers this also transiently breaks the strict *one-in-flight-per-buffer* ordering invariant.

## What
- Run each execution under a cancelable `execCtx`. If the heartbeat can't be refreshed for **20s** (< the reaper's 30s cutoff), the worker cancels `execCtx` (aborting the HTTP call) and **relinquishes** the job without writing any outcome — the reaper recovers it cleanly. No double-write, no retry_count race.
- Brief blips (e.g. a Postgres failover, normally seconds) are **ridden out** — the lease only expires after a sustained 20s.
- Applied to **both** the job worker and the buffer drainer (shared constants + `errLeaseLost`).
- New `scheduler_worker_lease_lost_total` metric.
- Regression tests via `testing/synctest`.

Defense-in-depth on top of the existing `X-Fliq-Delivery-Id` idempotency header. Groundwork for the HA migration (failovers make heartbeat blips routine).

## Test
`go test ./internal/scheduler/ -race` green; build + vet clean.