### PR TITLE
[Phase C1] deploy: apply frontend-ingress.yaml (dash.fliq.sh routing)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,6 +116,7 @@ jobs:
           kubectl apply -f infra/k8s/server.yaml
           kubectl apply -f infra/k8s/scheduler.yaml
           kubectl apply -f infra/k8s/ingress.yaml
+          kubectl apply -f infra/k8s/frontend-ingress.yaml
           kubectl rollout restart deployment/server -n dist-scheduler
           kubectl rollout restart deployment/scheduler -n dist-scheduler
 


### PR DESCRIPTION
Adds `kubectl apply -f infra/k8s/frontend-ingress.yaml` to the deploy. Pairs with fliq-sh/infra#feat/dash-fliq-routing — merge both, then this deploy routes dash.fliq.sh to the dashboard + applies the CORS change. fliq.sh unchanged. See fliq-sh/landing RUNBOOK.md.