### PR TITLE
[Phase C2] deploy: apply landing-ingress.yaml (fliq.sh cutover)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,6 +117,7 @@ jobs:
           kubectl apply -f infra/k8s/scheduler.yaml
           kubectl apply -f infra/k8s/ingress.yaml
           kubectl apply -f infra/k8s/frontend-ingress.yaml
+          kubectl apply -f infra/k8s/landing-ingress.yaml
           kubectl rollout restart deployment/server -n dist-scheduler
           kubectl rollout restart deployment/scheduler -n dist-scheduler
 


### PR DESCRIPTION
Adds `kubectl apply -f infra/k8s/landing-ingress.yaml` to the deploy. Pairs with **fliq-sh/infra#8** — merge both, then this deploy makes fliq.sh serve the new landing. dash.fliq.sh keeps the dashboard.