### PR TITLE
Failure alerts, usage analytics, and dead-letter replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ No seat fees. No contracts. Pay only for what you execute.
 | API token auth (`fliq_sk_*`) + Clerk JWT | ✅ Done |
 | Per-user job isolation (ownership enforced at query level) | ✅ Done |
 | Credit system — free tier + pay-as-you-go via Stripe | ✅ Done |
+| Failure alerts — notify Slack/webhook channels on retry exhaustion | ✅ Done |
+| Usage & failure analytics — per-account stats + per-buffer breakdown | ✅ Done |
+| Dead-letter replay — re-run a failed job or buffer item | ✅ Done |
 | CI pipeline (lint, tests, migrations against real Postgres) | ✅ Done |
 
 ---

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -49,14 +49,17 @@ func main() {
 	creditRepo := postgres.NewCreditRepository(pool)
 
 	signingRepo := postgres.NewSigningSecretRepository(pool)
+	alertRepo := postgres.NewAlertChannelRepository(pool)
 
 	notifier := scheduler.NewWebhookNotifier(logger, signingRepo)
+	alertNotifier := scheduler.NewAlertNotifier(logger, alertRepo)
 
 	worker := scheduler.NewWorker(
 		jobRepo,
 		attemptRepo,
 		creditRepo,
 		notifier,
+		alertNotifier,
 		logger,
 		time.Duration(cfg.PollIntervalSec)*time.Second,
 		cfg.WorkerCount,
@@ -73,7 +76,7 @@ func main() {
 
 	bufferRepo := postgres.NewBufferRepository(pool)
 	drainer := scheduler.NewBufferDrainer(
-		bufferRepo, creditRepo, signingRepo, notifier, logger,
+		bufferRepo, creditRepo, signingRepo, notifier, alertNotifier, logger,
 		time.Duration(cfg.DrainerPollIntervalSec)*time.Second,
 		cfg.DrainerConcurrency,
 	)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,12 +13,12 @@ import (
 
 	"github.com/ErlanBelekov/dist-job-scheduler/config"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/health"
-	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
-	ctxlog "github.com/ErlanBelekov/dist-job-scheduler/internal/log"
-	"github.com/ErlanBelekov/dist-job-scheduler/internal/metrics"
 	httptransport "github.com/ErlanBelekov/dist-job-scheduler/internal/http"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/handler"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/middleware"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
+	ctxlog "github.com/ErlanBelekov/dist-job-scheduler/internal/log"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/metrics"
 	stripeclient "github.com/ErlanBelekov/dist-job-scheduler/internal/stripe"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
 	"github.com/gin-gonic/gin"
@@ -92,6 +92,16 @@ func main() {
 	bufferUsecase := usecase.NewBufferUsecase(bufferRepo, creditRepo)
 	bufferHandler := handler.NewBufferHandler(bufferUsecase, logger)
 
+	// Alert channels
+	alertRepo := postgres.NewAlertChannelRepository(pool)
+	alertUsecase := usecase.NewAlertUsecase(alertRepo)
+	alertHandler := handler.NewAlertHandler(alertUsecase, logger)
+
+	// Analytics
+	statsRepo := postgres.NewStatsRepository(pool)
+	statsUsecase := usecase.NewStatsUsecase(statsRepo, creditRepo)
+	statsHandler := handler.NewStatsHandler(statsUsecase, logger)
+
 	metrics.Register()
 	checker := health.NewChecker(pool, logger, prometheus.DefaultRegisterer)
 
@@ -100,7 +110,7 @@ func main() {
 
 	srv := http.Server{
 		Addr:    ":" + cfg.Port,
-		Handler: httptransport.NewRouter(logger, jobHandler, scheduleHandler, tokenHandler, billingHandler, signingHandler, bufferHandler, userRepo, creditRepo, tokenRepo, cfg.ClerkJWKSURL, []byte(cfg.JWTSecret), cfg.CORSAllowedOrigins, rateLimiter),
+		Handler: httptransport.NewRouter(logger, jobHandler, scheduleHandler, tokenHandler, billingHandler, signingHandler, bufferHandler, alertHandler, statsHandler, userRepo, creditRepo, tokenRepo, cfg.ClerkJWKSURL, []byte(cfg.JWTSecret), cfg.CORSAllowedOrigins, rateLimiter),
 	}
 
 	metricsSrv := metrics.NewServer(":"+cfg.MetricsPort, checker)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -16,4 +16,5 @@ When changing a design, update the relevant doc in the same PR.
 | [auth.md](auth.md) | JWT (Clerk RS256) + API tokens (fliq_sk_*), user-scoped 404s |
 | [billing.md](billing.md) | Credit model, lazy daily refresh, dual HasCredits gate, audit ledger |
 | [buffer-delivery.md](buffer-delivery.md) | Per-buffer ordering, ordered retries, skip-after-fail, per-second token bucket |
+| [alerts-analytics-replay.md](alerts-analytics-replay.md) | Failure alert channels, usage/failure analytics, dead-letter replay (clone-not-reset) |
 | [observability.md](observability.md) | Structured logging, Prometheus metrics, health checks, request ID |

--- a/docs/design/alerts-analytics-replay.md
+++ b/docs/design/alerts-analytics-replay.md
@@ -1,0 +1,68 @@
+# Failure alerts, analytics & dead-letter replay
+
+Three operator-facing features built on top of the existing execution engine. None
+of them change how jobs or buffer items execute — they surface what already
+happens and let users act on it.
+
+## Failure alerts
+
+A user configures **alert channels** (`/alerts`). Each channel has a `type`
+(`webhook` or `slack`) and a `target` URL. When a job or buffer item exhausts its
+retries — i.e. reaches a *permanent* failure, including the out-of-credits failure
+— the scheduler fans the event out to every **enabled** channel.
+
+- Delivery lives in `internal/scheduler` (`AlertNotifier`), alongside the existing
+  `WebhookNotifier`, because only the scheduler observes terminal failures. It is
+  fire-and-forget and best-effort: errors are logged, never returned, and never
+  block job processing. The notifier is injected into both the `Worker` and the
+  `BufferDrainer`; a nil notifier is a safe no-op so the worker can run without it.
+- `slack` channels receive a `{"text": ...}` message; `webhook` channels receive a
+  structured JSON payload (`resource_type`, `resource_id`, `last_error`,
+  `status_code`, `attempts`, …). Body shaping is a pure function (`buildAlertBody`)
+  so it is unit-tested without the network.
+- Outbound delivery uses the same SSRF-safe dialer as the executor/webhook paths.
+- **`email` is intentionally not implemented yet** — it needs a mail provider and
+  credentials this service does not have. The type enum is open for it later; the
+  API rejects unknown types at the binding layer.
+
+Why fire on *permanent* failure only (not every retry): retries are expected and
+self-healing. An alert means "your endpoint is down and Fliq has given up" — the
+signal a reliability tool exists to provide. Permanent failures are rare relative
+to total executions, so the one indexed `ListEnabled` query per failure is cheap.
+
+## Usage & failure analytics
+
+Read-only aggregates over data the engine already records — no new write paths.
+
+- **`GET /stats/jobs?days=N`** — from `job_attempts` joined to `jobs`: total
+  completed attempts, success/failure counts, success rate, avg & p95 duration. A
+  success is a 2xx with no transport error; everything else is a failure.
+- **`GET /stats/usage?days=N`** — from `credit_transactions`: per-UTC-day execution
+  counts split job vs buffer, plus window totals and the current credit balance
+  (best-effort; a missing balance does not fail the report). This is the
+  "what am I paying for" view.
+- **`GET /buffers/:id/stats`** — per-buffer item status breakdown (pending/running/
+  completed/failed/total) and success rate. Ownership is enforced via the buffer's
+  `GetByID` before the stats query runs.
+
+`days` defaults to 30 and is clamped to `[1, 365]` in the usecase.
+
+## Dead-letter replay
+
+- **`POST /jobs/:id/replay`** and **`POST /buffers/:id/items/:itemId/replay`** —
+  re-run a permanently-**failed** job/item. Anything not in `failed` returns 409.
+
+Replay **clones** rather than resetting the original row in place:
+
+- Job attempt records are keyed `UNIQUE(job_id, attempt_num)`. Re-running the same
+  row with `retry_count` reset would collide on `attempt_num`. A fresh job gets a
+  clean attempt sequence.
+- The original failed row is preserved as history/audit.
+- The clone carries a `replay_of` FK back to the source (`ON DELETE SET NULL`) for
+  lineage, a fresh idempotency key, `status = pending`, and `scheduled_at = now`.
+  A replayed buffer item is appended to the **tail** of the buffer (new
+  `created_at`), so it drains in order after the current queue rather than jumping
+  ahead of in-flight work.
+
+A replay enqueues a new execution, so it passes the same credit gate as a fresh
+create/push (402 when out of credits).

--- a/internal/domain/alert.go
+++ b/internal/domain/alert.go
@@ -1,0 +1,71 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	ErrAlertChannelNotFound    = errors.New("alert channel not found")
+	ErrInvalidAlertChannelType = errors.New("invalid alert channel type")
+)
+
+// AlertChannelType is the delivery mechanism for an alert channel.
+type AlertChannelType string
+
+const (
+	// AlertChannelWebhook POSTs a structured JSON payload to the target URL.
+	AlertChannelWebhook AlertChannelType = "webhook"
+	// AlertChannelSlack POSTs a Slack-incoming-webhook message ({"text": ...})
+	// to the target URL.
+	AlertChannelSlack AlertChannelType = "slack"
+)
+
+// ValidAlertChannelType reports whether t is a supported channel type.
+func ValidAlertChannelType(t AlertChannelType) bool {
+	switch t {
+	case AlertChannelWebhook, AlertChannelSlack:
+		return true
+	default:
+		return false
+	}
+}
+
+// AlertChannel is a user-configured destination notified when one of the user's
+// jobs or buffer items exhausts its retries (permanent failure).
+type AlertChannel struct {
+	ID        string
+	UserID    string
+	Type      AlertChannelType
+	Target    string
+	Name      string
+	Enabled   bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// AlertResourceType identifies what kind of resource failed.
+type AlertResourceType string
+
+const (
+	AlertResourceJob        AlertResourceType = "job"
+	AlertResourceBufferItem AlertResourceType = "buffer_item"
+)
+
+// AlertEvent is the failure that triggers alert delivery. It is assembled by the
+// scheduler at the moment a job or buffer item is marked permanently failed and
+// passed to the alert notifier for fan-out across the user's enabled channels.
+type AlertEvent struct {
+	UserID       string
+	ResourceType AlertResourceType
+	ResourceID   string
+	// BufferID is set only for buffer_item events.
+	BufferID   string
+	URL        string
+	Method     string
+	LastError  string
+	StatusCode *int
+	// Attempts is the total number of execution attempts made before giving up.
+	Attempts int
+	FailedAt time.Time
+}

--- a/internal/domain/buffer.go
+++ b/internal/domain/buffer.go
@@ -6,11 +6,12 @@ import (
 )
 
 var (
-	ErrBufferNotFound      = errors.New("buffer not found")
-	ErrBufferNameConflict  = errors.New("buffer with this name already exists")
-	ErrBufferAlreadyPaused = errors.New("buffer is already paused")
-	ErrBufferNotPaused     = errors.New("buffer is not paused")
-	ErrBufferItemNotFound  = errors.New("buffer item not found")
+	ErrBufferNotFound          = errors.New("buffer not found")
+	ErrBufferNameConflict      = errors.New("buffer with this name already exists")
+	ErrBufferAlreadyPaused     = errors.New("buffer is already paused")
+	ErrBufferNotPaused         = errors.New("buffer is not paused")
+	ErrBufferItemNotFound      = errors.New("buffer item not found")
+	ErrBufferItemNotReplayable = errors.New("buffer item is not in a replayable state")
 )
 
 type BufferItemStatus string
@@ -54,6 +55,10 @@ type BufferItem struct {
 	Status     BufferItemStatus
 	RetryCount int
 	MaxRetries int
+
+	// ReplayOf is the ID of the failed item this one was cloned from via the
+	// item replay endpoint. Nil for ordinary items.
+	ReplayOf *string
 
 	ScheduledAt time.Time
 	ClaimedAt   *time.Time

--- a/internal/domain/job.go
+++ b/internal/domain/job.go
@@ -6,10 +6,11 @@ import (
 )
 
 var (
-	ErrJobNotFound      = errors.New("job not found")
-	ErrDuplicateJob     = errors.New("job with this idempotency key already exists")
-	ErrInvalidStatus    = errors.New("invalid status value")
+	ErrJobNotFound       = errors.New("job not found")
+	ErrDuplicateJob      = errors.New("job with this idempotency key already exists")
+	ErrInvalidStatus     = errors.New("invalid status value")
 	ErrJobNotCancellable = errors.New("job is not in a cancellable state")
+	ErrJobNotReplayable  = errors.New("job is not in a replayable state")
 )
 
 type Status string
@@ -53,6 +54,10 @@ type Job struct {
 	LastError   *string    `json:"lastError"`
 
 	ScheduleID *string `json:"scheduleID,omitempty"`
+
+	// ReplayOf is the ID of the failed job this one was cloned from via the
+	// replay endpoint. Nil for ordinary jobs.
+	ReplayOf *string `json:"replayOf,omitempty"`
 
 	WebhookURL     *string           `json:"webhookURL,omitempty"`
 	WebhookHeaders map[string]string `json:"webhookHeaders,omitempty"`

--- a/internal/domain/stats.go
+++ b/internal/domain/stats.go
@@ -1,0 +1,44 @@
+package domain
+
+// JobStats aggregates job execution outcomes for a user over a time window.
+// Derived from job_attempts (one row per execution attempt).
+type JobStats struct {
+	// TotalExecutions is the number of completed attempts in the window.
+	TotalExecutions int64
+	Succeeded       int64
+	Failed          int64
+	// SuccessRate is Succeeded/TotalExecutions in [0,1], 0 when there are none.
+	SuccessRate   float64
+	AvgDurationMS float64
+	P95DurationMS float64
+	SinceDays     int
+}
+
+// BufferStats summarizes the current item backlog and outcomes for one buffer.
+type BufferStats struct {
+	Pending   int64
+	Running   int64
+	Completed int64
+	Failed    int64
+	Total     int64
+	// SuccessRate is Completed/(Completed+Failed) in [0,1], 0 when there are none.
+	SuccessRate float64
+}
+
+// UsageBucket is one UTC-day of execution counts, split by execution type.
+type UsageBucket struct {
+	Date             string `json:"date"`
+	JobExecutions    int64  `json:"job_executions"`
+	BufferExecutions int64  `json:"buffer_executions"`
+}
+
+// UsageSummary is the account-level usage rollup: a daily time series plus
+// window totals and the current credit position.
+type UsageSummary struct {
+	Buckets               []UsageBucket
+	TotalJobExecutions    int64
+	TotalBufferExecutions int64
+	Balance               int64
+	Plan                  Plan
+	SinceDays             int
+}

--- a/internal/http/handler/alert.go
+++ b/internal/http/handler/alert.go
@@ -1,0 +1,149 @@
+package handler
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
+	"github.com/gin-gonic/gin"
+)
+
+type AlertHandler struct {
+	uc     *usecase.AlertUsecase
+	logger *slog.Logger
+}
+
+func NewAlertHandler(uc *usecase.AlertUsecase, logger *slog.Logger) *AlertHandler {
+	return &AlertHandler{uc: uc, logger: logger.With("component", "alert_handler")}
+}
+
+type createAlertChannelRequest struct {
+	Type   domain.AlertChannelType `json:"type"   binding:"required,oneof=webhook slack"`
+	Target string                  `json:"target" binding:"required,url,max=2048"`
+	Name   string                  `json:"name"   binding:"omitempty,max=256"`
+}
+
+type updateAlertChannelRequest struct {
+	Enabled *bool `json:"enabled" binding:"required"`
+}
+
+type alertChannelResponse struct {
+	ID        string                  `json:"id"`
+	Type      domain.AlertChannelType `json:"type"`
+	Target    string                  `json:"target"`
+	Name      string                  `json:"name"`
+	Enabled   bool                    `json:"enabled"`
+	CreatedAt time.Time               `json:"created_at"`
+	UpdatedAt time.Time               `json:"updated_at"`
+}
+
+func toAlertChannelResponse(ch *domain.AlertChannel) alertChannelResponse {
+	return alertChannelResponse{
+		ID:        ch.ID,
+		Type:      ch.Type,
+		Target:    ch.Target,
+		Name:      ch.Name,
+		Enabled:   ch.Enabled,
+		CreatedAt: ch.CreatedAt,
+		UpdatedAt: ch.UpdatedAt,
+	}
+}
+
+func (h *AlertHandler) Create(ctx *gin.Context) {
+	var req createAlertChannelRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": formatValidationError(err)})
+		return
+	}
+
+	ch, err := h.uc.CreateChannel(ctx.Request.Context(), usecase.CreateAlertChannelInput{
+		UserID: ctx.GetString("userID"),
+		Type:   req.Type,
+		Target: req.Target,
+		Name:   req.Name,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrInvalidAlertChannelType) {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidAlertChannelType})
+			return
+		}
+		h.logger.ErrorContext(ctx.Request.Context(), "create alert channel", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, toAlertChannelResponse(ch))
+}
+
+func (h *AlertHandler) List(ctx *gin.Context) {
+	channels, err := h.uc.ListChannels(ctx.Request.Context(), ctx.GetString("userID"))
+	if err != nil {
+		h.logger.ErrorContext(ctx.Request.Context(), "list alert channels", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	items := make([]alertChannelResponse, len(channels))
+	for i, ch := range channels {
+		items[i] = toAlertChannelResponse(ch)
+	}
+	ctx.JSON(http.StatusOK, gin.H{"channels": items})
+}
+
+func (h *AlertHandler) GetByID(ctx *gin.Context) {
+	id := ctx.Param("id")
+
+	ch, err := h.uc.GetChannel(ctx.Request.Context(), id, ctx.GetString("userID"))
+	if err != nil {
+		if errors.Is(err, domain.ErrAlertChannelNotFound) {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errAlertChannelNotFound})
+			return
+		}
+		h.logger.ErrorContext(ctx.Request.Context(), "get alert channel", "channel_id", id, "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, toAlertChannelResponse(ch))
+}
+
+func (h *AlertHandler) Update(ctx *gin.Context) {
+	id := ctx.Param("id")
+
+	var req updateAlertChannelRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": formatValidationError(err)})
+		return
+	}
+
+	if err := h.uc.SetEnabled(ctx.Request.Context(), id, ctx.GetString("userID"), *req.Enabled); err != nil {
+		if errors.Is(err, domain.ErrAlertChannelNotFound) {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errAlertChannelNotFound})
+			return
+		}
+		h.logger.ErrorContext(ctx.Request.Context(), "update alert channel", "channel_id", id, "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+func (h *AlertHandler) Delete(ctx *gin.Context) {
+	id := ctx.Param("id")
+
+	if err := h.uc.DeleteChannel(ctx.Request.Context(), id, ctx.GetString("userID")); err != nil {
+		if errors.Is(err, domain.ErrAlertChannelNotFound) {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errAlertChannelNotFound})
+			return
+		}
+		h.logger.ErrorContext(ctx.Request.Context(), "delete alert channel", "channel_id", id, "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}

--- a/internal/http/handler/alert_test.go
+++ b/internal/http/handler/alert_test.go
@@ -1,0 +1,182 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/handler"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
+	"github.com/gin-gonic/gin"
+)
+
+func setupAlertRouter(repo *testutil.MockAlertChannelRepository) *gin.Engine {
+	uc := usecase.NewAlertUsecase(repo)
+	h := handler.NewAlertHandler(uc, slog.Default())
+
+	r := gin.New()
+	g := r.Group("/", injectUser(testUserID))
+	g.POST("/alerts", h.Create)
+	g.GET("/alerts", h.List)
+	g.GET("/alerts/:id", h.GetByID)
+	g.PATCH("/alerts/:id", h.Update)
+	g.DELETE("/alerts/:id", h.Delete)
+	return r
+}
+
+func TestCreateAlertChannel_HappyPath(t *testing.T) {
+	repo := &testutil.MockAlertChannelRepository{
+		CreateFn: func(_ context.Context, ch *domain.AlertChannel) (*domain.AlertChannel, error) {
+			ch.ID = "alert-xyz"
+			return ch, nil
+		},
+	}
+	r := setupAlertRouter(repo)
+
+	body := `{"type":"webhook","target":"https://example.com/hook","name":"ops"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/alerts", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["id"] != "alert-xyz" {
+		t.Errorf("id = %v, want alert-xyz", resp["id"])
+	}
+	if resp["enabled"] != true {
+		t.Errorf("enabled = %v, want true", resp["enabled"])
+	}
+}
+
+func TestCreateAlertChannel_InvalidTypeRejectedByBinding(t *testing.T) {
+	r := setupAlertRouter(&testutil.MockAlertChannelRepository{})
+
+	body := `{"type":"email","target":"ops@example.com"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/alerts", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestCreateAlertChannel_NonURLTarget(t *testing.T) {
+	r := setupAlertRouter(&testutil.MockAlertChannelRepository{})
+
+	body := `{"type":"slack","target":"not-a-url"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/alerts", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestGetAlertChannel_NotFound(t *testing.T) {
+	repo := &testutil.MockAlertChannelRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.AlertChannel, error) {
+			return nil, domain.ErrAlertChannelNotFound
+		},
+	}
+	r := setupAlertRouter(repo)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/alerts/missing", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestUpdateAlertChannel_TogglesEnabled(t *testing.T) {
+	var gotEnabled bool
+	var called bool
+	repo := &testutil.MockAlertChannelRepository{
+		SetEnabledFn: func(_ context.Context, _, _ string, enabled bool) error {
+			called = true
+			gotEnabled = enabled
+			return nil
+		},
+	}
+	r := setupAlertRouter(repo)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/alerts/alert-1", strings.NewReader(`{"enabled":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusNoContent, w.Body.String())
+	}
+	if !called || gotEnabled != false {
+		t.Errorf("SetEnabled called=%v enabled=%v, want true/false", called, gotEnabled)
+	}
+}
+
+func TestUpdateAlertChannel_MissingEnabledField(t *testing.T) {
+	r := setupAlertRouter(&testutil.MockAlertChannelRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/alerts/alert-1", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestDeleteAlertChannel_NotFound(t *testing.T) {
+	repo := &testutil.MockAlertChannelRepository{
+		DeleteFn: func(_ context.Context, _, _ string) error { return domain.ErrAlertChannelNotFound },
+	}
+	r := setupAlertRouter(repo)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/alerts/missing", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestListAlertChannels_HappyPath(t *testing.T) {
+	repo := &testutil.MockAlertChannelRepository{
+		ListFn: func(_ context.Context, _ string) ([]*domain.AlertChannel, error) {
+			return []*domain.AlertChannel{
+				{ID: "a", Type: domain.AlertChannelSlack, Target: "https://x", Enabled: true},
+				{ID: "b", Type: domain.AlertChannelWebhook, Target: "https://y", Enabled: false},
+			}, nil
+		},
+	}
+	r := setupAlertRouter(repo)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/alerts", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp map[string][]map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp["channels"]) != 2 {
+		t.Errorf("len(channels) = %d, want 2", len(resp["channels"]))
+	}
+}

--- a/internal/http/handler/buffer.go
+++ b/internal/http/handler/buffer.go
@@ -73,15 +73,16 @@ type pushItemRequest struct {
 }
 
 type bufferItemResponse struct {
-	ID          string                `json:"id"`
-	BufferID    string                `json:"buffer_id"`
+	ID          string                  `json:"id"`
+	BufferID    string                  `json:"buffer_id"`
 	Status      domain.BufferItemStatus `json:"status"`
-	StatusCode  *int                  `json:"status_code,omitempty"`
-	RetryCount  int                   `json:"retry_count"`
-	MaxRetries  int                   `json:"max_retries"`
-	LastError   *string               `json:"last_error,omitempty"`
-	CreatedAt   time.Time             `json:"created_at"`
-	CompletedAt *time.Time            `json:"completed_at,omitempty"`
+	StatusCode  *int                    `json:"status_code,omitempty"`
+	RetryCount  int                     `json:"retry_count"`
+	MaxRetries  int                     `json:"max_retries"`
+	LastError   *string                 `json:"last_error,omitempty"`
+	ReplayOf    *string                 `json:"replay_of,omitempty"`
+	CreatedAt   time.Time               `json:"created_at"`
+	CompletedAt *time.Time              `json:"completed_at,omitempty"`
 }
 
 func toBufferItemResponse(item *domain.BufferItem) bufferItemResponse {
@@ -93,6 +94,7 @@ func toBufferItemResponse(item *domain.BufferItem) bufferItemResponse {
 		RetryCount:  item.RetryCount,
 		MaxRetries:  item.MaxRetries,
 		LastError:   item.LastError,
+		ReplayOf:    item.ReplayOf,
 		CreatedAt:   item.CreatedAt,
 		CompletedAt: item.CompletedAt,
 	}
@@ -182,6 +184,39 @@ func (h *BufferHandler) GetByID(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, toBufferResponse(b))
+}
+
+type bufferStatsResponse struct {
+	Pending     int64   `json:"pending"`
+	Running     int64   `json:"running"`
+	Completed   int64   `json:"completed"`
+	Failed      int64   `json:"failed"`
+	Total       int64   `json:"total"`
+	SuccessRate float64 `json:"success_rate"`
+}
+
+func (h *BufferHandler) Stats(ctx *gin.Context) {
+	id := ctx.Param("id")
+
+	s, err := h.uc.GetBufferStats(ctx.Request.Context(), id, ctx.GetString("userID"))
+	if err != nil {
+		if errors.Is(err, domain.ErrBufferNotFound) {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errBufferNotFound})
+			return
+		}
+		h.logger.ErrorContext(ctx.Request.Context(), "buffer stats", "buffer_id", id, "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, bufferStatsResponse{
+		Pending:     s.Pending,
+		Running:     s.Running,
+		Completed:   s.Completed,
+		Failed:      s.Failed,
+		Total:       s.Total,
+		SuccessRate: s.SuccessRate,
+	})
 }
 
 func (h *BufferHandler) Pause(ctx *gin.Context) {
@@ -309,6 +344,33 @@ func (h *BufferHandler) ListItems(ctx *gin.Context) {
 		"items":       items,
 		"next_cursor": result.NextCursor,
 	})
+}
+
+// ReplayItem clones a permanently-failed buffer item into a fresh pending item
+// appended to the tail of the buffer.
+func (h *BufferHandler) ReplayItem(ctx *gin.Context) {
+	bufferID := ctx.Param("id")
+	itemID := ctx.Param("itemId")
+
+	item, err := h.uc.ReplayItem(ctx.Request.Context(), itemID, bufferID, ctx.GetString("userID"))
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrBufferNotFound):
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errBufferNotFound})
+		case errors.Is(err, domain.ErrBufferItemNotFound):
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errBufferItemNotFound})
+		case errors.Is(err, domain.ErrBufferItemNotReplayable):
+			ctx.JSON(http.StatusConflict, gin.H{"error": errBufferItemNotReplayable})
+		case errors.Is(err, domain.ErrInsufficientCredits):
+			ctx.JSON(http.StatusPaymentRequired, gin.H{"error": errInsufficientCredits})
+		default:
+			h.logger.ErrorContext(ctx.Request.Context(), "replay buffer item", "buffer_id", bufferID, "item_id", itemID, "error", err)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		}
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, toBufferItemResponse(item))
 }
 
 func (h *BufferHandler) GetItem(ctx *gin.Context) {

--- a/internal/http/handler/buffer_test.go
+++ b/internal/http/handler/buffer_test.go
@@ -1,0 +1,143 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/handler"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
+	"github.com/gin-gonic/gin"
+)
+
+func setupBufferRouter(bufRepo *testutil.MockBufferRepository, creditRepo *testutil.MockCreditRepository) *gin.Engine {
+	uc := usecase.NewBufferUsecase(bufRepo, creditRepo)
+	h := handler.NewBufferHandler(uc, slog.Default())
+
+	r := gin.New()
+	g := r.Group("/", injectUser(testUserID))
+	g.GET("/buffers/:id/stats", h.Stats)
+	g.POST("/buffers/:id/items/:itemId/replay", h.ReplayItem)
+	return r
+}
+
+func ownedBuffer(_ context.Context, id, uid string) (*domain.Buffer, error) {
+	if uid == testUserID {
+		return &domain.Buffer{ID: id, UserID: uid}, nil
+	}
+	return nil, domain.ErrBufferNotFound
+}
+
+func TestBufferStats_HappyPath(t *testing.T) {
+	bufRepo := &testutil.MockBufferRepository{
+		GetByIDFn: ownedBuffer,
+		BufferStatsFn: func(_ context.Context, _ string) (domain.BufferStats, error) {
+			return domain.BufferStats{Pending: 2, Running: 1, Completed: 9, Failed: 1, Total: 13, SuccessRate: 0.9}, nil
+		},
+	}
+	r := setupBufferRouter(bufRepo, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/buffers/buf-1/stats", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["total"].(float64) != 13 {
+		t.Errorf("total = %v, want 13", resp["total"])
+	}
+	if resp["failed"].(float64) != 1 {
+		t.Errorf("failed = %v, want 1", resp["failed"])
+	}
+}
+
+func TestBufferStats_NotFound(t *testing.T) {
+	bufRepo := &testutil.MockBufferRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.Buffer, error) {
+			return nil, domain.ErrBufferNotFound
+		},
+	}
+	r := setupBufferRouter(bufRepo, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/buffers/missing/stats", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestReplayBufferItem_HappyPath(t *testing.T) {
+	failed := &domain.BufferItem{ID: "item-1", BufferID: "buf-1", UserID: testUserID, URL: "https://x", Method: "POST", Status: domain.BufferItemFailed}
+	bufRepo := &testutil.MockBufferRepository{
+		GetByIDFn:     ownedBuffer,
+		GetItemByIDFn: func(_ context.Context, _, _ string) (*domain.BufferItem, error) { return failed, nil },
+		CreateItemFn: func(_ context.Context, it *domain.BufferItem) (*domain.BufferItem, error) {
+			it.ID = "item-replay"
+			return it, nil
+		},
+	}
+	r := setupBufferRouter(bufRepo, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/buffers/buf-1/items/item-1/replay", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["id"] != "item-replay" {
+		t.Errorf("id = %v, want item-replay", resp["id"])
+	}
+	if resp["replay_of"] != "item-1" {
+		t.Errorf("replay_of = %v, want item-1", resp["replay_of"])
+	}
+}
+
+func TestReplayBufferItem_NotReplayable(t *testing.T) {
+	item := &domain.BufferItem{ID: "item-1", BufferID: "buf-1", UserID: testUserID, Status: domain.BufferItemCompleted}
+	bufRepo := &testutil.MockBufferRepository{
+		GetByIDFn:     ownedBuffer,
+		GetItemByIDFn: func(_ context.Context, _, _ string) (*domain.BufferItem, error) { return item, nil },
+	}
+	r := setupBufferRouter(bufRepo, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/buffers/buf-1/items/item-1/replay", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+	}
+}
+
+func TestReplayBufferItem_InsufficientCredits(t *testing.T) {
+	failed := &domain.BufferItem{ID: "item-1", BufferID: "buf-1", UserID: testUserID, Status: domain.BufferItemFailed}
+	bufRepo := &testutil.MockBufferRepository{
+		GetByIDFn:     ownedBuffer,
+		GetItemByIDFn: func(_ context.Context, _, _ string) (*domain.BufferItem, error) { return failed, nil },
+	}
+	credits := &testutil.MockCreditRepository{
+		HasCreditsFn: func(_ context.Context, _ string) (bool, error) { return false, nil },
+	}
+	r := setupBufferRouter(bufRepo, credits)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/buffers/buf-1/items/item-1/replay", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusPaymentRequired)
+	}
+}

--- a/internal/http/handler/errors.go
+++ b/internal/http/handler/errors.go
@@ -1,12 +1,13 @@
 package handler
 
 const (
-	errInternalServer = "Internal server error"
-	errJobNotFound    = "Job not found"
-	errDuplicateJob   = "Job with this idempotency key already exists"
-	errTokenInvalid   = "Token is invalid or expired"
+	errInternalServer    = "Internal server error"
+	errJobNotFound       = "Job not found"
+	errDuplicateJob      = "Job with this idempotency key already exists"
+	errTokenInvalid      = "Token is invalid or expired"
 	errInvalidStatus     = "Invalid status value"
 	errJobNotCancellable = "Job cannot be cancelled in its current state"
+	errJobNotReplayable  = "Only failed jobs can be replayed"
 
 	errScheduleNotFound      = "Schedule not found"
 	errInvalidCronExpr       = "Invalid cron expression"
@@ -20,11 +21,17 @@ const (
 
 	errSigningSecretNotFound = "No signing secret found to rotate"
 
-	errBufferNotFound      = "Buffer not found"
-	errBufferNameConflict  = "Buffer with this name already exists"
-	errBufferAlreadyPaused = "Buffer is already paused"
-	errBufferNotPaused     = "Buffer is not paused"
-	errBufferItemNotFound  = "Buffer item not found"
+	errBufferNotFound          = "Buffer not found"
+	errBufferNameConflict      = "Buffer with this name already exists"
+	errBufferAlreadyPaused     = "Buffer is already paused"
+	errBufferNotPaused         = "Buffer is not paused"
+	errBufferItemNotFound      = "Buffer item not found"
+	errBufferItemNotReplayable = "Only failed buffer items can be replayed"
 
 	errInvalidLimit = "limit must be between 1 and 100"
+
+	errAlertChannelNotFound    = "Alert channel not found"
+	errInvalidAlertChannelType = "Invalid alert channel type"
+
+	errInvalidDays = "days must be a non-negative integer"
 )

--- a/internal/http/handler/job.go
+++ b/internal/http/handler/job.go
@@ -101,6 +101,43 @@ func (h *JobHandler) Cancel(ctx *gin.Context) {
 	ctx.Status(http.StatusNoContent)
 }
 
+type replayJobResponse struct {
+	ID          string        `json:"id"`
+	Status      domain.Status `json:"status"`
+	ReplayOf    *string       `json:"replay_of,omitempty"`
+	ScheduledAt time.Time     `json:"scheduled_at"`
+	CreatedAt   time.Time     `json:"created_at"`
+}
+
+// Replay clones a permanently-failed job into a fresh pending job.
+func (h *JobHandler) Replay(ctx *gin.Context) {
+	jobID := ctx.Param("id")
+
+	job, err := h.jobUsecase.Replay(ctx.Request.Context(), jobID, ctx.GetString("userID"))
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrJobNotFound):
+			ctx.JSON(http.StatusNotFound, gin.H{"error": errJobNotFound})
+		case errors.Is(err, domain.ErrJobNotReplayable):
+			ctx.JSON(http.StatusConflict, gin.H{"error": errJobNotReplayable})
+		case errors.Is(err, domain.ErrInsufficientCredits):
+			ctx.JSON(http.StatusPaymentRequired, gin.H{"error": errInsufficientCredits})
+		default:
+			h.logger.ErrorContext(ctx.Request.Context(), "replay job", "job_id", jobID, "error", err)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		}
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, replayJobResponse{
+		ID:          job.ID,
+		Status:      job.Status,
+		ReplayOf:    job.ReplayOf,
+		ScheduledAt: job.ScheduledAt,
+		CreatedAt:   job.CreatedAt,
+	})
+}
+
 func (h *JobHandler) List(ctx *gin.Context) {
 	limit, err := parseLimit(ctx.Query("limit"))
 	if err != nil {

--- a/internal/http/handler/job_replay_test.go
+++ b/internal/http/handler/job_replay_test.go
@@ -1,0 +1,107 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/handler"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
+	"github.com/gin-gonic/gin"
+)
+
+func setupReplayRouter(jobRepo *testutil.MockJobRepository, creditRepo *testutil.MockCreditRepository) *gin.Engine {
+	uc := usecase.NewJobUsecase(jobRepo, &testutil.MockAttemptRepository{}, creditRepo)
+	h := handler.NewJobHandler(uc, slog.Default())
+
+	r := gin.New()
+	g := r.Group("/", injectUser(testUserID))
+	g.POST("/jobs/:id/replay", h.Replay)
+	return r
+}
+
+func TestReplayJobHandler_HappyPath(t *testing.T) {
+	failed := testutil.NewJob(testutil.WithUserID(testUserID), testutil.WithJobID("job-failed"), testutil.WithStatus(domain.StatusFailed))
+	jobRepo := &testutil.MockJobRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.Job, error) { return failed, nil },
+		CreateFn: func(_ context.Context, j *domain.Job) (*domain.Job, error) {
+			j.ID = "job-replay"
+			return j, nil
+		},
+	}
+	r := setupReplayRouter(jobRepo, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/jobs/job-failed/replay", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["id"] != "job-replay" {
+		t.Errorf("id = %v, want job-replay", resp["id"])
+	}
+	if resp["replay_of"] != "job-failed" {
+		t.Errorf("replay_of = %v, want job-failed", resp["replay_of"])
+	}
+	if resp["status"] != string(domain.StatusPending) {
+		t.Errorf("status = %v, want pending", resp["status"])
+	}
+}
+
+func TestReplayJobHandler_NotReplayable(t *testing.T) {
+	running := testutil.NewJob(testutil.WithUserID(testUserID), testutil.WithStatus(domain.StatusRunning))
+	jobRepo := &testutil.MockJobRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.Job, error) { return running, nil },
+	}
+	r := setupReplayRouter(jobRepo, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/jobs/job-1/replay", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+	}
+}
+
+func TestReplayJobHandler_NotFound(t *testing.T) {
+	jobRepo := &testutil.MockJobRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.Job, error) { return nil, domain.ErrJobNotFound },
+	}
+	r := setupReplayRouter(jobRepo, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/jobs/missing/replay", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestReplayJobHandler_InsufficientCredits(t *testing.T) {
+	failed := testutil.NewJob(testutil.WithUserID(testUserID), testutil.WithStatus(domain.StatusFailed))
+	jobRepo := &testutil.MockJobRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.Job, error) { return failed, nil },
+	}
+	credits := &testutil.MockCreditRepository{
+		HasCreditsFn: func(_ context.Context, _ string) (bool, error) { return false, nil },
+	}
+	r := setupReplayRouter(jobRepo, credits)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/jobs/job-1/replay", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusPaymentRequired)
+	}
+}

--- a/internal/http/handler/stats.go
+++ b/internal/http/handler/stats.go
@@ -1,0 +1,105 @@
+package handler
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
+	"github.com/gin-gonic/gin"
+)
+
+type StatsHandler struct {
+	uc     *usecase.StatsUsecase
+	logger *slog.Logger
+}
+
+func NewStatsHandler(uc *usecase.StatsUsecase, logger *slog.Logger) *StatsHandler {
+	return &StatsHandler{uc: uc, logger: logger.With("component", "stats_handler")}
+}
+
+// parseDays reads the ?days query param. Empty or invalid yields 0, which the
+// usecase treats as "use the default window".
+func parseDays(raw string) (int, bool) {
+	if raw == "" {
+		return 0, true
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+type jobStatsResponse struct {
+	TotalExecutions int64   `json:"total_executions"`
+	Succeeded       int64   `json:"succeeded"`
+	Failed          int64   `json:"failed"`
+	SuccessRate     float64 `json:"success_rate"`
+	AvgDurationMS   float64 `json:"avg_duration_ms"`
+	P95DurationMS   float64 `json:"p95_duration_ms"`
+	SinceDays       int     `json:"since_days"`
+}
+
+func (h *StatsHandler) Jobs(ctx *gin.Context) {
+	days, ok := parseDays(ctx.Query("days"))
+	if !ok {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidDays})
+		return
+	}
+
+	s, err := h.uc.GetJobStats(ctx.Request.Context(), ctx.GetString("userID"), days)
+	if err != nil {
+		h.logger.ErrorContext(ctx.Request.Context(), "job stats", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, jobStatsResponse{
+		TotalExecutions: s.TotalExecutions,
+		Succeeded:       s.Succeeded,
+		Failed:          s.Failed,
+		SuccessRate:     s.SuccessRate,
+		AvgDurationMS:   s.AvgDurationMS,
+		P95DurationMS:   s.P95DurationMS,
+		SinceDays:       s.SinceDays,
+	})
+}
+
+type usageResponse struct {
+	Buckets               []domain.UsageBucket `json:"buckets"`
+	TotalJobExecutions    int64                `json:"total_job_executions"`
+	TotalBufferExecutions int64                `json:"total_buffer_executions"`
+	Balance               int64                `json:"balance"`
+	Plan                  domain.Plan          `json:"plan"`
+	SinceDays             int                  `json:"since_days"`
+}
+
+func (h *StatsHandler) Usage(ctx *gin.Context) {
+	days, ok := parseDays(ctx.Query("days"))
+	if !ok {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidDays})
+		return
+	}
+
+	summary, err := h.uc.GetUsage(ctx.Request.Context(), ctx.GetString("userID"), days)
+	if err != nil {
+		h.logger.ErrorContext(ctx.Request.Context(), "usage", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	buckets := summary.Buckets
+	if buckets == nil {
+		buckets = []domain.UsageBucket{}
+	}
+	ctx.JSON(http.StatusOK, usageResponse{
+		Buckets:               buckets,
+		TotalJobExecutions:    summary.TotalJobExecutions,
+		TotalBufferExecutions: summary.TotalBufferExecutions,
+		Balance:               summary.Balance,
+		Plan:                  summary.Plan,
+		SinceDays:             summary.SinceDays,
+	})
+}

--- a/internal/http/handler/stats_test.go
+++ b/internal/http/handler/stats_test.go
@@ -1,0 +1,120 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/handler"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
+	"github.com/gin-gonic/gin"
+)
+
+func setupStatsRouter(statsRepo *testutil.MockStatsRepository, creditRepo *testutil.MockCreditRepository) *gin.Engine {
+	uc := usecase.NewStatsUsecase(statsRepo, creditRepo)
+	h := handler.NewStatsHandler(uc, slog.Default())
+
+	r := gin.New()
+	g := r.Group("/", injectUser(testUserID))
+	g.GET("/stats/jobs", h.Jobs)
+	g.GET("/stats/usage", h.Usage)
+	return r
+}
+
+func TestStatsJobs_HappyPath(t *testing.T) {
+	statsRepo := &testutil.MockStatsRepository{
+		JobStatsFn: func(_ context.Context, _ string, _ time.Time) (domain.JobStats, error) {
+			return domain.JobStats{
+				TotalExecutions: 20, Succeeded: 18, Failed: 2,
+				SuccessRate: 0.9, AvgDurationMS: 120.5, P95DurationMS: 300,
+			}, nil
+		},
+	}
+	r := setupStatsRouter(statsRepo, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/stats/jobs?days=14", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["total_executions"].(float64) != 20 {
+		t.Errorf("total_executions = %v, want 20", resp["total_executions"])
+	}
+	if resp["success_rate"].(float64) != 0.9 {
+		t.Errorf("success_rate = %v, want 0.9", resp["success_rate"])
+	}
+	if resp["since_days"].(float64) != 14 {
+		t.Errorf("since_days = %v, want 14", resp["since_days"])
+	}
+}
+
+func TestStatsJobs_InvalidDays(t *testing.T) {
+	r := setupStatsRouter(&testutil.MockStatsRepository{}, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/stats/jobs?days=abc", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestStatsUsage_HappyPath(t *testing.T) {
+	statsRepo := &testutil.MockStatsRepository{
+		UsageSeriesFn: func(_ context.Context, _ string, _ time.Time) ([]domain.UsageBucket, error) {
+			return []domain.UsageBucket{
+				{Date: "2026-06-11", JobExecutions: 4, BufferExecutions: 6},
+			}, nil
+		},
+	}
+	r := setupStatsRouter(statsRepo, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/stats/usage", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["total_job_executions"].(float64) != 4 {
+		t.Errorf("total_job_executions = %v, want 4", resp["total_job_executions"])
+	}
+	if resp["total_buffer_executions"].(float64) != 6 {
+		t.Errorf("total_buffer_executions = %v, want 6", resp["total_buffer_executions"])
+	}
+	buckets, ok := resp["buckets"].([]interface{})
+	if !ok || len(buckets) != 1 {
+		t.Errorf("buckets = %v, want 1 entry", resp["buckets"])
+	}
+}
+
+func TestStatsUsage_EmptyReturnsArrayNotNull(t *testing.T) {
+	r := setupStatsRouter(&testutil.MockStatsRepository{}, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/stats/usage", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	// buckets must serialize as [] not null, so clients can iterate safely.
+	var resp map[string]json.RawMessage
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if string(resp["buckets"]) != "[]" {
+		t.Errorf("buckets = %s, want []", resp["buckets"])
+	}
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -11,7 +11,7 @@ import (
 	sloggin "github.com/samber/slog-gin"
 )
 
-func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHandler *handler.ScheduleHandler, tokenHandler *handler.TokenHandler, billingHandler *handler.BillingHandler, signingHandler *handler.SigningHandler, bufferHandler *handler.BufferHandler, userRepo repository.UserRepository, creditRepo repository.CreditRepository, tokenRepo repository.APITokenRepository, jwksURL string, hmacKey []byte, corsAllowedOrigins string, rateLimiter *middleware.RateLimiter) *gin.Engine {
+func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHandler *handler.ScheduleHandler, tokenHandler *handler.TokenHandler, billingHandler *handler.BillingHandler, signingHandler *handler.SigningHandler, bufferHandler *handler.BufferHandler, alertHandler *handler.AlertHandler, statsHandler *handler.StatsHandler, userRepo repository.UserRepository, creditRepo repository.CreditRepository, tokenRepo repository.APITokenRepository, jwksURL string, hmacKey []byte, corsAllowedOrigins string, rateLimiter *middleware.RateLimiter) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
 	r.Use(middleware.RequestID())
@@ -29,6 +29,7 @@ func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHand
 	jobs.POST("", jobHandler.Create)
 	jobs.GET("/:id", jobHandler.GetByID)
 	jobs.DELETE("/:id", jobHandler.Cancel)
+	jobs.POST("/:id/replay", jobHandler.Replay)
 	jobs.GET("/:id/attempts", jobHandler.ListAttempts)
 
 	// Protected schedule routes
@@ -46,12 +47,27 @@ func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHand
 	buffers.POST("", bufferHandler.Create)
 	buffers.GET("", bufferHandler.List)
 	buffers.GET("/:id", bufferHandler.GetByID)
+	buffers.GET("/:id/stats", bufferHandler.Stats)
 	buffers.POST("/:id/pause", bufferHandler.Pause)
 	buffers.POST("/:id/resume", bufferHandler.Resume)
 	buffers.DELETE("/:id", bufferHandler.Delete)
 	buffers.POST("/:id/items", bufferHandler.PushItem)
 	buffers.GET("/:id/items", bufferHandler.ListItems)
 	buffers.GET("/:id/items/:itemId", bufferHandler.GetItem)
+	buffers.POST("/:id/items/:itemId/replay", bufferHandler.ReplayItem)
+
+	// Protected alert channel routes
+	alerts := r.Group("/alerts", authMW, ensureUser, rateLimiter.Middleware())
+	alerts.POST("", alertHandler.Create)
+	alerts.GET("", alertHandler.List)
+	alerts.GET("/:id", alertHandler.GetByID)
+	alerts.PATCH("/:id", alertHandler.Update)
+	alerts.DELETE("/:id", alertHandler.Delete)
+
+	// Protected analytics routes
+	stats := r.Group("/stats", authMW, ensureUser, rateLimiter.Middleware())
+	stats.GET("/usage", statsHandler.Usage)
+	stats.GET("/jobs", statsHandler.Jobs)
 
 	// Protected token routes
 	tokens := r.Group("/tokens", authMW, ensureUser, rateLimiter.Middleware())

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -1,0 +1,76 @@
+package httptransport_test
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	httptransport "github.com/ErlanBelekov/dist-job-scheduler/internal/http"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+// buildRouter constructs the full production route table. Handlers are nil:
+// forming a method value from a nil pointer receiver is legal in Go, and route
+// registration never calls them — so this exercises the real routing tree
+// (including conflict detection, which panics at registration) without a DB.
+func buildRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	rl := middleware.NewRateLimiter(50, 100)
+	t.Cleanup(rl.Stop)
+	return httptransport.NewRouter(
+		slog.Default(),
+		nil, nil, nil, nil, nil, nil, nil, nil, // handlers
+		nil, nil, nil, // userRepo, creditRepo, tokenRepo
+		"", []byte("test-key"), "", rl,
+	)
+}
+
+// TestRouter_RegistersWithoutConflict fails if any route (including the new
+// replay/alerts/stats routes) collides — Gin panics on conflicting paths.
+func TestRouter_RegistersWithoutConflict(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("router registration panicked (route conflict?): %v", r)
+		}
+	}()
+	_ = buildRouter(t)
+}
+
+func TestRouter_HealthIsPublic(t *testing.T) {
+	r := buildRouter(t)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /health = %d, want 200", w.Code)
+	}
+}
+
+// The new protected routes must sit behind auth — no token yields 401, proving
+// they were registered with the auth middleware (not left open).
+func TestRouter_NewRoutesRequireAuth(t *testing.T) {
+	r := buildRouter(t)
+	cases := []struct {
+		method, path string
+	}{
+		{http.MethodPost, "/jobs/abc/replay"},
+		{http.MethodPost, "/buffers/abc/items/xyz/replay"},
+		{http.MethodGet, "/buffers/abc/stats"},
+		{http.MethodGet, "/stats/jobs"},
+		{http.MethodGet, "/stats/usage"},
+		{http.MethodPost, "/alerts"},
+		{http.MethodGet, "/alerts"},
+		{http.MethodPatch, "/alerts/abc"},
+		{http.MethodDelete, "/alerts/abc"},
+	}
+	for _, c := range cases {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(c.method, c.path, nil))
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s %s = %d, want 401 (unauthenticated)", c.method, c.path, w.Code)
+		}
+	}
+}

--- a/internal/infrastructure/postgres/alert_repo.go
+++ b/internal/infrastructure/postgres/alert_repo.go
@@ -1,0 +1,115 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type AlertChannelRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewAlertChannelRepository(pool *pgxpool.Pool) *AlertChannelRepository {
+	return &AlertChannelRepository{pool: pool}
+}
+
+func (r *AlertChannelRepository) Create(ctx context.Context, ch *domain.AlertChannel) (*domain.AlertChannel, error) {
+	query := `
+		INSERT INTO alert_channels (user_id, type, target, name, enabled)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id, user_id, type, target, name, enabled, created_at, updated_at`
+
+	row := r.pool.QueryRow(ctx, query, ch.UserID, ch.Type, ch.Target, ch.Name, ch.Enabled)
+	return scanAlertChannel(row)
+}
+
+func (r *AlertChannelRepository) GetByID(ctx context.Context, id, userID string) (*domain.AlertChannel, error) {
+	query := `
+		SELECT id, user_id, type, target, name, enabled, created_at, updated_at
+		FROM alert_channels
+		WHERE id = $1 AND user_id = $2`
+
+	row := r.pool.QueryRow(ctx, query, id, userID)
+	return scanAlertChannel(row)
+}
+
+func (r *AlertChannelRepository) List(ctx context.Context, userID string) ([]*domain.AlertChannel, error) {
+	return r.list(ctx, `
+		SELECT id, user_id, type, target, name, enabled, created_at, updated_at
+		FROM alert_channels
+		WHERE user_id = $1
+		ORDER BY created_at DESC, id DESC`, userID)
+}
+
+func (r *AlertChannelRepository) ListEnabled(ctx context.Context, userID string) ([]*domain.AlertChannel, error) {
+	return r.list(ctx, `
+		SELECT id, user_id, type, target, name, enabled, created_at, updated_at
+		FROM alert_channels
+		WHERE user_id = $1 AND enabled
+		ORDER BY created_at DESC, id DESC`, userID)
+}
+
+func (r *AlertChannelRepository) list(ctx context.Context, query, userID string) ([]*domain.AlertChannel, error) {
+	rows, err := r.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list alert channels: %w", err)
+	}
+	defer rows.Close()
+
+	var channels []*domain.AlertChannel
+	for rows.Next() {
+		ch, scanErr := scanAlertChannel(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		channels = append(channels, ch)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate alert channels: %w", err)
+	}
+	return channels, nil
+}
+
+func (r *AlertChannelRepository) SetEnabled(ctx context.Context, id, userID string, enabled bool) error {
+	tag, err := r.pool.Exec(ctx,
+		`UPDATE alert_channels SET enabled = $3, updated_at = NOW()
+		 WHERE id = $1 AND user_id = $2`,
+		id, userID, enabled)
+	if err != nil {
+		return fmt.Errorf("set alert channel enabled: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.ErrAlertChannelNotFound
+	}
+	return nil
+}
+
+func (r *AlertChannelRepository) Delete(ctx context.Context, id, userID string) error {
+	tag, err := r.pool.Exec(ctx,
+		`DELETE FROM alert_channels WHERE id = $1 AND user_id = $2`,
+		id, userID)
+	if err != nil {
+		return fmt.Errorf("delete alert channel: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.ErrAlertChannelNotFound
+	}
+	return nil
+}
+
+func scanAlertChannel(row rowScanner) (*domain.AlertChannel, error) {
+	var ch domain.AlertChannel
+	err := row.Scan(&ch.ID, &ch.UserID, &ch.Type, &ch.Target, &ch.Name, &ch.Enabled, &ch.CreatedAt, &ch.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrAlertChannelNotFound
+		}
+		return nil, fmt.Errorf("scan alert channel: %w", err)
+	}
+	return &ch, nil
+}

--- a/internal/infrastructure/postgres/alert_repo_integration_test.go
+++ b/internal/infrastructure/postgres/alert_repo_integration_test.go
@@ -1,0 +1,118 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+)
+
+func TestAlertRepo_CreateGetList(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	repo := postgres.NewAlertChannelRepository(pool)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.AlertChannel{
+		UserID:  userID,
+		Type:    domain.AlertChannelSlack,
+		Target:  "https://hooks.slack.com/services/x",
+		Name:    "ops",
+		Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("created channel has empty ID")
+	}
+
+	got, err := repo.GetByID(ctx, created.ID, userID)
+	if err != nil {
+		t.Fatalf("get by id: %v", err)
+	}
+	if got.Target != "https://hooks.slack.com/services/x" || got.Type != domain.AlertChannelSlack {
+		t.Errorf("got %+v, want slack target", got)
+	}
+
+	list, err := repo.List(ctx, userID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("list len = %d, want 1", len(list))
+	}
+}
+
+func TestAlertRepo_ListEnabledFiltersDisabled(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	repo := postgres.NewAlertChannelRepository(pool)
+	ctx := context.Background()
+
+	on, _ := repo.Create(ctx, &domain.AlertChannel{UserID: userID, Type: domain.AlertChannelWebhook, Target: "https://a.example.com", Enabled: true})
+	off, _ := repo.Create(ctx, &domain.AlertChannel{UserID: userID, Type: domain.AlertChannelWebhook, Target: "https://b.example.com", Enabled: true})
+
+	if err := repo.SetEnabled(ctx, off.ID, userID, false); err != nil {
+		t.Fatalf("set enabled false: %v", err)
+	}
+
+	enabled, err := repo.ListEnabled(ctx, userID)
+	if err != nil {
+		t.Fatalf("list enabled: %v", err)
+	}
+	if len(enabled) != 1 || enabled[0].ID != on.ID {
+		t.Fatalf("ListEnabled returned %d channels, want only the enabled one (%s)", len(enabled), on.ID)
+	}
+}
+
+func TestAlertRepo_OwnershipIsolation(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	owner := testutil.UserID()
+	other := testutil.UserID()
+	testutil.SeedUser(t, pool, owner)
+	testutil.SeedUser(t, pool, other)
+	repo := postgres.NewAlertChannelRepository(pool)
+	ctx := context.Background()
+
+	created, _ := repo.Create(ctx, &domain.AlertChannel{UserID: owner, Type: domain.AlertChannelSlack, Target: "https://x.example.com", Enabled: true})
+
+	// Another user must not see or fetch it.
+	if _, err := repo.GetByID(ctx, created.ID, other); !errors.Is(err, domain.ErrAlertChannelNotFound) {
+		t.Errorf("cross-user GetByID err = %v, want ErrAlertChannelNotFound", err)
+	}
+	if err := repo.Delete(ctx, created.ID, other); !errors.Is(err, domain.ErrAlertChannelNotFound) {
+		t.Errorf("cross-user Delete err = %v, want ErrAlertChannelNotFound", err)
+	}
+}
+
+func TestAlertRepo_DeleteAndNotFound(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	repo := postgres.NewAlertChannelRepository(pool)
+	ctx := context.Background()
+
+	created, _ := repo.Create(ctx, &domain.AlertChannel{UserID: userID, Type: domain.AlertChannelSlack, Target: "https://x.example.com", Enabled: true})
+
+	if err := repo.Delete(ctx, created.ID, userID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := repo.GetByID(ctx, created.ID, userID); !errors.Is(err, domain.ErrAlertChannelNotFound) {
+		t.Errorf("after delete GetByID err = %v, want ErrAlertChannelNotFound", err)
+	}
+	if err := repo.SetEnabled(ctx, created.ID, userID, true); !errors.Is(err, domain.ErrAlertChannelNotFound) {
+		t.Errorf("SetEnabled on missing err = %v, want ErrAlertChannelNotFound", err)
+	}
+}

--- a/internal/infrastructure/postgres/buffer_repo.go
+++ b/internal/infrastructure/postgres/buffer_repo.go
@@ -144,22 +144,47 @@ func (r *BufferRepository) Delete(ctx context.Context, id, userID string) error 
 	return nil
 }
 
+// BufferStats returns the item status breakdown for one buffer. Ownership is
+// assumed to have been verified by the caller (usecase GetByID).
+func (r *BufferRepository) BufferStats(ctx context.Context, bufferID string) (domain.BufferStats, error) {
+	var s domain.BufferStats
+	err := r.pool.QueryRow(ctx, `
+		SELECT
+			COUNT(*) FILTER (WHERE status = 'pending'),
+			COUNT(*) FILTER (WHERE status = 'running'),
+			COUNT(*) FILTER (WHERE status = 'completed'),
+			COUNT(*) FILTER (WHERE status = 'failed'),
+			COUNT(*)
+		FROM buffer_items
+		WHERE buffer_id = $1`,
+		bufferID,
+	).Scan(&s.Pending, &s.Running, &s.Completed, &s.Failed, &s.Total)
+	if err != nil {
+		return domain.BufferStats{}, fmt.Errorf("buffer stats: %w", err)
+	}
+
+	if terminal := s.Completed + s.Failed; terminal > 0 {
+		s.SuccessRate = float64(s.Completed) / float64(terminal)
+	}
+	return s, nil
+}
+
 // ── Item CRUD ────────────────────────────────────────────────────────────────
 
 func (r *BufferRepository) CreateItem(ctx context.Context, item *domain.BufferItem) (*domain.BufferItem, error) {
 	query := `
 		INSERT INTO buffer_items (
 			buffer_id, user_id, url, method, headers, body,
-			timeout_seconds, backoff, status, max_retries, scheduled_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			timeout_seconds, backoff, status, max_retries, scheduled_at, replay_of
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 		RETURNING id, buffer_id, user_id, url, method, headers, body,
 		          timeout_seconds, backoff, status, retry_count, max_retries,
 		          scheduled_at, claimed_at, claimed_by, heartbeat_at,
-		          completed_at, last_error, status_code, created_at, updated_at`
+		          completed_at, last_error, status_code, created_at, updated_at, replay_of`
 
 	row := r.pool.QueryRow(ctx, query,
 		item.BufferID, item.UserID, item.URL, item.Method, item.Headers, item.Body,
-		item.TimeoutSeconds, item.Backoff, item.Status, item.MaxRetries, item.ScheduledAt,
+		item.TimeoutSeconds, item.Backoff, item.Status, item.MaxRetries, item.ScheduledAt, item.ReplayOf,
 	)
 
 	return scanBufferItem(row)
@@ -170,7 +195,7 @@ func (r *BufferRepository) GetItemByID(ctx context.Context, itemID, bufferID str
 		SELECT id, buffer_id, user_id, url, method, headers, body,
 		       timeout_seconds, backoff, status, retry_count, max_retries,
 		       scheduled_at, claimed_at, claimed_by, heartbeat_at,
-		       completed_at, last_error, status_code, created_at, updated_at
+		       completed_at, last_error, status_code, created_at, updated_at, replay_of
 		FROM buffer_items
 		WHERE id = $1 AND buffer_id = $2`
 
@@ -196,7 +221,7 @@ func (r *BufferRepository) ListItems(ctx context.Context, input repository.ListB
 		SELECT id, buffer_id, user_id, url, method, headers, body,
 		       timeout_seconds, backoff, status, retry_count, max_retries,
 		       scheduled_at, claimed_at, claimed_by, heartbeat_at,
-		       completed_at, last_error, status_code, created_at, updated_at
+		       completed_at, last_error, status_code, created_at, updated_at, replay_of
 		FROM buffer_items
 		WHERE %s
 		ORDER BY created_at DESC, id DESC
@@ -302,7 +327,7 @@ func (r *BufferRepository) ClaimNextItem(ctx context.Context, bufferID, workerID
 		RETURNING id, buffer_id, user_id, url, method, headers, body,
 		          timeout_seconds, backoff, status, retry_count, max_retries,
 		          scheduled_at, claimed_at, claimed_by, heartbeat_at,
-		          completed_at, last_error, status_code, created_at, updated_at`
+		          completed_at, last_error, status_code, created_at, updated_at, replay_of`
 
 	item, err := scanBufferItem(r.pool.QueryRow(ctx, query, workerID, bufferID))
 	if err != nil {
@@ -418,7 +443,7 @@ func scanBufferItem(row rowScanner) (*domain.BufferItem, error) {
 		&item.ID, &item.BufferID, &item.UserID, &item.URL, &item.Method, &item.Headers, &item.Body,
 		&item.TimeoutSeconds, &item.Backoff, &item.Status, &item.RetryCount, &item.MaxRetries,
 		&item.ScheduledAt, &item.ClaimedAt, &item.ClaimedBy, &item.HeartbeatAt,
-		&item.CompletedAt, &item.LastError, &item.StatusCode, &item.CreatedAt, &item.UpdatedAt,
+		&item.CompletedAt, &item.LastError, &item.StatusCode, &item.CreatedAt, &item.UpdatedAt, &item.ReplayOf,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/infrastructure/postgres/buffer_stats_replay_integration_test.go
+++ b/internal/infrastructure/postgres/buffer_stats_replay_integration_test.go
@@ -1,0 +1,142 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+)
+
+func newTestBuffer(t *testing.T, repo *postgres.BufferRepository, userID string) *domain.Buffer {
+	t.Helper()
+	b, err := repo.Create(context.Background(), &domain.Buffer{
+		UserID:         userID,
+		Name:           "test-buffer",
+		URL:            "https://example.com/api",
+		Method:         "POST",
+		Headers:        map[string]string{},
+		WebhookHeaders: map[string]string{},
+		TimeoutSeconds: 30,
+		RateLimit:      10,
+		MaxRetries:     3,
+		Backoff:        domain.BackoffExponential,
+	})
+	if err != nil {
+		t.Fatalf("create buffer: %v", err)
+	}
+	return b
+}
+
+func newTestItem(t *testing.T, repo *postgres.BufferRepository, b *domain.Buffer, status domain.BufferItemStatus) *domain.BufferItem {
+	t.Helper()
+	item, err := repo.CreateItem(context.Background(), &domain.BufferItem{
+		BufferID:       b.ID,
+		UserID:         b.UserID,
+		URL:            b.URL,
+		Method:         b.Method,
+		Headers:        map[string]string{},
+		TimeoutSeconds: 30,
+		Backoff:        domain.BackoffExponential,
+		Status:         status,
+		MaxRetries:     3,
+	})
+	if err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+	return item
+}
+
+func TestBufferRepo_BufferStats(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	repo := postgres.NewBufferRepository(pool)
+
+	b := newTestBuffer(t, repo, userID)
+	newTestItem(t, repo, b, domain.BufferItemPending)
+	newTestItem(t, repo, b, domain.BufferItemPending)
+	newTestItem(t, repo, b, domain.BufferItemRunning)
+	newTestItem(t, repo, b, domain.BufferItemCompleted)
+	newTestItem(t, repo, b, domain.BufferItemCompleted)
+	newTestItem(t, repo, b, domain.BufferItemCompleted)
+	newTestItem(t, repo, b, domain.BufferItemFailed)
+
+	s, err := repo.BufferStats(context.Background(), b.ID)
+	if err != nil {
+		t.Fatalf("buffer stats: %v", err)
+	}
+	if s.Pending != 2 || s.Running != 1 || s.Completed != 3 || s.Failed != 1 || s.Total != 7 {
+		t.Errorf("stats = %+v, want pending2/running1/completed3/failed1/total7", s)
+	}
+	// 3 completed of 4 terminal = 0.75.
+	if s.SuccessRate < 0.74 || s.SuccessRate > 0.76 {
+		t.Errorf("success_rate = %f, want ~0.75", s.SuccessRate)
+	}
+}
+
+func TestBufferRepo_BufferStats_Isolation(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	repo := postgres.NewBufferRepository(pool)
+
+	b1 := newTestBuffer(t, repo, userID)
+	b2, err := repo.Create(context.Background(), &domain.Buffer{
+		UserID: userID, Name: "other", URL: "https://example.com/x", Method: "POST",
+		Headers: map[string]string{}, WebhookHeaders: map[string]string{},
+		TimeoutSeconds: 30, RateLimit: 10, MaxRetries: 3, Backoff: domain.BackoffExponential,
+	})
+	if err != nil {
+		t.Fatalf("create buffer 2: %v", err)
+	}
+
+	newTestItem(t, repo, b1, domain.BufferItemFailed)
+	newTestItem(t, repo, b2, domain.BufferItemCompleted)
+
+	s, err := repo.BufferStats(context.Background(), b1.ID)
+	if err != nil {
+		t.Fatalf("buffer stats: %v", err)
+	}
+	if s.Total != 1 || s.Failed != 1 {
+		t.Errorf("stats = %+v, want only buffer 1's single failed item", s)
+	}
+}
+
+func TestBufferRepo_ReplayOfPersists(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	repo := postgres.NewBufferRepository(pool)
+	ctx := context.Background()
+
+	b := newTestBuffer(t, repo, userID)
+	original := newTestItem(t, repo, b, domain.BufferItemFailed)
+
+	clone, err := repo.CreateItem(ctx, &domain.BufferItem{
+		BufferID: b.ID, UserID: userID, URL: b.URL, Method: b.Method,
+		Headers: map[string]string{}, TimeoutSeconds: 30, Backoff: domain.BackoffExponential,
+		Status: domain.BufferItemPending, MaxRetries: 3, ReplayOf: &original.ID,
+	})
+	if err != nil {
+		t.Fatalf("create replay item: %v", err)
+	}
+	if clone.ReplayOf == nil || *clone.ReplayOf != original.ID {
+		t.Fatalf("clone.ReplayOf = %v, want %s", clone.ReplayOf, original.ID)
+	}
+
+	// Round-trips through a read.
+	got, err := repo.GetItemByID(ctx, clone.ID, b.ID)
+	if err != nil {
+		t.Fatalf("get item: %v", err)
+	}
+	if got.ReplayOf == nil || *got.ReplayOf != original.ID {
+		t.Errorf("read-back ReplayOf = %v, want %s", got.ReplayOf, original.ID)
+	}
+}

--- a/internal/infrastructure/postgres/job_replay_integration_test.go
+++ b/internal/infrastructure/postgres/job_replay_integration_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+)
+
+func TestJobRepo_ReplayOfPersists(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	repo := postgres.NewJobRepository(pool)
+	ctx := context.Background()
+
+	original, err := repo.Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
+	if err != nil {
+		t.Fatalf("create original: %v", err)
+	}
+	if original.ReplayOf != nil {
+		t.Errorf("ordinary job ReplayOf = %v, want nil", original.ReplayOf)
+	}
+
+	clone := testutil.NewJob(testutil.WithUserID(userID))
+	clone.ReplayOf = &original.ID
+	created, err := repo.Create(ctx, clone)
+	if err != nil {
+		t.Fatalf("create clone: %v", err)
+	}
+	if created.ReplayOf == nil || *created.ReplayOf != original.ID {
+		t.Fatalf("clone.ReplayOf = %v, want %s", created.ReplayOf, original.ID)
+	}
+
+	// Round-trips through GetByID (which shares scanJob with every other read).
+	got, err := repo.GetByID(ctx, created.ID, userID)
+	if err != nil {
+		t.Fatalf("get by id: %v", err)
+	}
+	if got.ReplayOf == nil || *got.ReplayOf != original.ID {
+		t.Errorf("read-back ReplayOf = %v, want %s", got.ReplayOf, original.ID)
+	}
+}
+
+func TestJobRepo_ReplayOfRejectsUnknownParent(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	repo := postgres.NewJobRepository(pool)
+	ctx := context.Background()
+
+	// replay_of has an FK to jobs(id); a dangling reference must be rejected.
+	bogus := "nonexistent-job-id"
+	clone := testutil.NewJob(testutil.WithUserID(userID))
+	clone.ReplayOf = &bogus
+	if _, err := repo.Create(ctx, clone); err == nil {
+		t.Fatal("expected FK violation for unknown replay_of parent, got nil")
+	}
+}

--- a/internal/infrastructure/postgres/job_repo.go
+++ b/internal/infrastructure/postgres/job_repo.go
@@ -27,13 +27,13 @@ func (r *JobRepository) Create(ctx context.Context, job *domain.Job) (*domain.Jo
 		INSERT INTO jobs (
 			user_id, idempotency_key, url, method, headers, body,
 			timeout_seconds, status, scheduled_at, max_retries, backoff, schedule_id,
-			webhook_url, webhook_headers
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+			webhook_url, webhook_headers, replay_of
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 		RETURNING id, user_id, idempotency_key, url, method, headers, body,
 		          timeout_seconds, status, scheduled_at, retry_count,
 		          max_retries, backoff, claimed_at, claimed_by,
 		          heartbeat_at, completed_at, last_error, created_at, updated_at, schedule_id,
-		          webhook_url, webhook_headers`
+		          webhook_url, webhook_headers, replay_of`
 
 	row := r.pool.QueryRow(ctx, query,
 		job.UserID,
@@ -50,6 +50,7 @@ func (r *JobRepository) Create(ctx context.Context, job *domain.Job) (*domain.Jo
 		job.ScheduleID,
 		job.WebhookURL,
 		job.WebhookHeaders,
+		job.ReplayOf,
 	)
 
 	created, err := scanJob(row)
@@ -69,7 +70,7 @@ func (r *JobRepository) GetByID(ctx context.Context, id, userID string) (*domain
 		       timeout_seconds, status, scheduled_at, retry_count,
 		       max_retries, backoff, claimed_at, claimed_by,
 		       heartbeat_at, completed_at, last_error, created_at, updated_at, schedule_id,
-		       webhook_url, webhook_headers
+		       webhook_url, webhook_headers, replay_of
 		FROM jobs
 		WHERE id = $1 AND user_id = $2`
 
@@ -98,7 +99,7 @@ func (r *JobRepository) Claim(ctx context.Context, workerID string, limit int) (
 		          timeout_seconds, status, scheduled_at, retry_count,
 		          max_retries, backoff, claimed_at, claimed_by,
 		          heartbeat_at, completed_at, last_error, created_at, updated_at, schedule_id,
-		          webhook_url, webhook_headers`
+		          webhook_url, webhook_headers, replay_of`
 
 	rows, err := r.pool.Query(ctx, query, workerID, limit)
 	if err != nil {
@@ -230,7 +231,7 @@ func (r *JobRepository) ListJobs(ctx context.Context, input repository.ListJobsI
 		       timeout_seconds, status, scheduled_at, retry_count,
 		       max_retries, backoff, claimed_at, claimed_by,
 		       heartbeat_at, completed_at, last_error, created_at, updated_at, schedule_id,
-		       webhook_url, webhook_headers
+		       webhook_url, webhook_headers, replay_of
 		FROM jobs
 		WHERE %s
 		ORDER BY scheduled_at DESC, id DESC
@@ -268,7 +269,7 @@ func scanJob(row rowScanner) (*domain.Job, error) {
 		&j.MaxRetries, &j.Backoff, &j.ClaimedAt, &j.ClaimedBy,
 		&j.HeartbeatAt, &j.CompletedAt, &j.LastError, &j.CreatedAt, &j.UpdatedAt,
 		&j.ScheduleID,
-		&j.WebhookURL, &j.WebhookHeaders,
+		&j.WebhookURL, &j.WebhookHeaders, &j.ReplayOf,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -294,7 +295,7 @@ func (r *JobRepository) ListByScheduleID(ctx context.Context, scheduleID string,
 		       timeout_seconds, status, scheduled_at, retry_count,
 		       max_retries, backoff, claimed_at, claimed_by,
 		       heartbeat_at, completed_at, last_error, created_at, updated_at, schedule_id,
-		       webhook_url, webhook_headers
+		       webhook_url, webhook_headers, replay_of
 		FROM jobs
 		WHERE %s
 		ORDER BY scheduled_at DESC, id DESC

--- a/internal/infrastructure/postgres/stats_repo.go
+++ b/internal/infrastructure/postgres/stats_repo.go
@@ -1,0 +1,82 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type StatsRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewStatsRepository(pool *pgxpool.Pool) *StatsRepository {
+	return &StatsRepository{pool: pool}
+}
+
+// JobStats aggregates completed attempts for the user's jobs since the cutoff.
+// An attempt counts as a success when it returned a 2xx with no transport error;
+// everything else (non-2xx, timeout, connection error) is a failure.
+func (r *StatsRepository) JobStats(ctx context.Context, userID string, since time.Time) (domain.JobStats, error) {
+	var s domain.JobStats
+	err := r.pool.QueryRow(ctx, `
+		SELECT
+			COUNT(*),
+			COUNT(*) FILTER (WHERE ja.error IS NULL AND ja.status_code BETWEEN 200 AND 299),
+			COALESCE(AVG(ja.duration_ms), 0),
+			COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY ja.duration_ms), 0)
+		FROM job_attempts ja
+		JOIN jobs j ON j.id = ja.job_id
+		WHERE j.user_id = $1
+		  AND ja.started_at >= $2
+		  AND ja.completed_at IS NOT NULL`,
+		userID, since,
+	).Scan(&s.TotalExecutions, &s.Succeeded, &s.AvgDurationMS, &s.P95DurationMS)
+	if err != nil {
+		return domain.JobStats{}, fmt.Errorf("job stats: %w", err)
+	}
+
+	s.Failed = s.TotalExecutions - s.Succeeded
+	if s.TotalExecutions > 0 {
+		s.SuccessRate = float64(s.Succeeded) / float64(s.TotalExecutions)
+	}
+	return s, nil
+}
+
+// UsageSeries returns per-UTC-day execution counts split by execution type. Only
+// days with activity appear; callers that need a dense series fill the gaps.
+func (r *StatsRepository) UsageSeries(ctx context.Context, userID string, since time.Time) ([]domain.UsageBucket, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT
+			to_char(DATE(created_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD') AS d,
+			COUNT(*) FILTER (WHERE type = $3) AS jobs,
+			COUNT(*) FILTER (WHERE type = $4) AS buffers
+		FROM credit_transactions
+		WHERE user_id = $1
+		  AND created_at >= $2
+		  AND type IN ($3, $4)
+		GROUP BY d
+		ORDER BY d ASC`,
+		userID, since, domain.CreditTxJobExecution, domain.CreditTxBufferExecution,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("usage series: %w", err)
+	}
+	defer rows.Close()
+
+	var buckets []domain.UsageBucket
+	for rows.Next() {
+		var b domain.UsageBucket
+		if err := rows.Scan(&b.Date, &b.JobExecutions, &b.BufferExecutions); err != nil {
+			return nil, fmt.Errorf("scan usage bucket: %w", err)
+		}
+		buckets = append(buckets, b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate usage series: %w", err)
+	}
+	return buckets, nil
+}

--- a/internal/infrastructure/postgres/stats_repo_integration_test.go
+++ b/internal/infrastructure/postgres/stats_repo_integration_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+)
+
+// seedCompletedAttempt creates a job and one completed attempt with the given
+// outcome, so JobStats has a row to aggregate.
+func seedCompletedAttempt(t *testing.T, jobRepo *postgres.JobRepository, attemptRepo *postgres.AttemptRepository, userID string, statusCode int, errMsg *string, durationMS int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	job, err := jobRepo.Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
+	if err != nil {
+		t.Fatalf("seed job: %v", err)
+	}
+	attempt, err := attemptRepo.CreateAttempt(ctx, &domain.JobAttempt{
+		JobID:      job.ID,
+		AttemptNum: 1,
+		WorkerID:   "worker-test",
+		StartedAt:  time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("seed attempt: %v", err)
+	}
+	sc := statusCode
+	if err := attemptRepo.CompleteAttempt(ctx, attempt.ID, &sc, errMsg, durationMS); err != nil {
+		t.Fatalf("complete attempt: %v", err)
+	}
+}
+
+func TestStatsRepo_JobStats(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+
+	jobRepo := postgres.NewJobRepository(pool)
+	attemptRepo := postgres.NewAttemptRepository(pool)
+	statsRepo := postgres.NewStatsRepository(pool)
+	ctx := context.Background()
+
+	// 3 successes (2xx, no error), 1 failure (5xx), 1 failure (transport error).
+	errMsg := "boom"
+	seedCompletedAttempt(t, jobRepo, attemptRepo, userID, 200, nil, 100)
+	seedCompletedAttempt(t, jobRepo, attemptRepo, userID, 201, nil, 200)
+	seedCompletedAttempt(t, jobRepo, attemptRepo, userID, 204, nil, 300)
+	seedCompletedAttempt(t, jobRepo, attemptRepo, userID, 503, &errMsg, 50)
+	seedCompletedAttempt(t, jobRepo, attemptRepo, userID, 0, &errMsg, 10)
+
+	s, err := statsRepo.JobStats(ctx, userID, time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("job stats: %v", err)
+	}
+	if s.TotalExecutions != 5 {
+		t.Errorf("total = %d, want 5", s.TotalExecutions)
+	}
+	if s.Succeeded != 3 {
+		t.Errorf("succeeded = %d, want 3", s.Succeeded)
+	}
+	if s.Failed != 2 {
+		t.Errorf("failed = %d, want 2", s.Failed)
+	}
+	if s.SuccessRate < 0.59 || s.SuccessRate > 0.61 {
+		t.Errorf("success_rate = %f, want ~0.6", s.SuccessRate)
+	}
+	if s.AvgDurationMS <= 0 || s.P95DurationMS <= 0 {
+		t.Errorf("durations should be positive: avg=%f p95=%f", s.AvgDurationMS, s.P95DurationMS)
+	}
+}
+
+func TestStatsRepo_JobStats_RespectsWindow(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+
+	jobRepo := postgres.NewJobRepository(pool)
+	attemptRepo := postgres.NewAttemptRepository(pool)
+	statsRepo := postgres.NewStatsRepository(pool)
+	ctx := context.Background()
+
+	seedCompletedAttempt(t, jobRepo, attemptRepo, userID, 200, nil, 100)
+
+	// A cutoff in the future excludes the just-created attempt.
+	s, err := statsRepo.JobStats(ctx, userID, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("job stats: %v", err)
+	}
+	if s.TotalExecutions != 0 {
+		t.Errorf("total = %d, want 0 (outside window)", s.TotalExecutions)
+	}
+}
+
+func TestStatsRepo_UsageSeries(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+
+	creditRepo := postgres.NewCreditRepository(pool)
+	statsRepo := postgres.NewStatsRepository(pool)
+	ctx := context.Background()
+
+	// 2 job executions + 1 buffer execution, all today.
+	job1, _ := postgres.NewJobRepository(pool).Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
+	job2, _ := postgres.NewJobRepository(pool).Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
+	if err := creditRepo.Deduct(ctx, userID, job1.ID); err != nil {
+		t.Fatalf("deduct job1: %v", err)
+	}
+	if err := creditRepo.Deduct(ctx, userID, job2.ID); err != nil {
+		t.Fatalf("deduct job2: %v", err)
+	}
+	itemID := seedBufferItem(t, pool, userID)
+	if err := creditRepo.DeductForBufferItem(ctx, userID, itemID); err != nil {
+		t.Fatalf("deduct buffer item: %v", err)
+	}
+
+	buckets, err := statsRepo.UsageSeries(ctx, userID, time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("usage series: %v", err)
+	}
+
+	var totalJobs, totalBuffers int64
+	for _, b := range buckets {
+		totalJobs += b.JobExecutions
+		totalBuffers += b.BufferExecutions
+	}
+	if totalJobs != 2 {
+		t.Errorf("job executions = %d, want 2", totalJobs)
+	}
+	if totalBuffers != 1 {
+		t.Errorf("buffer executions = %d, want 1", totalBuffers)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -97,6 +97,14 @@ var (
 		Buckets:   []float64{.01, .05, .1, .25, .5, 1, 2.5, 5, 10},
 	})
 
+	// Alert metrics
+
+	AlertDeliveriesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "scheduler",
+		Name:      "alert_deliveries_total",
+		Help:      "Total failure-alert delivery attempts, by channel type and outcome.",
+	}, []string{"type", "outcome"})
+
 	// Buffer drainer metrics
 
 	BufferItemsInFlight = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -154,6 +162,7 @@ func Register() {
 		HTTPRequestsTotal,
 		WebhookDeliveriesTotal,
 		WebhookDuration,
+		AlertDeliveriesTotal,
 		BufferItemsInFlight,
 		BufferItemsCompletedTotal,
 		BufferDrainerCycleDuration,

--- a/internal/repository/alert.go
+++ b/internal/repository/alert.go
@@ -1,0 +1,21 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+)
+
+// AlertChannelRepository persists user-configured alert channels. Channels are
+// few per user, so listing is unpaginated.
+type AlertChannelRepository interface {
+	Create(ctx context.Context, ch *domain.AlertChannel) (*domain.AlertChannel, error)
+	GetByID(ctx context.Context, id, userID string) (*domain.AlertChannel, error)
+	List(ctx context.Context, userID string) ([]*domain.AlertChannel, error)
+	SetEnabled(ctx context.Context, id, userID string, enabled bool) error
+	Delete(ctx context.Context, id, userID string) error
+
+	// ListEnabled returns the user's enabled channels. Called by the scheduler
+	// when a job or buffer item is permanently failed, to fan out the alert.
+	ListEnabled(ctx context.Context, userID string) ([]*domain.AlertChannel, error)
+}

--- a/internal/repository/buffer.go
+++ b/internal/repository/buffer.go
@@ -31,6 +31,9 @@ type BufferRepository interface {
 	SetPaused(ctx context.Context, id, userID string, paused bool) error
 	Delete(ctx context.Context, id, userID string) error
 
+	// BufferStats returns the item status breakdown for a single buffer.
+	BufferStats(ctx context.Context, bufferID string) (domain.BufferStats, error)
+
 	// Item CRUD
 	CreateItem(ctx context.Context, item *domain.BufferItem) (*domain.BufferItem, error)
 	GetItemByID(ctx context.Context, itemID, bufferID string) (*domain.BufferItem, error)

--- a/internal/repository/stats.go
+++ b/internal/repository/stats.go
@@ -1,0 +1,19 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+)
+
+// StatsRepository serves account-level analytics derived from existing tables
+// (job_attempts and credit_transactions). All reads are scoped to a user.
+type StatsRepository interface {
+	// JobStats aggregates completed job attempts for the user since the cutoff.
+	JobStats(ctx context.Context, userID string, since time.Time) (domain.JobStats, error)
+
+	// UsageSeries returns per-UTC-day execution counts (job vs buffer) for the
+	// user since the cutoff, ordered by date ascending.
+	UsageSeries(ctx context.Context, userID string, since time.Time) ([]domain.UsageBucket, error)
+}

--- a/internal/scheduler/alert.go
+++ b/internal/scheduler/alert.go
@@ -1,0 +1,160 @@
+package scheduler
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/metrics"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/safedialer"
+)
+
+// alertWebhookPayload is the JSON body POSTed to a 'webhook'-type alert channel.
+type alertWebhookPayload struct {
+	Event        string `json:"event"`
+	ResourceType string `json:"resource_type"`
+	ResourceID   string `json:"resource_id"`
+	BufferID     string `json:"buffer_id,omitempty"`
+	URL          string `json:"url"`
+	Method       string `json:"method"`
+	LastError    string `json:"last_error"`
+	StatusCode   *int   `json:"status_code,omitempty"`
+	Attempts     int    `json:"attempts"`
+	FailedAt     string `json:"failed_at"`
+}
+
+// AlertNotifier delivers failure alerts to a user's configured channels. It is
+// used by the scheduler (worker + buffer drainer) when a job or buffer item is
+// permanently failed.
+type AlertNotifier struct {
+	client *http.Client
+	repo   repository.AlertChannelRepository
+	logger *slog.Logger
+}
+
+func NewAlertNotifier(logger *slog.Logger, repo repository.AlertChannelRepository) *AlertNotifier {
+	return newAlertNotifier(logger, repo, &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+			DialContext:     safedialer.NewSafeDialContext(5*time.Second, 30*time.Second),
+		},
+	})
+}
+
+// newAlertNotifier lets tests inject a client without the SSRF-safe dialer so
+// they can deliver to a loopback httptest server.
+func newAlertNotifier(logger *slog.Logger, repo repository.AlertChannelRepository, client *http.Client) *AlertNotifier {
+	return &AlertNotifier{
+		client: client,
+		repo:   repo,
+		logger: logger.With("component", "alert_notifier"),
+	}
+}
+
+// NotifyFailureAsync loads the user's enabled alert channels and delivers the
+// failure event to each in a background goroutine. Best-effort: errors are
+// logged, never returned. Safe to call on a nil receiver, which makes alerting
+// an opt-in dependency the worker can run without.
+func (n *AlertNotifier) NotifyFailureAsync(ctx context.Context, event domain.AlertEvent) {
+	if n == nil {
+		return
+	}
+	go func() {
+		// Detach from the per-job deadline but keep shutdown cancellation.
+		dctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+		n.notifyFailure(dctx, event)
+	}()
+}
+
+func (n *AlertNotifier) notifyFailure(ctx context.Context, event domain.AlertEvent) {
+	channels, err := n.repo.ListEnabled(ctx, event.UserID)
+	if err != nil {
+		n.logger.WarnContext(ctx, "load alert channels failed", "user_id", event.UserID, "error", err)
+		return
+	}
+	for _, ch := range channels {
+		n.deliver(ctx, ch, event)
+	}
+}
+
+func (n *AlertNotifier) deliver(ctx context.Context, ch *domain.AlertChannel, event domain.AlertEvent) {
+	body, err := buildAlertBody(ch.Type, event)
+	if err != nil {
+		n.logger.ErrorContext(ctx, "build alert body", "channel_id", ch.ID, "error", err)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ch.Target, bytes.NewReader(body))
+	if err != nil {
+		metrics.AlertDeliveriesTotal.WithLabelValues(string(ch.Type), "failure").Inc()
+		n.logger.ErrorContext(ctx, "build alert request", "channel_id", ch.ID, "error", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		metrics.AlertDeliveriesTotal.WithLabelValues(string(ch.Type), "failure").Inc()
+		n.logger.WarnContext(ctx, "alert delivery failed",
+			"channel_id", ch.ID, "type", ch.Type, "error", err)
+		return
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		metrics.AlertDeliveriesTotal.WithLabelValues(string(ch.Type), "success").Inc()
+		n.logger.InfoContext(ctx, "alert delivered",
+			"channel_id", ch.ID, "type", ch.Type, "resource_id", event.ResourceID, "status_code", resp.StatusCode)
+		return
+	}
+	metrics.AlertDeliveriesTotal.WithLabelValues(string(ch.Type), "failure").Inc()
+	n.logger.WarnContext(ctx, "alert delivery non-2xx",
+		"channel_id", ch.ID, "type", ch.Type, "status_code", resp.StatusCode)
+}
+
+// buildAlertBody renders the event into the body shape expected by the channel
+// type: a Slack incoming-webhook message, or a structured JSON webhook payload.
+func buildAlertBody(t domain.AlertChannelType, event domain.AlertEvent) ([]byte, error) {
+	if t == domain.AlertChannelSlack {
+		return json.Marshal(map[string]string{"text": alertMessage(event)})
+	}
+	return json.Marshal(alertWebhookPayload{
+		Event:        "failure",
+		ResourceType: string(event.ResourceType),
+		ResourceID:   event.ResourceID,
+		BufferID:     event.BufferID,
+		URL:          event.URL,
+		Method:       event.Method,
+		LastError:    event.LastError,
+		StatusCode:   event.StatusCode,
+		Attempts:     event.Attempts,
+		FailedAt:     event.FailedAt.UTC().Format(time.RFC3339),
+	})
+}
+
+// alertMessage formats a human-readable one-liner for Slack-type channels.
+func alertMessage(e domain.AlertEvent) string {
+	noun := "Job"
+	if e.ResourceType == domain.AlertResourceBufferItem {
+		noun = "Buffer item"
+	}
+	status := ""
+	if e.StatusCode != nil {
+		status = fmt.Sprintf(" (HTTP %d)", *e.StatusCode)
+	}
+	return fmt.Sprintf("🔴 Fliq: %s %s failed permanently after %d attempt(s)%s — %s %s\nLast error: %s",
+		noun, e.ResourceID, e.Attempts, status, e.Method, e.URL, e.LastError)
+}

--- a/internal/scheduler/alert_test.go
+++ b/internal/scheduler/alert_test.go
@@ -1,0 +1,137 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+)
+
+func TestBuildAlertBody_Slack(t *testing.T) {
+	code := 500
+	event := domain.AlertEvent{
+		ResourceType: domain.AlertResourceJob,
+		ResourceID:   "job-1",
+		URL:          "https://api.example.com",
+		Method:       "POST",
+		LastError:    "boom",
+		StatusCode:   &code,
+		Attempts:     4,
+	}
+	body, err := buildAlertBody(domain.AlertChannelSlack, event)
+	if err != nil {
+		t.Fatalf("buildAlertBody: %v", err)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	text, ok := payload["text"]
+	if !ok {
+		t.Fatal("slack payload missing text field")
+	}
+	for _, want := range []string{"job-1", "boom", "4 attempt", "HTTP 500"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("slack text %q missing %q", text, want)
+		}
+	}
+}
+
+func TestBuildAlertBody_Webhook(t *testing.T) {
+	event := domain.AlertEvent{
+		ResourceType: domain.AlertResourceBufferItem,
+		ResourceID:   "item-1",
+		BufferID:     "buf-1",
+		URL:          "https://api.example.com",
+		Method:       "POST",
+		LastError:    "timeout",
+		Attempts:     3,
+		FailedAt:     time.Now(),
+	}
+	body, err := buildAlertBody(domain.AlertChannelWebhook, event)
+	if err != nil {
+		t.Fatalf("buildAlertBody: %v", err)
+	}
+	var payload alertWebhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if payload.Event != "failure" || payload.ResourceType != "buffer_item" || payload.ResourceID != "item-1" {
+		t.Errorf("payload = %+v, want failure/buffer_item/item-1", payload)
+	}
+	if payload.BufferID != "buf-1" {
+		t.Errorf("buffer_id = %q, want buf-1", payload.BufferID)
+	}
+	if payload.Attempts != 3 {
+		t.Errorf("attempts = %d, want 3", payload.Attempts)
+	}
+}
+
+func TestNotifyFailureAsync_DeliversToEnabledChannels(t *testing.T) {
+	var mu sync.Mutex
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	repo := &testutil.MockAlertChannelRepository{
+		ListEnabledFn: func(_ context.Context, _ string) ([]*domain.AlertChannel, error) {
+			return []*domain.AlertChannel{
+				{ID: "a", Type: domain.AlertChannelWebhook, Target: srv.URL, Enabled: true},
+				{ID: "b", Type: domain.AlertChannelSlack, Target: srv.URL, Enabled: true},
+			}, nil
+		},
+	}
+	n := newAlertNotifier(slog.Default(), repo, srv.Client())
+
+	n.NotifyFailureAsync(context.Background(), domain.AlertEvent{
+		UserID: "user-1", ResourceType: domain.AlertResourceJob, ResourceID: "job-1",
+	})
+
+	waitFor(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return hits == 2
+	})
+}
+
+func TestNotifyFailureAsync_NilReceiverSafe(t *testing.T) {
+	var n *AlertNotifier
+	// Must not panic — alerting is an opt-in dependency.
+	n.NotifyFailureAsync(context.Background(), domain.AlertEvent{UserID: "user-1"})
+}
+
+func TestNotifyFailure_RepoErrorTolerated(t *testing.T) {
+	repo := &testutil.MockAlertChannelRepository{
+		ListEnabledFn: func(_ context.Context, _ string) ([]*domain.AlertChannel, error) {
+			return nil, context.DeadlineExceeded
+		},
+	}
+	n := NewAlertNotifier(slog.Default(), repo)
+	// notifyFailure swallows the repo error (logged, not returned).
+	n.notifyFailure(context.Background(), domain.AlertEvent{UserID: "user-1"})
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met within timeout")
+}

--- a/internal/scheduler/drainer.go
+++ b/internal/scheduler/drainer.go
@@ -25,6 +25,7 @@ type BufferDrainer struct {
 	signingSecrets repository.SigningSecretRepository
 	executor       *Executor
 	notifier       *WebhookNotifier
+	alerts         *AlertNotifier
 	logger         *slog.Logger
 	pollInterval   time.Duration
 	concurrency    int
@@ -36,6 +37,7 @@ func NewBufferDrainer(
 	credits repository.CreditRepository,
 	signingSecrets repository.SigningSecretRepository,
 	notifier *WebhookNotifier,
+	alerts *AlertNotifier,
 	logger *slog.Logger,
 	pollInterval time.Duration,
 	concurrency int,
@@ -49,11 +51,29 @@ func NewBufferDrainer(
 		signingSecrets: signingSecrets,
 		executor:       NewExecutor(logger),
 		notifier:       notifier,
+		alerts:         alerts,
 		logger:         logger.With("component", "buffer_drainer", "worker_id", id),
 		pollInterval:   pollInterval,
 		concurrency:    concurrency,
 		sem:            make(chan struct{}, concurrency),
 	}
+}
+
+// alertItemFailure fires a best-effort failure alert for a permanently-failed
+// buffer item.
+func (d *BufferDrainer) alertItemFailure(ctx context.Context, item *domain.BufferItem, statusCode *int, errMsg string) {
+	d.alerts.NotifyFailureAsync(ctx, domain.AlertEvent{
+		UserID:       item.UserID,
+		ResourceType: domain.AlertResourceBufferItem,
+		ResourceID:   item.ID,
+		BufferID:     item.BufferID,
+		URL:          item.URL,
+		Method:       item.Method,
+		LastError:    errMsg,
+		StatusCode:   statusCode,
+		Attempts:     item.RetryCount + 1,
+		FailedAt:     time.Now(),
+	})
 }
 
 func (d *BufferDrainer) Start(ctx context.Context) {
@@ -137,6 +157,7 @@ func (d *BufferDrainer) runItem(ctx context.Context, buf *domain.Buffer, item *d
 		}
 		metrics.BufferItemsCompletedTotal.WithLabelValues("failed").Inc()
 		d.notifyBufferItem(ctx, buf, item, domain.BufferItemFailed, nil, &errMsg)
+		d.alertItemFailure(ctx, item, nil, errMsg)
 		return
 	}
 
@@ -227,6 +248,7 @@ func (d *BufferDrainer) runItem(ctx context.Context, buf *domain.Buffer, item *d
 		}
 		metrics.BufferItemsCompletedTotal.WithLabelValues("failed").Inc()
 		d.notifyBufferItem(ctx, buf, item, domain.BufferItemFailed, statusCode, &errMsg)
+		d.alertItemFailure(ctx, item, statusCode, errMsg)
 		d.logger.WarnContext(ctx, "buffer item permanently failed", "item_id", item.ID, "error", errMsg)
 	}
 }

--- a/internal/scheduler/worker.go
+++ b/internal/scheduler/worker.go
@@ -24,6 +24,7 @@ type Worker struct {
 	signingSecrets repository.SigningSecretRepository
 	executor       *Executor
 	notifier       *WebhookNotifier
+	alerts         *AlertNotifier
 	logger         *slog.Logger
 	pollInterval   time.Duration
 	concurrency    int
@@ -35,6 +36,7 @@ func NewWorker(
 	attempts repository.AttemptRepository,
 	credits repository.CreditRepository,
 	notifier *WebhookNotifier,
+	alerts *AlertNotifier,
 	logger *slog.Logger,
 	pollInterval time.Duration,
 	concurrency int,
@@ -50,11 +52,27 @@ func NewWorker(
 		signingSecrets: signingSecrets,
 		executor:       NewExecutor(logger),
 		notifier:       notifier,
+		alerts:         alerts,
 		logger:         logger.With("worker_id", id),
 		pollInterval:   pollInterval,
 		concurrency:    concurrency,
 		sem:            make(chan struct{}, concurrency),
 	}
+}
+
+// alertJobFailure fires a best-effort failure alert for a permanently-failed job.
+func (w *Worker) alertJobFailure(ctx context.Context, job *domain.Job, statusCode *int, errMsg string) {
+	w.alerts.NotifyFailureAsync(ctx, domain.AlertEvent{
+		UserID:       job.UserID,
+		ResourceType: domain.AlertResourceJob,
+		ResourceID:   job.ID,
+		URL:          job.URL,
+		Method:       job.Method,
+		LastError:    errMsg,
+		StatusCode:   statusCode,
+		Attempts:     job.RetryCount + 1,
+		FailedAt:     time.Now(),
+	})
 }
 
 func (w *Worker) Start(ctx context.Context) {
@@ -142,6 +160,7 @@ func (w *Worker) runJob(ctx context.Context, job *domain.Job) {
 		job.Status = domain.StatusFailed
 		job.LastError = &errMsg
 		w.notifier.notifyAsync(ctx, job, nil)
+		w.alertJobFailure(ctx, job, nil, errMsg)
 		w.logger.WarnContext(ctx, "job permanently failed: insufficient credits", "job_id", job.ID)
 		return
 	}
@@ -220,6 +239,7 @@ func (w *Worker) runJob(ctx context.Context, job *domain.Job) {
 		job.Status = domain.StatusFailed
 		job.LastError = &errMsg
 		w.notifier.notifyAsync(ctx, job, statusCode)
+		w.alertJobFailure(ctx, job, statusCode, errMsg)
 		metrics.JobsCompletedTotal.WithLabelValues("failed").Inc()
 		w.logger.WarnContext(ctx, "job permanently failed", "job_id", job.ID, "error", errMsg)
 	}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -352,6 +352,204 @@ func (m *MockStripeCustomerRepository) Save(ctx context.Context, userID, stripeC
 	return nil
 }
 
+// ---------- MockAlertChannelRepository ----------
+
+type MockAlertChannelRepository struct {
+	CreateFn      func(ctx context.Context, ch *domain.AlertChannel) (*domain.AlertChannel, error)
+	GetByIDFn     func(ctx context.Context, id, userID string) (*domain.AlertChannel, error)
+	ListFn        func(ctx context.Context, userID string) ([]*domain.AlertChannel, error)
+	SetEnabledFn  func(ctx context.Context, id, userID string, enabled bool) error
+	DeleteFn      func(ctx context.Context, id, userID string) error
+	ListEnabledFn func(ctx context.Context, userID string) ([]*domain.AlertChannel, error)
+}
+
+func (m *MockAlertChannelRepository) Create(ctx context.Context, ch *domain.AlertChannel) (*domain.AlertChannel, error) {
+	if m.CreateFn != nil {
+		return m.CreateFn(ctx, ch)
+	}
+	ch.ID = "alert-1"
+	ch.CreatedAt = time.Now()
+	ch.UpdatedAt = ch.CreatedAt
+	return ch, nil
+}
+
+func (m *MockAlertChannelRepository) GetByID(ctx context.Context, id, userID string) (*domain.AlertChannel, error) {
+	if m.GetByIDFn != nil {
+		return m.GetByIDFn(ctx, id, userID)
+	}
+	return nil, domain.ErrAlertChannelNotFound
+}
+
+func (m *MockAlertChannelRepository) List(ctx context.Context, userID string) ([]*domain.AlertChannel, error) {
+	if m.ListFn != nil {
+		return m.ListFn(ctx, userID)
+	}
+	return nil, nil
+}
+
+func (m *MockAlertChannelRepository) SetEnabled(ctx context.Context, id, userID string, enabled bool) error {
+	if m.SetEnabledFn != nil {
+		return m.SetEnabledFn(ctx, id, userID, enabled)
+	}
+	return nil
+}
+
+func (m *MockAlertChannelRepository) Delete(ctx context.Context, id, userID string) error {
+	if m.DeleteFn != nil {
+		return m.DeleteFn(ctx, id, userID)
+	}
+	return nil
+}
+
+func (m *MockAlertChannelRepository) ListEnabled(ctx context.Context, userID string) ([]*domain.AlertChannel, error) {
+	if m.ListEnabledFn != nil {
+		return m.ListEnabledFn(ctx, userID)
+	}
+	return nil, nil
+}
+
+// ---------- MockStatsRepository ----------
+
+type MockStatsRepository struct {
+	JobStatsFn    func(ctx context.Context, userID string, since time.Time) (domain.JobStats, error)
+	UsageSeriesFn func(ctx context.Context, userID string, since time.Time) ([]domain.UsageBucket, error)
+}
+
+func (m *MockStatsRepository) JobStats(ctx context.Context, userID string, since time.Time) (domain.JobStats, error) {
+	if m.JobStatsFn != nil {
+		return m.JobStatsFn(ctx, userID, since)
+	}
+	return domain.JobStats{}, nil
+}
+
+func (m *MockStatsRepository) UsageSeries(ctx context.Context, userID string, since time.Time) ([]domain.UsageBucket, error) {
+	if m.UsageSeriesFn != nil {
+		return m.UsageSeriesFn(ctx, userID, since)
+	}
+	return nil, nil
+}
+
+// ---------- MockBufferRepository ----------
+
+// MockBufferRepository implements repository.BufferRepository. Only the methods
+// exercised by a given test need a *Fn hook; the rest return zero values.
+type MockBufferRepository struct {
+	CreateFn          func(ctx context.Context, b *domain.Buffer) (*domain.Buffer, error)
+	GetByIDFn         func(ctx context.Context, id, userID string) (*domain.Buffer, error)
+	GetByIDInternalFn func(ctx context.Context, id string) (*domain.Buffer, error)
+	ListFn            func(ctx context.Context, input repository.ListBuffersInput) ([]*domain.Buffer, error)
+	SetPausedFn       func(ctx context.Context, id, userID string, paused bool) error
+	DeleteFn          func(ctx context.Context, id, userID string) error
+	BufferStatsFn     func(ctx context.Context, bufferID string) (domain.BufferStats, error)
+	CreateItemFn      func(ctx context.Context, item *domain.BufferItem) (*domain.BufferItem, error)
+	GetItemByIDFn     func(ctx context.Context, itemID, bufferID string) (*domain.BufferItem, error)
+	ListItemsFn       func(ctx context.Context, input repository.ListBufferItemsInput) ([]*domain.BufferItem, error)
+}
+
+func (m *MockBufferRepository) Create(ctx context.Context, b *domain.Buffer) (*domain.Buffer, error) {
+	if m.CreateFn != nil {
+		return m.CreateFn(ctx, b)
+	}
+	b.ID = "buffer-1"
+	return b, nil
+}
+
+func (m *MockBufferRepository) GetByID(ctx context.Context, id, userID string) (*domain.Buffer, error) {
+	if m.GetByIDFn != nil {
+		return m.GetByIDFn(ctx, id, userID)
+	}
+	return nil, domain.ErrBufferNotFound
+}
+
+func (m *MockBufferRepository) GetByIDInternal(ctx context.Context, id string) (*domain.Buffer, error) {
+	if m.GetByIDInternalFn != nil {
+		return m.GetByIDInternalFn(ctx, id)
+	}
+	return nil, domain.ErrBufferNotFound
+}
+
+func (m *MockBufferRepository) List(ctx context.Context, input repository.ListBuffersInput) ([]*domain.Buffer, error) {
+	if m.ListFn != nil {
+		return m.ListFn(ctx, input)
+	}
+	return nil, nil
+}
+
+func (m *MockBufferRepository) SetPaused(ctx context.Context, id, userID string, paused bool) error {
+	if m.SetPausedFn != nil {
+		return m.SetPausedFn(ctx, id, userID, paused)
+	}
+	return nil
+}
+
+func (m *MockBufferRepository) Delete(ctx context.Context, id, userID string) error {
+	if m.DeleteFn != nil {
+		return m.DeleteFn(ctx, id, userID)
+	}
+	return nil
+}
+
+func (m *MockBufferRepository) BufferStats(ctx context.Context, bufferID string) (domain.BufferStats, error) {
+	if m.BufferStatsFn != nil {
+		return m.BufferStatsFn(ctx, bufferID)
+	}
+	return domain.BufferStats{}, nil
+}
+
+func (m *MockBufferRepository) CreateItem(ctx context.Context, item *domain.BufferItem) (*domain.BufferItem, error) {
+	if m.CreateItemFn != nil {
+		return m.CreateItemFn(ctx, item)
+	}
+	item.ID = "item-1"
+	return item, nil
+}
+
+func (m *MockBufferRepository) GetItemByID(ctx context.Context, itemID, bufferID string) (*domain.BufferItem, error) {
+	if m.GetItemByIDFn != nil {
+		return m.GetItemByIDFn(ctx, itemID, bufferID)
+	}
+	return nil, domain.ErrBufferItemNotFound
+}
+
+func (m *MockBufferRepository) ListItems(ctx context.Context, input repository.ListBufferItemsInput) ([]*domain.BufferItem, error) {
+	if m.ListItemsFn != nil {
+		return m.ListItemsFn(ctx, input)
+	}
+	return nil, nil
+}
+
+func (m *MockBufferRepository) ListActiveBufferIDs(ctx context.Context, limit int) ([]string, error) {
+	return nil, nil
+}
+
+func (m *MockBufferRepository) ClaimNextItem(ctx context.Context, bufferID, workerID string) (*domain.BufferItem, error) {
+	return nil, nil
+}
+
+func (m *MockBufferRepository) UpdateItemHeartbeat(ctx context.Context, itemID string) error {
+	return nil
+}
+
+func (m *MockBufferRepository) CompleteItem(ctx context.Context, itemID string, statusCode int) error {
+	return nil
+}
+
+func (m *MockBufferRepository) FailItem(ctx context.Context, itemID string, lastError string, statusCode *int) error {
+	return nil
+}
+
+func (m *MockBufferRepository) RescheduleItem(ctx context.Context, itemID string, lastError string, statusCode *int, retryAt time.Time) error {
+	return nil
+}
+
+func (m *MockBufferRepository) RescheduleStaleItems(ctx context.Context, staleCutoff time.Time, limit int) (int, error) {
+	return 0, nil
+}
+
+func (m *MockBufferRepository) FailStaleItems(ctx context.Context, staleCutoff time.Time, limit int) (int, error) {
+	return 0, nil
+}
+
 // ---------- MockSigningSecretRepository ----------
 
 type MockSigningSecretRepository struct {

--- a/internal/usecase/alert.go
+++ b/internal/usecase/alert.go
@@ -1,0 +1,74 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
+)
+
+type AlertUsecase struct {
+	repo repository.AlertChannelRepository
+}
+
+func NewAlertUsecase(repo repository.AlertChannelRepository) *AlertUsecase {
+	return &AlertUsecase{repo: repo}
+}
+
+type CreateAlertChannelInput struct {
+	UserID string
+	Type   domain.AlertChannelType
+	Target string
+	Name   string
+}
+
+func (u *AlertUsecase) CreateChannel(ctx context.Context, input CreateAlertChannelInput) (*domain.AlertChannel, error) {
+	if !domain.ValidAlertChannelType(input.Type) {
+		return nil, domain.ErrInvalidAlertChannelType
+	}
+
+	ch := &domain.AlertChannel{
+		UserID:  input.UserID,
+		Type:    input.Type,
+		Target:  input.Target,
+		Name:    input.Name,
+		Enabled: true,
+	}
+
+	created, err := u.repo.Create(ctx, ch)
+	if err != nil {
+		return nil, fmt.Errorf("create alert channel: %w", err)
+	}
+	return created, nil
+}
+
+func (u *AlertUsecase) ListChannels(ctx context.Context, userID string) ([]*domain.AlertChannel, error) {
+	channels, err := u.repo.List(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list alert channels: %w", err)
+	}
+	return channels, nil
+}
+
+func (u *AlertUsecase) GetChannel(ctx context.Context, id, userID string) (*domain.AlertChannel, error) {
+	ch, err := u.repo.GetByID(ctx, id, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get alert channel: %w", err)
+	}
+	return ch, nil
+}
+
+func (u *AlertUsecase) SetEnabled(ctx context.Context, id, userID string, enabled bool) error {
+	if err := u.repo.SetEnabled(ctx, id, userID, enabled); err != nil {
+		return fmt.Errorf("set alert channel enabled: %w", err)
+	}
+	return nil
+}
+
+func (u *AlertUsecase) DeleteChannel(ctx context.Context, id, userID string) error {
+	if err := u.repo.Delete(ctx, id, userID); err != nil {
+		return fmt.Errorf("delete alert channel: %w", err)
+	}
+	return nil
+}

--- a/internal/usecase/alert_test.go
+++ b/internal/usecase/alert_test.go
@@ -1,0 +1,97 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
+)
+
+func TestCreateAlertChannel_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	var saved *domain.AlertChannel
+	repo := &testutil.MockAlertChannelRepository{
+		CreateFn: func(_ context.Context, ch *domain.AlertChannel) (*domain.AlertChannel, error) {
+			ch.ID = "alert-1"
+			saved = ch
+			return ch, nil
+		},
+	}
+	uc := usecase.NewAlertUsecase(repo)
+
+	got, err := uc.CreateChannel(context.Background(), usecase.CreateAlertChannelInput{
+		UserID: "user-1",
+		Type:   domain.AlertChannelSlack,
+		Target: "https://hooks.slack.com/services/x",
+		Name:   "ops",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID != "alert-1" {
+		t.Errorf("id = %q, want alert-1", got.ID)
+	}
+	if !saved.Enabled {
+		t.Error("new channel should be enabled by default")
+	}
+}
+
+func TestCreateAlertChannel_InvalidType(t *testing.T) {
+	t.Parallel()
+
+	repo := &testutil.MockAlertChannelRepository{
+		CreateFn: func(_ context.Context, _ *domain.AlertChannel) (*domain.AlertChannel, error) {
+			t.Fatal("Create must not be called for an invalid type")
+			return nil, nil
+		},
+	}
+	uc := usecase.NewAlertUsecase(repo)
+
+	_, err := uc.CreateChannel(context.Background(), usecase.CreateAlertChannelInput{
+		UserID: "user-1",
+		Type:   domain.AlertChannelType("email"),
+		Target: "ops@example.com",
+	})
+	if !errors.Is(err, domain.ErrInvalidAlertChannelType) {
+		t.Errorf("err = %v, want ErrInvalidAlertChannelType", err)
+	}
+}
+
+func TestAlertChannel_SetEnabled_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := &testutil.MockAlertChannelRepository{
+		SetEnabledFn: func(_ context.Context, _, _ string, _ bool) error {
+			return domain.ErrAlertChannelNotFound
+		},
+	}
+	uc := usecase.NewAlertUsecase(repo)
+
+	err := uc.SetEnabled(context.Background(), "missing", "user-1", false)
+	if !errors.Is(err, domain.ErrAlertChannelNotFound) {
+		t.Errorf("err = %v, want ErrAlertChannelNotFound", err)
+	}
+}
+
+func TestAlertChannel_List(t *testing.T) {
+	t.Parallel()
+
+	repo := &testutil.MockAlertChannelRepository{
+		ListFn: func(_ context.Context, _ string) ([]*domain.AlertChannel, error) {
+			return []*domain.AlertChannel{{ID: "a"}, {ID: "b"}}, nil
+		},
+	}
+	uc := usecase.NewAlertUsecase(repo)
+
+	got, err := uc.ListChannels(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len = %d, want 2", len(got))
+	}
+}

--- a/internal/usecase/buffer.go
+++ b/internal/usecase/buffer.go
@@ -171,6 +171,18 @@ func (u *BufferUsecase) ResumeBuffer(ctx context.Context, id, userID string) err
 	return nil
 }
 
+// GetBufferStats returns the item status breakdown for a buffer the user owns.
+func (u *BufferUsecase) GetBufferStats(ctx context.Context, id, userID string) (domain.BufferStats, error) {
+	if _, err := u.repo.GetByID(ctx, id, userID); err != nil {
+		return domain.BufferStats{}, fmt.Errorf("get buffer: %w", err)
+	}
+	stats, err := u.repo.BufferStats(ctx, id)
+	if err != nil {
+		return domain.BufferStats{}, fmt.Errorf("buffer stats: %w", err)
+	}
+	return stats, nil
+}
+
 func (u *BufferUsecase) DeleteBuffer(ctx context.Context, id, userID string) error {
 	if err := u.repo.Delete(ctx, id, userID); err != nil {
 		return fmt.Errorf("delete buffer: %w", err)
@@ -241,6 +253,58 @@ func (u *BufferUsecase) GetItem(ctx context.Context, itemID, bufferID, userID st
 		return nil, fmt.Errorf("get buffer item: %w", err)
 	}
 	return item, nil
+}
+
+// ReplayItem clones a permanently-failed buffer item into a fresh pending item
+// appended to the tail of the buffer (new created_at), so it drains in order
+// after the current queue rather than jumping ahead of in-flight work. The
+// original failed item is left as history; the clone carries a replay_of pointer
+// back to it.
+func (u *BufferUsecase) ReplayItem(ctx context.Context, itemID, bufferID, userID string) (*domain.BufferItem, error) {
+	// Verify buffer ownership.
+	buf, err := u.repo.GetByID(ctx, bufferID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get buffer: %w", err)
+	}
+
+	item, err := u.repo.GetItemByID(ctx, itemID, bufferID)
+	if err != nil {
+		return nil, fmt.Errorf("get buffer item: %w", err)
+	}
+
+	if item.Status != domain.BufferItemFailed {
+		return nil, domain.ErrBufferItemNotReplayable
+	}
+
+	// A replay enqueues a new execution — gate it on credits like a fresh push.
+	ok, err := u.credits.HasCredits(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("check credits: %w", err)
+	}
+	if !ok {
+		return nil, domain.ErrInsufficientCredits
+	}
+
+	clone := &domain.BufferItem{
+		BufferID:       buf.ID,
+		UserID:         userID,
+		URL:            item.URL,
+		Method:         item.Method,
+		Headers:        item.Headers,
+		Body:           item.Body,
+		TimeoutSeconds: item.TimeoutSeconds,
+		Backoff:        item.Backoff,
+		Status:         domain.BufferItemPending,
+		MaxRetries:     item.MaxRetries,
+		ScheduledAt:    time.Now(),
+		ReplayOf:       &item.ID,
+	}
+
+	created, err := u.repo.CreateItem(ctx, clone)
+	if err != nil {
+		return nil, fmt.Errorf("create replay item: %w", err)
+	}
+	return created, nil
 }
 
 type ListBufferItemsInput struct {

--- a/internal/usecase/job.go
+++ b/internal/usecase/job.go
@@ -92,6 +92,59 @@ func (u *JobUsecase) CreateJob(ctx context.Context, input CreateJobInput) (*doma
 	return created, nil
 }
 
+// Replay clones a permanently-failed job into a fresh pending job and returns
+// it. The original is left untouched as history; the clone carries a new
+// idempotency key and a replay_of pointer back to the source for lineage.
+//
+// Replay clones rather than resetting the original in place: a job's attempt
+// records are keyed UNIQUE(job_id, attempt_num), so re-running the same row
+// would collide on attempt_num. A new job gets a clean attempt sequence and
+// preserves the failed job's audit trail.
+func (u *JobUsecase) Replay(ctx context.Context, jobID, userID string) (*domain.Job, error) {
+	job, err := u.repo.GetByID(ctx, jobID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get job: %w", err)
+	}
+
+	// Only terminal failures are replayable. Pending/running/completed/cancelled
+	// jobs are not dead letters.
+	if job.Status != domain.StatusFailed {
+		return nil, domain.ErrJobNotReplayable
+	}
+
+	// A replay enqueues a new execution — gate it on credits like a fresh create.
+	ok, err := u.credits.HasCredits(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("check credits: %w", err)
+	}
+	if !ok {
+		return nil, domain.ErrInsufficientCredits
+	}
+
+	clone := &domain.Job{
+		UserID:         job.UserID,
+		IdempotencyKey: uuid.New().String(),
+		URL:            job.URL,
+		Method:         job.Method,
+		Headers:        job.Headers,
+		Body:           job.Body,
+		TimeoutSeconds: job.TimeoutSeconds,
+		Status:         domain.StatusPending,
+		ScheduledAt:    time.Now(),
+		MaxRetries:     job.MaxRetries,
+		Backoff:        job.Backoff,
+		WebhookURL:     job.WebhookURL,
+		WebhookHeaders: job.WebhookHeaders,
+		ReplayOf:       &job.ID,
+	}
+
+	created, err := u.repo.Create(ctx, clone)
+	if err != nil {
+		return nil, fmt.Errorf("create replay job: %w", err)
+	}
+	return created, nil
+}
+
 func (u *JobUsecase) CancelJob(ctx context.Context, jobID, userID string) error {
 	if err := u.repo.Cancel(ctx, jobID, userID); err != nil {
 		return fmt.Errorf("cancel job: %w", err)

--- a/internal/usecase/replay_test.go
+++ b/internal/usecase/replay_test.go
@@ -1,0 +1,236 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
+)
+
+func TestReplayJob_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	failed := testutil.NewJob(
+		testutil.WithUserID("user-1"),
+		testutil.WithJobID("job-failed"),
+		testutil.WithStatus(domain.StatusFailed),
+		testutil.WithURL("https://example.com/hook"),
+	)
+
+	var created *domain.Job
+	jobRepo := &testutil.MockJobRepository{
+		GetByIDFn: func(_ context.Context, id, uid string) (*domain.Job, error) {
+			if id == "job-failed" && uid == "user-1" {
+				return failed, nil
+			}
+			return nil, domain.ErrJobNotFound
+		},
+		CreateFn: func(_ context.Context, j *domain.Job) (*domain.Job, error) {
+			j.ID = "job-replay"
+			created = j
+			return j, nil
+		},
+	}
+	uc := usecase.NewJobUsecase(jobRepo, &testutil.MockAttemptRepository{}, &testutil.MockCreditRepository{})
+
+	got, err := uc.Replay(context.Background(), "job-failed", "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID != "job-replay" {
+		t.Errorf("id = %q, want job-replay", got.ID)
+	}
+	if created.Status != domain.StatusPending {
+		t.Errorf("clone status = %q, want pending", created.Status)
+	}
+	if created.ReplayOf == nil || *created.ReplayOf != "job-failed" {
+		t.Errorf("clone replay_of = %v, want job-failed", created.ReplayOf)
+	}
+	if created.URL != "https://example.com/hook" {
+		t.Errorf("clone url = %q, want carried over from source", created.URL)
+	}
+	if created.IdempotencyKey == failed.IdempotencyKey {
+		t.Error("clone must get a fresh idempotency key, not reuse the source's")
+	}
+}
+
+func TestReplayJob_NotFailed(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []domain.Status{
+		domain.StatusPending, domain.StatusRunning, domain.StatusCompleted, domain.StatusCancelled,
+	} {
+		job := testutil.NewJob(testutil.WithUserID("user-1"), testutil.WithStatus(status))
+		jobRepo := &testutil.MockJobRepository{
+			GetByIDFn: func(_ context.Context, _, _ string) (*domain.Job, error) { return job, nil },
+			CreateFn: func(_ context.Context, _ *domain.Job) (*domain.Job, error) {
+				t.Fatal("Create must not be called for a non-failed job")
+				return nil, nil
+			},
+		}
+		uc := usecase.NewJobUsecase(jobRepo, &testutil.MockAttemptRepository{}, &testutil.MockCreditRepository{})
+
+		_, err := uc.Replay(context.Background(), "job-1", "user-1")
+		if !errors.Is(err, domain.ErrJobNotReplayable) {
+			t.Errorf("status %q: err = %v, want ErrJobNotReplayable", status, err)
+		}
+	}
+}
+
+func TestReplayJob_NotFound(t *testing.T) {
+	t.Parallel()
+
+	jobRepo := &testutil.MockJobRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.Job, error) {
+			return nil, domain.ErrJobNotFound
+		},
+	}
+	uc := usecase.NewJobUsecase(jobRepo, &testutil.MockAttemptRepository{}, &testutil.MockCreditRepository{})
+
+	_, err := uc.Replay(context.Background(), "missing", "user-1")
+	if !errors.Is(err, domain.ErrJobNotFound) {
+		t.Errorf("err = %v, want ErrJobNotFound", err)
+	}
+}
+
+func TestReplayJob_InsufficientCredits(t *testing.T) {
+	t.Parallel()
+
+	failed := testutil.NewJob(testutil.WithUserID("user-1"), testutil.WithStatus(domain.StatusFailed))
+	jobRepo := &testutil.MockJobRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.Job, error) { return failed, nil },
+		CreateFn: func(_ context.Context, _ *domain.Job) (*domain.Job, error) {
+			t.Fatal("Create must not be called when out of credits")
+			return nil, nil
+		},
+	}
+	credits := &testutil.MockCreditRepository{
+		HasCreditsFn: func(_ context.Context, _ string) (bool, error) { return false, nil },
+	}
+	uc := usecase.NewJobUsecase(jobRepo, &testutil.MockAttemptRepository{}, credits)
+
+	_, err := uc.Replay(context.Background(), "job-1", "user-1")
+	if !errors.Is(err, domain.ErrInsufficientCredits) {
+		t.Errorf("err = %v, want ErrInsufficientCredits", err)
+	}
+}
+
+func TestReplayBufferItem_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	body := `{"x":1}`
+	failed := &domain.BufferItem{
+		ID:         "item-failed",
+		BufferID:   "buf-1",
+		UserID:     "user-1",
+		URL:        "https://example.com/api",
+		Method:     "POST",
+		Body:       &body,
+		MaxRetries: 3,
+		Status:     domain.BufferItemFailed,
+	}
+	var created *domain.BufferItem
+	bufRepo := &testutil.MockBufferRepository{
+		GetByIDFn: func(_ context.Context, id, uid string) (*domain.Buffer, error) {
+			if id == "buf-1" && uid == "user-1" {
+				return &domain.Buffer{ID: "buf-1", UserID: "user-1"}, nil
+			}
+			return nil, domain.ErrBufferNotFound
+		},
+		GetItemByIDFn: func(_ context.Context, itemID, bufferID string) (*domain.BufferItem, error) {
+			if itemID == "item-failed" && bufferID == "buf-1" {
+				return failed, nil
+			}
+			return nil, domain.ErrBufferItemNotFound
+		},
+		CreateItemFn: func(_ context.Context, it *domain.BufferItem) (*domain.BufferItem, error) {
+			it.ID = "item-replay"
+			created = it
+			return it, nil
+		},
+	}
+	uc := usecase.NewBufferUsecase(bufRepo, &testutil.MockCreditRepository{})
+
+	got, err := uc.ReplayItem(context.Background(), "item-failed", "buf-1", "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID != "item-replay" {
+		t.Errorf("id = %q, want item-replay", got.ID)
+	}
+	if created.Status != domain.BufferItemPending {
+		t.Errorf("clone status = %q, want pending", created.Status)
+	}
+	if created.ReplayOf == nil || *created.ReplayOf != "item-failed" {
+		t.Errorf("clone replay_of = %v, want item-failed", created.ReplayOf)
+	}
+	if created.URL != failed.URL {
+		t.Errorf("clone url = %q, want carried over", created.URL)
+	}
+}
+
+func TestReplayBufferItem_NotFailed(t *testing.T) {
+	t.Parallel()
+
+	item := &domain.BufferItem{ID: "item-1", BufferID: "buf-1", UserID: "user-1", Status: domain.BufferItemCompleted}
+	bufRepo := &testutil.MockBufferRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.Buffer, error) {
+			return &domain.Buffer{ID: "buf-1", UserID: "user-1"}, nil
+		},
+		GetItemByIDFn: func(_ context.Context, _, _ string) (*domain.BufferItem, error) { return item, nil },
+		CreateItemFn: func(_ context.Context, _ *domain.BufferItem) (*domain.BufferItem, error) {
+			t.Fatal("CreateItem must not be called for a non-failed item")
+			return nil, nil
+		},
+	}
+	uc := usecase.NewBufferUsecase(bufRepo, &testutil.MockCreditRepository{})
+
+	_, err := uc.ReplayItem(context.Background(), "item-1", "buf-1", "user-1")
+	if !errors.Is(err, domain.ErrBufferItemNotReplayable) {
+		t.Errorf("err = %v, want ErrBufferItemNotReplayable", err)
+	}
+}
+
+func TestReplayBufferItem_BufferNotOwned(t *testing.T) {
+	t.Parallel()
+
+	bufRepo := &testutil.MockBufferRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.Buffer, error) {
+			return nil, domain.ErrBufferNotFound
+		},
+	}
+	uc := usecase.NewBufferUsecase(bufRepo, &testutil.MockCreditRepository{})
+
+	_, err := uc.ReplayItem(context.Background(), "item-1", "buf-1", "user-1")
+	if !errors.Is(err, domain.ErrBufferNotFound) {
+		t.Errorf("err = %v, want ErrBufferNotFound", err)
+	}
+}
+
+func TestReplayBufferItem_InsufficientCredits(t *testing.T) {
+	t.Parallel()
+
+	failed := &domain.BufferItem{ID: "item-1", BufferID: "buf-1", UserID: "user-1", Status: domain.BufferItemFailed}
+	bufRepo := &testutil.MockBufferRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.Buffer, error) {
+			return &domain.Buffer{ID: "buf-1", UserID: "user-1"}, nil
+		},
+		GetItemByIDFn: func(_ context.Context, _, _ string) (*domain.BufferItem, error) { return failed, nil },
+		CreateItemFn: func(_ context.Context, _ *domain.BufferItem) (*domain.BufferItem, error) {
+			t.Fatal("CreateItem must not be called when out of credits")
+			return nil, nil
+		},
+	}
+	credits := &testutil.MockCreditRepository{
+		HasCreditsFn: func(_ context.Context, _ string) (bool, error) { return false, nil },
+	}
+	uc := usecase.NewBufferUsecase(bufRepo, credits)
+
+	_, err := uc.ReplayItem(context.Background(), "item-1", "buf-1", "user-1")
+	if !errors.Is(err, domain.ErrInsufficientCredits) {
+		t.Errorf("err = %v, want ErrInsufficientCredits", err)
+	}
+}

--- a/internal/usecase/stats.go
+++ b/internal/usecase/stats.go
@@ -1,0 +1,73 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
+)
+
+const (
+	defaultStatsDays = 30
+	maxStatsDays     = 365
+)
+
+type StatsUsecase struct {
+	stats   repository.StatsRepository
+	credits repository.CreditRepository
+}
+
+func NewStatsUsecase(stats repository.StatsRepository, credits repository.CreditRepository) *StatsUsecase {
+	return &StatsUsecase{stats: stats, credits: credits}
+}
+
+// clampDays normalizes a requested window to [1, maxStatsDays], defaulting to
+// defaultStatsDays when days <= 0.
+func clampDays(days int) int {
+	if days <= 0 {
+		return defaultStatsDays
+	}
+	if days > maxStatsDays {
+		return maxStatsDays
+	}
+	return days
+}
+
+func (u *StatsUsecase) GetJobStats(ctx context.Context, userID string, days int) (domain.JobStats, error) {
+	days = clampDays(days)
+	since := time.Now().Add(-time.Duration(days) * 24 * time.Hour)
+
+	s, err := u.stats.JobStats(ctx, userID, since)
+	if err != nil {
+		return domain.JobStats{}, fmt.Errorf("job stats: %w", err)
+	}
+	s.SinceDays = days
+	return s, nil
+}
+
+func (u *StatsUsecase) GetUsage(ctx context.Context, userID string, days int) (domain.UsageSummary, error) {
+	days = clampDays(days)
+	since := time.Now().Add(-time.Duration(days) * 24 * time.Hour)
+
+	buckets, err := u.stats.UsageSeries(ctx, userID, since)
+	if err != nil {
+		return domain.UsageSummary{}, fmt.Errorf("usage series: %w", err)
+	}
+
+	summary := domain.UsageSummary{Buckets: buckets, SinceDays: days}
+	for _, b := range buckets {
+		summary.TotalJobExecutions += b.JobExecutions
+		summary.TotalBufferExecutions += b.BufferExecutions
+	}
+
+	// Current credit position is best-effort context for the usage view; a
+	// missing balance row should not fail the whole report.
+	if bal, err := u.credits.GetBalance(ctx, userID); err == nil {
+		summary.Balance = bal.Balance
+		summary.Plan = bal.Plan
+	}
+
+	return summary, nil
+}

--- a/internal/usecase/stats_test.go
+++ b/internal/usecase/stats_test.go
@@ -1,0 +1,161 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
+)
+
+func TestGetJobStats_DefaultsAndSinceDays(t *testing.T) {
+	t.Parallel()
+
+	var gotSince time.Time
+	repo := &testutil.MockStatsRepository{
+		JobStatsFn: func(_ context.Context, _ string, since time.Time) (domain.JobStats, error) {
+			gotSince = since
+			return domain.JobStats{TotalExecutions: 10, Succeeded: 7, Failed: 3, SuccessRate: 0.7}, nil
+		},
+	}
+	uc := usecase.NewStatsUsecase(repo, &testutil.MockCreditRepository{})
+
+	// days <= 0 should default to 30.
+	got, err := uc.GetJobStats(context.Background(), "user-1", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.SinceDays != 30 {
+		t.Errorf("SinceDays = %d, want 30", got.SinceDays)
+	}
+	if d := time.Since(gotSince); d < 29*24*time.Hour || d > 31*24*time.Hour {
+		t.Errorf("since cutoff ~%v ago, want ~30 days", d)
+	}
+}
+
+func TestGetJobStats_ClampsToMax(t *testing.T) {
+	t.Parallel()
+
+	repo := &testutil.MockStatsRepository{
+		JobStatsFn: func(_ context.Context, _ string, _ time.Time) (domain.JobStats, error) {
+			return domain.JobStats{}, nil
+		},
+	}
+	uc := usecase.NewStatsUsecase(repo, &testutil.MockCreditRepository{})
+
+	got, err := uc.GetJobStats(context.Background(), "user-1", 100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.SinceDays != 365 {
+		t.Errorf("SinceDays = %d, want clamped to 365", got.SinceDays)
+	}
+}
+
+func TestGetUsage_SumsTotalsAndAttachesBalance(t *testing.T) {
+	t.Parallel()
+
+	repo := &testutil.MockStatsRepository{
+		UsageSeriesFn: func(_ context.Context, _ string, _ time.Time) ([]domain.UsageBucket, error) {
+			return []domain.UsageBucket{
+				{Date: "2026-06-10", JobExecutions: 3, BufferExecutions: 5},
+				{Date: "2026-06-11", JobExecutions: 2, BufferExecutions: 1},
+			}, nil
+		},
+	}
+	credits := &testutil.MockCreditRepository{
+		GetBalanceFn: func(_ context.Context, uid string) (*domain.CreditBalance, error) {
+			return &domain.CreditBalance{UserID: uid, Balance: 4242, Plan: domain.PlanPaid}, nil
+		},
+	}
+	uc := usecase.NewStatsUsecase(repo, credits)
+
+	got, err := uc.GetUsage(context.Background(), "user-1", 7)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.TotalJobExecutions != 5 {
+		t.Errorf("TotalJobExecutions = %d, want 5", got.TotalJobExecutions)
+	}
+	if got.TotalBufferExecutions != 6 {
+		t.Errorf("TotalBufferExecutions = %d, want 6", got.TotalBufferExecutions)
+	}
+	if got.Balance != 4242 || got.Plan != domain.PlanPaid {
+		t.Errorf("balance/plan = %d/%s, want 4242/paid", got.Balance, got.Plan)
+	}
+	if got.SinceDays != 7 {
+		t.Errorf("SinceDays = %d, want 7", got.SinceDays)
+	}
+}
+
+func TestGetUsage_BalanceErrorTolerated(t *testing.T) {
+	t.Parallel()
+
+	repo := &testutil.MockStatsRepository{
+		UsageSeriesFn: func(_ context.Context, _ string, _ time.Time) ([]domain.UsageBucket, error) {
+			return []domain.UsageBucket{{Date: "2026-06-11", JobExecutions: 1}}, nil
+		},
+	}
+	credits := &testutil.MockCreditRepository{
+		GetBalanceFn: func(_ context.Context, _ string) (*domain.CreditBalance, error) {
+			return nil, errors.New("no balance row")
+		},
+	}
+	uc := usecase.NewStatsUsecase(repo, credits)
+
+	got, err := uc.GetUsage(context.Background(), "user-1", 7)
+	if err != nil {
+		t.Fatalf("usage should not fail when balance is unavailable: %v", err)
+	}
+	if got.TotalJobExecutions != 1 {
+		t.Errorf("TotalJobExecutions = %d, want 1", got.TotalJobExecutions)
+	}
+	if got.Balance != 0 {
+		t.Errorf("Balance = %d, want 0 when unavailable", got.Balance)
+	}
+}
+
+func TestGetBufferStats_OwnershipChecked(t *testing.T) {
+	t.Parallel()
+
+	bufRepo := &testutil.MockBufferRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.Buffer, error) {
+			return nil, domain.ErrBufferNotFound
+		},
+		BufferStatsFn: func(_ context.Context, _ string) (domain.BufferStats, error) {
+			t.Fatal("BufferStats must not be called when ownership check fails")
+			return domain.BufferStats{}, nil
+		},
+	}
+	uc := usecase.NewBufferUsecase(bufRepo, &testutil.MockCreditRepository{})
+
+	_, err := uc.GetBufferStats(context.Background(), "buf-1", "user-1")
+	if !errors.Is(err, domain.ErrBufferNotFound) {
+		t.Errorf("err = %v, want ErrBufferNotFound", err)
+	}
+}
+
+func TestGetBufferStats_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	bufRepo := &testutil.MockBufferRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.Buffer, error) {
+			return &domain.Buffer{ID: "buf-1", UserID: "user-1"}, nil
+		},
+		BufferStatsFn: func(_ context.Context, _ string) (domain.BufferStats, error) {
+			return domain.BufferStats{Completed: 9, Failed: 1, Total: 10, SuccessRate: 0.9}, nil
+		},
+	}
+	uc := usecase.NewBufferUsecase(bufRepo, &testutil.MockCreditRepository{})
+
+	got, err := uc.GetBufferStats(context.Background(), "buf-1", "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Total != 10 || got.SuccessRate != 0.9 {
+		t.Errorf("stats = %+v, want total 10 / rate 0.9", got)
+	}
+}

--- a/migrations/20260612000000_alert_channels.sql
+++ b/migrations/20260612000000_alert_channels.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+
+-- Alert channels: user-configured destinations that receive a notification
+-- when a job or buffer item exhausts its retries (permanent failure).
+-- type is the delivery mechanism ('webhook' = generic JSON POST, 'slack' =
+-- Slack incoming-webhook formatted message). target is the destination URL.
+CREATE TABLE alert_channels (
+    id         TEXT        PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    user_id    TEXT        NOT NULL REFERENCES users(id),
+    type       TEXT        NOT NULL,
+    target     TEXT        NOT NULL,
+    name       TEXT        NOT NULL DEFAULT '',
+    enabled    BOOLEAN     NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_alert_channels_user ON alert_channels (user_id, created_at DESC, id DESC);
+
+-- The scheduler looks up a user's enabled channels on every permanent failure.
+CREATE INDEX idx_alert_channels_enabled ON alert_channels (user_id) WHERE enabled;
+
+-- +goose Down
+DROP TABLE alert_channels;

--- a/migrations/20260612000001_jobs_replay_of.sql
+++ b/migrations/20260612000001_jobs_replay_of.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+
+-- replay_of links a job created via POST /jobs/:id/replay back to the failed
+-- job it was cloned from, for dead-letter lineage. NULL for ordinary jobs.
+-- ON DELETE SET NULL is defensive: jobs are not row-deleted today (DELETE =
+-- cancel), but a future hard-delete must not orphan the FK.
+ALTER TABLE jobs ADD COLUMN replay_of TEXT REFERENCES jobs(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_jobs_replay_of ON jobs (replay_of) WHERE replay_of IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_jobs_replay_of;
+ALTER TABLE jobs DROP COLUMN replay_of;

--- a/migrations/20260612000002_buffer_items_replay_of.sql
+++ b/migrations/20260612000002_buffer_items_replay_of.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+
+-- replay_of links a buffer item created via POST /buffers/:id/items/:itemId/replay
+-- back to the failed item it was cloned from. NULL for ordinary items. The clone
+-- is appended to the tail of the buffer (new created_at) so it drains in order
+-- after the current queue, rather than jumping ahead of in-flight work.
+ALTER TABLE buffer_items ADD COLUMN replay_of TEXT REFERENCES buffer_items(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_buffer_items_replay_of ON buffer_items (replay_of) WHERE replay_of IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_buffer_items_replay_of;
+ALTER TABLE buffer_items DROP COLUMN replay_of;


### PR DESCRIPTION
Implements the three **Tier-1** retention/trust features: turn the existing reliability engine into something customers can *see* working and *act* on.

## What's in here

### 1. Failure alerts (`/alerts`)
User-configured alert channels (`type`: `slack` | `webhook`, plus a target URL). When a job or buffer item **exhausts its retries** (permanent failure, including out-of-credits), the scheduler fans the event out to every enabled channel.
- Delivery lives in `internal/scheduler` (`AlertNotifier`) next to the existing webhook notifier — only the scheduler observes terminal failures. Fire-and-forget, best-effort, SSRF-safe dialer, **nil-safe** so the worker runs without it.
- `slack` → `{"text": ...}`; `webhook` → structured JSON. Body shaping is a pure, unit-tested function.
- `email` is **intentionally deferred** — needs a mail provider/credentials this service doesn't have. Enum is open for it; the API rejects unknown types at binding.

### 2. Usage & failure analytics
Read-only aggregates over data the engine already records — no new write paths.
- `GET /stats/jobs?days=N` — total/success/failure, success rate, avg & p95 duration (from `job_attempts`).
- `GET /stats/usage?days=N` — per-UTC-day job vs buffer execution series + totals + current balance (from the credit ledger).
- `GET /buffers/:id/stats` — per-buffer item status breakdown + success rate.

### 3. Dead-letter replay
- `POST /jobs/:id/replay` and `POST /buffers/:id/items/:itemId/replay` — re-run a permanently-**failed** job/item (409 otherwise).
- **Clones** rather than resetting in place: re-running a row would collide on `UNIQUE(job_id, attempt_num)`, and the failed row is worth keeping as audit. The clone carries a new `replay_of` FK (lineage), a fresh idempotency key, and passes the same credit gate as a create/push. Replayed buffer items append to the tail so they drain in order.

## Migrations
`alert_channels` table; `replay_of` columns on `jobs` and `buffer_items` (both `ON DELETE SET NULL`). All three verified with a down/up roundtrip.

## Testing
- **Unit** (mock-backed): alert + stats + replay usecases, alert/stats/buffer/job handlers, scheduler `AlertNotifier` (payload shaping, delivery, nil-safety, repo-error tolerance).
- **Integration** (real Postgres): alert repo CRUD + `ListEnabled` filtering + ownership isolation; stats aggregation; buffer stats + `replay_of` persistence; job `replay_of` persistence + FK enforcement.
- **Router smoke test**: builds the real route table (catches Gin route conflicts) and asserts the new routes are auth-gated.
- Green: `go build`, `go vet`, `gofmt`, `golangci-lint` (0 issues), unit + integration with `-race`.

## Notes
- `email` alert delivery and a "send test alert" endpoint are deliberate follow-ups.
- Two pre-existing `gofmt` nits (`scheduler/webhook.go`, `safedialer/safedialer.go`) are left untouched.

See `docs/design/alerts-analytics-replay.md` for the design rationale.
