### PR TITLE
Email alert channel + proactive low-balance warning

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/health"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
 	ctxlog "github.com/ErlanBelekov/dist-job-scheduler/internal/log"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/mailer"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/metrics"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/scheduler"
 	"github.com/lmittmann/tint"
@@ -51,8 +52,21 @@ func main() {
 	signingRepo := postgres.NewSigningSecretRepository(pool)
 	alertRepo := postgres.NewAlertChannelRepository(pool)
 
+	var mailProvider mailer.Provider
+	if cfg.ResendAPIKey == "" {
+		logger.Warn("RESEND_API_KEY unset — email alerts will be dropped (no-op mailer)")
+		mailProvider = mailer.NewNoopProvider(logger)
+	} else {
+		mailProvider = mailer.NewResendProvider(cfg.ResendAPIKey, cfg.AlertEmailFrom)
+	}
+
 	notifier := scheduler.NewWebhookNotifier(logger, signingRepo)
-	alertNotifier := scheduler.NewAlertNotifier(logger, alertRepo)
+	alertNotifier := scheduler.NewAlertNotifier(logger, alertRepo, mailProvider)
+
+	lowBalance := scheduler.LowBalanceConfig{
+		Threshold: cfg.LowBalanceThreshold,
+		TopUpURL:  cfg.BillingSuccessURL,
+	}
 
 	worker := scheduler.NewWorker(
 		jobRepo,
@@ -60,6 +74,7 @@ func main() {
 		creditRepo,
 		notifier,
 		alertNotifier,
+		lowBalance,
 		logger,
 		time.Duration(cfg.PollIntervalSec)*time.Second,
 		cfg.WorkerCount,
@@ -76,7 +91,7 @@ func main() {
 
 	bufferRepo := postgres.NewBufferRepository(pool)
 	drainer := scheduler.NewBufferDrainer(
-		bufferRepo, creditRepo, signingRepo, notifier, alertNotifier, logger,
+		bufferRepo, creditRepo, signingRepo, notifier, alertNotifier, lowBalance, logger,
 		time.Duration(cfg.DrainerPollIntervalSec)*time.Second,
 		cfg.DrainerConcurrency,
 	)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,12 +12,14 @@ import (
 	"time"
 
 	"github.com/ErlanBelekov/dist-job-scheduler/config"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/emailverify"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/health"
 	httptransport "github.com/ErlanBelekov/dist-job-scheduler/internal/http"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/handler"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/middleware"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
 	ctxlog "github.com/ErlanBelekov/dist-job-scheduler/internal/log"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/mailer"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/metrics"
 	stripeclient "github.com/ErlanBelekov/dist-job-scheduler/internal/stripe"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
@@ -92,9 +94,11 @@ func main() {
 	bufferUsecase := usecase.NewBufferUsecase(bufferRepo, creditRepo)
 	bufferHandler := handler.NewBufferHandler(bufferUsecase, logger)
 
-	// Alert channels
+	// Alert channels (with email verification + Resend mailer)
 	alertRepo := postgres.NewAlertChannelRepository(pool)
-	alertUsecase := usecase.NewAlertUsecase(alertRepo)
+	mailProvider := newMailer(cfg, logger)
+	verifySigner := emailverify.NewSigner([]byte(cfg.JWTSecret))
+	alertUsecase := usecase.NewAlertUsecase(alertRepo, mailProvider, verifySigner, cfg.AppBaseURL)
 	alertHandler := handler.NewAlertHandler(alertUsecase, logger)
 
 	// Analytics
@@ -141,6 +145,16 @@ func main() {
 	if err := metricsSrv.Shutdown(shutdownCtx); err != nil {
 		logger.Error("metrics server shutdown", "error", err)
 	}
+}
+
+// newMailer returns a Resend provider when RESEND_API_KEY is set, otherwise a
+// no-op provider (email channels can be created but nothing is sent).
+func newMailer(cfg *config.Config, logger *slog.Logger) mailer.Provider {
+	if cfg.ResendAPIKey == "" {
+		logger.Warn("RESEND_API_KEY unset — email alerts will be dropped (no-op mailer)")
+		return mailer.NewNoopProvider(logger)
+	}
+	return mailer.NewResendProvider(cfg.ResendAPIKey, cfg.AlertEmailFrom)
 }
 
 func newLogger(env string, level slog.Level) *slog.Logger {

--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,20 @@ type Config struct {
 	// Billing URLs for Stripe Checkout redirect.
 	BillingSuccessURL string `env:"BILLING_SUCCESS_URL" envDefault:"http://localhost:3000/app/billing/success"`
 	BillingCancelURL  string `env:"BILLING_CANCEL_URL" envDefault:"http://localhost:3000/app/billing/cancel"`
+
+	// LowBalanceThreshold is the credit floor that triggers a proactive
+	// credit_low alert when a deduction crosses below it. 0 disables the warning.
+	LowBalanceThreshold int64 `env:"LOW_BALANCE_THRESHOLD" envDefault:"10000"`
+
+	// Email alerts (Resend). When ResendAPIKey is empty the mailer is a safe
+	// no-op: email channels can still be created but nothing is sent, exactly
+	// like a nil AlertNotifier. Set both to deliver live.
+	ResendAPIKey   string `env:"RESEND_API_KEY"`
+	AlertEmailFrom string `env:"ALERT_EMAIL_FROM" envDefault:"alerts@fliq.sh"`
+
+	// AppBaseURL is the public base URL used to build email-verification confirm
+	// links (e.g. https://api.fliq.sh). Falls back to localhost for local dev.
+	AppBaseURL string `env:"APP_BASE_URL" envDefault:"http://localhost:8080"`
 }
 
 func Load() (*Config, error) {

--- a/internal/domain/alert.go
+++ b/internal/domain/alert.go
@@ -8,6 +8,12 @@ import (
 var (
 	ErrAlertChannelNotFound    = errors.New("alert channel not found")
 	ErrInvalidAlertChannelType = errors.New("invalid alert channel type")
+	// ErrAlertChannelNotVerified is returned when enabling an email channel whose
+	// address has not yet confirmed ownership.
+	ErrAlertChannelNotVerified = errors.New("alert channel not verified")
+	// ErrInvalidVerificationToken is returned when an email-verification confirm
+	// token is malformed, expired, or its signature does not validate.
+	ErrInvalidVerificationToken = errors.New("invalid verification token")
 )
 
 // AlertChannelType is the delivery mechanism for an alert channel.
@@ -19,27 +25,44 @@ const (
 	// AlertChannelSlack POSTs a Slack-incoming-webhook message ({"text": ...})
 	// to the target URL.
 	AlertChannelSlack AlertChannelType = "slack"
+	// AlertChannelEmail sends a transactional email to the target address.
+	// Email channels start disabled and require address verification (a signed
+	// confirm token) before they are enabled and delivered to — this prevents
+	// Fliq from being used to spam third-party addresses.
+	AlertChannelEmail AlertChannelType = "email"
 )
 
 // ValidAlertChannelType reports whether t is a supported channel type.
 func ValidAlertChannelType(t AlertChannelType) bool {
 	switch t {
-	case AlertChannelWebhook, AlertChannelSlack:
+	case AlertChannelWebhook, AlertChannelSlack, AlertChannelEmail:
 		return true
 	default:
 		return false
 	}
 }
 
+// RequiresVerification reports whether a channel of this type must verify its
+// target before it can be enabled. Only email channels do — webhook/slack
+// targets are caller-owned URLs, an email address may belong to a third party.
+func (t AlertChannelType) RequiresVerification() bool {
+	return t == AlertChannelEmail
+}
+
 // AlertChannel is a user-configured destination notified when one of the user's
 // jobs or buffer items exhausts its retries (permanent failure).
 type AlertChannel struct {
-	ID        string
-	UserID    string
-	Type      AlertChannelType
-	Target    string
-	Name      string
-	Enabled   bool
+	ID     string
+	UserID string
+	Type   AlertChannelType
+	Target string
+	Name   string
+	// Enabled gates fan-out. Email channels are created disabled and only flip
+	// to enabled once Verified is set via the confirm-token endpoint.
+	Enabled bool
+	// Verified is true once an email channel's target address has confirmed
+	// ownership. Always true for webhook/slack channels (nothing to verify).
+	Verified  bool
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
@@ -51,6 +74,41 @@ const (
 	AlertResourceJob        AlertResourceType = "job"
 	AlertResourceBufferItem AlertResourceType = "buffer_item"
 )
+
+// CreditLowBurnWindow is the trailing window over which recent burn is summed
+// for the low-balance hint.
+const CreditLowBurnWindow = 24 * time.Hour
+
+// CrossedLowBalance reports whether a deduction from prev to current crosses the
+// low-balance threshold on the downward edge: prev was at or above the
+// threshold and current is below it. This is the hysteresis guard — it fires at
+// most once per crossing. A balance already below the threshold (prev already
+// below) does not re-fire, and a top-up back above followed by another drop will
+// fire again, which is the intended behaviour.
+func CrossedLowBalance(prev, current, threshold int64) bool {
+	if threshold <= 0 {
+		return false
+	}
+	return prev >= threshold && current < threshold
+}
+
+// CreditLowEvent is fired once when a user's credit balance crosses below the
+// low-balance threshold (downward edge only — hysteresis is enforced by the
+// caller so a hovering balance does not spam). It is fanned out through the
+// user's enabled channels like a failure alert.
+type CreditLowEvent struct {
+	UserID string
+	// Balance is the credit balance at the moment of the crossing.
+	Balance int64
+	// Threshold is the floor the balance dropped below.
+	Threshold int64
+	// RecentBurn is the number of credits spent over the trailing window
+	// (see CreditLowBurnWindow), used to hint how soon the user runs dry.
+	RecentBurn int64
+	// TopUpURL is where the user can add credits.
+	TopUpURL string
+	CrossedAt time.Time
+}
 
 // AlertEvent is the failure that triggers alert delivery. It is assembled by the
 // scheduler at the moment a job or buffer item is marked permanently failed and

--- a/internal/emailverify/token.go
+++ b/internal/emailverify/token.go
@@ -1,0 +1,97 @@
+// Package emailverify mints and validates the signed confirm tokens that gate
+// email alert channels. A token binds an alert-channel ID to an expiry and is
+// signed with an HMAC secret (the same JWT_SECRET used for local auth), so the
+// verify endpoint can trust a link it handed out without a DB round-trip to
+// look the token up.
+package emailverify
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+)
+
+// DefaultTTL is how long a confirm link stays valid.
+const DefaultTTL = 48 * time.Hour
+
+// Signer mints and validates confirm tokens with an HMAC-SHA256 secret.
+type Signer struct {
+	secret []byte
+	ttl    time.Duration
+	now    func() time.Time
+}
+
+// NewSigner returns a Signer keyed by secret (e.g. the JWT_SECRET bytes).
+func NewSigner(secret []byte) *Signer {
+	return &Signer{secret: secret, ttl: DefaultTTL, now: time.Now}
+}
+
+// Sign returns a confirm token binding channelID to an expiry DefaultTTL from
+// now. Format: base64url(channelID) "." base64url(expiryUnix) "." base64url(mac).
+func (s *Signer) Sign(channelID string) string {
+	exp := s.now().Add(s.ttl).Unix()
+	idPart := b64(channelID)
+	expPart := b64(strconv.FormatInt(exp, 10))
+	payload := idPart + "." + expPart
+	return payload + "." + b64Bytes(s.mac(payload))
+}
+
+// Verify checks the token's signature and expiry and returns the channel ID it
+// was issued for. It returns domain.ErrInvalidVerificationToken for any
+// malformed, tampered, or expired token.
+func (s *Signer) Verify(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", domain.ErrInvalidVerificationToken
+	}
+	payload := parts[0] + "." + parts[1]
+
+	gotMAC, err := unb64(parts[2])
+	if err != nil {
+		return "", domain.ErrInvalidVerificationToken
+	}
+	if subtle.ConstantTimeCompare(gotMAC, s.mac(payload)) != 1 {
+		return "", domain.ErrInvalidVerificationToken
+	}
+
+	expBytes, err := unb64(parts[1])
+	if err != nil {
+		return "", domain.ErrInvalidVerificationToken
+	}
+	exp, err := strconv.ParseInt(string(expBytes), 10, 64)
+	if err != nil {
+		return "", domain.ErrInvalidVerificationToken
+	}
+	if s.now().After(time.Unix(exp, 0)) {
+		return "", domain.ErrInvalidVerificationToken
+	}
+
+	idBytes, err := unb64(parts[0])
+	if err != nil {
+		return "", domain.ErrInvalidVerificationToken
+	}
+	return string(idBytes), nil
+}
+
+func (s *Signer) mac(payload string) []byte {
+	h := hmac.New(sha256.New, s.secret)
+	h.Write([]byte(payload))
+	return h.Sum(nil)
+}
+
+func b64(s string) string          { return base64.RawURLEncoding.EncodeToString([]byte(s)) }
+func b64Bytes(b []byte) string     { return base64.RawURLEncoding.EncodeToString(b) }
+func unb64(s string) ([]byte, error) {
+	b, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("decode token part: %w", err)
+	}
+	return b, nil
+}

--- a/internal/http/handler/alert.go
+++ b/internal/http/handler/alert.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/mail"
+	"net/url"
 	"time"
 
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
@@ -21,9 +23,23 @@ func NewAlertHandler(uc *usecase.AlertUsecase, logger *slog.Logger) *AlertHandle
 }
 
 type createAlertChannelRequest struct {
-	Type   domain.AlertChannelType `json:"type"   binding:"required,oneof=webhook slack"`
-	Target string                  `json:"target" binding:"required,url,max=2048"`
+	// Target is validated per-type in validateTarget (URL for webhook/slack, an
+	// email address for email) rather than with a single binding tag, since the
+	// two shapes are mutually exclusive.
+	Type   domain.AlertChannelType `json:"type"   binding:"required,oneof=webhook slack email"`
+	Target string                  `json:"target" binding:"required,max=2048"`
 	Name   string                  `json:"name"   binding:"omitempty,max=256"`
+}
+
+// validateTarget enforces the target shape for the channel type: a parseable
+// http(s) URL for webhook/slack, a valid address for email.
+func validateTarget(t domain.AlertChannelType, target string) bool {
+	if t == domain.AlertChannelEmail {
+		_, err := mail.ParseAddress(target)
+		return err == nil
+	}
+	u, err := url.Parse(target)
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
 }
 
 type updateAlertChannelRequest struct {
@@ -36,6 +52,7 @@ type alertChannelResponse struct {
 	Target    string                  `json:"target"`
 	Name      string                  `json:"name"`
 	Enabled   bool                    `json:"enabled"`
+	Verified  bool                    `json:"verified"`
 	CreatedAt time.Time               `json:"created_at"`
 	UpdatedAt time.Time               `json:"updated_at"`
 }
@@ -47,6 +64,7 @@ func toAlertChannelResponse(ch *domain.AlertChannel) alertChannelResponse {
 		Target:    ch.Target,
 		Name:      ch.Name,
 		Enabled:   ch.Enabled,
+		Verified:  ch.Verified,
 		CreatedAt: ch.CreatedAt,
 		UpdatedAt: ch.UpdatedAt,
 	}
@@ -56,6 +74,11 @@ func (h *AlertHandler) Create(ctx *gin.Context) {
 	var req createAlertChannelRequest
 	if err := ctx.ShouldBindJSON(&req); err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": formatValidationError(err)})
+		return
+	}
+
+	if !validateTarget(req.Type, req.Target) {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidAlertTarget})
 		return
 	}
 
@@ -124,12 +147,39 @@ func (h *AlertHandler) Update(ctx *gin.Context) {
 			ctx.JSON(http.StatusNotFound, gin.H{"error": errAlertChannelNotFound})
 			return
 		}
+		if errors.Is(err, domain.ErrAlertChannelNotVerified) {
+			ctx.JSON(http.StatusConflict, gin.H{"error": errAlertChannelNotVerified})
+			return
+		}
 		h.logger.ErrorContext(ctx.Request.Context(), "update alert channel", "channel_id", id, "error", err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
 		return
 	}
 
 	ctx.Status(http.StatusNoContent)
+}
+
+// Verify confirms an email alert channel from a signed token in the query
+// string and enables it. Public (the token is the credential) — registered
+// outside the authenticated /alerts group.
+func (h *AlertHandler) Verify(ctx *gin.Context) {
+	token := ctx.Query("token")
+	if token == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidVerifyToken})
+		return
+	}
+
+	if err := h.uc.VerifyChannel(ctx.Request.Context(), token); err != nil {
+		if errors.Is(err, domain.ErrInvalidVerificationToken) || errors.Is(err, domain.ErrAlertChannelNotFound) {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidVerifyToken})
+			return
+		}
+		h.logger.ErrorContext(ctx.Request.Context(), "verify alert channel", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"status": "verified"})
 }
 
 func (h *AlertHandler) Delete(ctx *gin.Context) {

--- a/internal/http/handler/alert_test.go
+++ b/internal/http/handler/alert_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/emailverify"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/handler"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
@@ -17,10 +18,12 @@ import (
 )
 
 func setupAlertRouter(repo *testutil.MockAlertChannelRepository) *gin.Engine {
-	uc := usecase.NewAlertUsecase(repo)
+	uc := usecase.NewAlertUsecase(repo, &testutil.FakeMailer{},
+		emailverify.NewSigner([]byte("test-secret-32-chars-long-xxxxxx")), "https://api.fliq.test")
 	h := handler.NewAlertHandler(uc, slog.Default())
 
 	r := gin.New()
+	r.GET("/alerts/verify", h.Verify)
 	g := r.Group("/", injectUser(testUserID))
 	g.POST("/alerts", h.Create)
 	g.GET("/alerts", h.List)
@@ -61,7 +64,7 @@ func TestCreateAlertChannel_HappyPath(t *testing.T) {
 func TestCreateAlertChannel_InvalidTypeRejectedByBinding(t *testing.T) {
 	r := setupAlertRouter(&testutil.MockAlertChannelRepository{})
 
-	body := `{"type":"email","target":"ops@example.com"}`
+	body := `{"type":"carrier_pigeon","target":"coop-3"}`
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/alerts", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -69,6 +72,82 @@ func TestCreateAlertChannel_InvalidTypeRejectedByBinding(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestCreateAlertChannel_Email_AcceptedAndDisabled(t *testing.T) {
+	var saved *domain.AlertChannel
+	repo := &testutil.MockAlertChannelRepository{
+		CreateFn: func(_ context.Context, ch *domain.AlertChannel) (*domain.AlertChannel, error) {
+			ch.ID = "alert-email"
+			saved = ch
+			return ch, nil
+		},
+	}
+	r := setupAlertRouter(repo)
+
+	body := `{"type":"email","target":"ops@example.com"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/alerts", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+	if saved.Enabled || saved.Verified {
+		t.Error("email channel should be created disabled + unverified")
+	}
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["enabled"] != false || resp["verified"] != false {
+		t.Errorf("enabled=%v verified=%v, want false/false", resp["enabled"], resp["verified"])
+	}
+}
+
+func TestCreateAlertChannel_EmailRejectsBadAddress(t *testing.T) {
+	r := setupAlertRouter(&testutil.MockAlertChannelRepository{})
+
+	body := `{"type":"email","target":"https://not-an-email.example.com"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/alerts", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestVerifyAlertChannel_Endpoint(t *testing.T) {
+	var verified string
+	repo := &testutil.MockAlertChannelRepository{
+		MarkVerifiedFn: func(_ context.Context, id string) error { verified = id; return nil },
+	}
+	r := setupAlertRouter(repo)
+
+	token := emailverify.NewSigner([]byte("test-secret-32-chars-long-xxxxxx")).Sign("chan-1")
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/alerts/verify?token="+token, nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	if verified != "chan-1" {
+		t.Errorf("verified = %q, want chan-1", verified)
+	}
+}
+
+func TestVerifyAlertChannel_BadToken(t *testing.T) {
+	r := setupAlertRouter(&testutil.MockAlertChannelRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/alerts/verify?token=garbage", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
 	}
 }
 

--- a/internal/http/handler/errors.go
+++ b/internal/http/handler/errors.go
@@ -32,6 +32,9 @@ const (
 
 	errAlertChannelNotFound    = "Alert channel not found"
 	errInvalidAlertChannelType = "Invalid alert channel type"
+	errAlertChannelNotVerified = "Email alert channels must be verified before they can be enabled"
+	errInvalidAlertTarget      = "target must be a URL for webhook/slack channels or an email address for email channels"
+	errInvalidVerifyToken      = "Verification link is invalid or expired"
 
 	errInvalidDays = "days must be a non-negative integer"
 )

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -56,6 +56,11 @@ func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHand
 	buffers.GET("/:id/items/:itemId", bufferHandler.GetItem)
 	buffers.POST("/:id/items/:itemId/replay", bufferHandler.ReplayItem)
 
+	// Public email-verification confirm endpoint. No auth: the signed token in
+	// the query string is the credential. Registered before the param route so
+	// "verify" is matched as a static segment, not as an :id.
+	r.GET("/alerts/verify", alertHandler.Verify)
+
 	// Protected alert channel routes
 	alerts := r.Group("/alerts", authMW, ensureUser, rateLimiter.Middleware())
 	alerts.POST("", alertHandler.Create)

--- a/internal/infrastructure/postgres/alert_repo.go
+++ b/internal/infrastructure/postgres/alert_repo.go
@@ -20,17 +20,17 @@ func NewAlertChannelRepository(pool *pgxpool.Pool) *AlertChannelRepository {
 
 func (r *AlertChannelRepository) Create(ctx context.Context, ch *domain.AlertChannel) (*domain.AlertChannel, error) {
 	query := `
-		INSERT INTO alert_channels (user_id, type, target, name, enabled)
-		VALUES ($1, $2, $3, $4, $5)
-		RETURNING id, user_id, type, target, name, enabled, created_at, updated_at`
+		INSERT INTO alert_channels (user_id, type, target, name, enabled, verified)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, user_id, type, target, name, enabled, verified, created_at, updated_at`
 
-	row := r.pool.QueryRow(ctx, query, ch.UserID, ch.Type, ch.Target, ch.Name, ch.Enabled)
+	row := r.pool.QueryRow(ctx, query, ch.UserID, ch.Type, ch.Target, ch.Name, ch.Enabled, ch.Verified)
 	return scanAlertChannel(row)
 }
 
 func (r *AlertChannelRepository) GetByID(ctx context.Context, id, userID string) (*domain.AlertChannel, error) {
 	query := `
-		SELECT id, user_id, type, target, name, enabled, created_at, updated_at
+		SELECT id, user_id, type, target, name, enabled, verified, created_at, updated_at
 		FROM alert_channels
 		WHERE id = $1 AND user_id = $2`
 
@@ -40,7 +40,7 @@ func (r *AlertChannelRepository) GetByID(ctx context.Context, id, userID string)
 
 func (r *AlertChannelRepository) List(ctx context.Context, userID string) ([]*domain.AlertChannel, error) {
 	return r.list(ctx, `
-		SELECT id, user_id, type, target, name, enabled, created_at, updated_at
+		SELECT id, user_id, type, target, name, enabled, verified, created_at, updated_at
 		FROM alert_channels
 		WHERE user_id = $1
 		ORDER BY created_at DESC, id DESC`, userID)
@@ -48,7 +48,7 @@ func (r *AlertChannelRepository) List(ctx context.Context, userID string) ([]*do
 
 func (r *AlertChannelRepository) ListEnabled(ctx context.Context, userID string) ([]*domain.AlertChannel, error) {
 	return r.list(ctx, `
-		SELECT id, user_id, type, target, name, enabled, created_at, updated_at
+		SELECT id, user_id, type, target, name, enabled, verified, created_at, updated_at
 		FROM alert_channels
 		WHERE user_id = $1 AND enabled
 		ORDER BY created_at DESC, id DESC`, userID)
@@ -102,9 +102,25 @@ func (r *AlertChannelRepository) Delete(ctx context.Context, id, userID string) 
 	return nil
 }
 
+// MarkVerified flips an email channel to verified + enabled. Keyed by id only —
+// the caller holds a signed confirm token, not a session. Idempotent.
+func (r *AlertChannelRepository) MarkVerified(ctx context.Context, id string) error {
+	tag, err := r.pool.Exec(ctx,
+		`UPDATE alert_channels SET verified = TRUE, enabled = TRUE, updated_at = NOW()
+		 WHERE id = $1`,
+		id)
+	if err != nil {
+		return fmt.Errorf("mark alert channel verified: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return domain.ErrAlertChannelNotFound
+	}
+	return nil
+}
+
 func scanAlertChannel(row rowScanner) (*domain.AlertChannel, error) {
 	var ch domain.AlertChannel
-	err := row.Scan(&ch.ID, &ch.UserID, &ch.Type, &ch.Target, &ch.Name, &ch.Enabled, &ch.CreatedAt, &ch.UpdatedAt)
+	err := row.Scan(&ch.ID, &ch.UserID, &ch.Type, &ch.Target, &ch.Name, &ch.Enabled, &ch.Verified, &ch.CreatedAt, &ch.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, domain.ErrAlertChannelNotFound

--- a/internal/infrastructure/postgres/billing_repo.go
+++ b/internal/infrastructure/postgres/billing_repo.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -68,9 +69,10 @@ func (r *CreditRepo) HasCredits(ctx context.Context, userID string) (bool, error
 	var dailyLimit int64
 	tag, refreshErr := tx.Exec(ctx,
 		`UPDATE user_credits
-		 SET balance          = daily_free_limit,
-		     refreshed_at     = NOW(),
-		     updated_at       = NOW()
+		 SET balance              = daily_free_limit,
+		     low_balance_notified = FALSE,
+		     refreshed_at         = NOW(),
+		     updated_at           = NOW()
 		 WHERE user_id = $1
 		   AND plan    = 'free'
 		   AND DATE(refreshed_at AT TIME ZONE 'UTC') < CURRENT_DATE`,
@@ -123,21 +125,28 @@ func (r *CreditRepo) HasCredits(ctx context.Context, userID string) (bool, error
 	return balance > 0, nil
 }
 
-func (r *CreditRepo) Deduct(ctx context.Context, userID, jobID string) error {
-	return r.deduct(ctx, userID, domain.CreditTxJobExecution, "job_id", jobID)
+func (r *CreditRepo) Deduct(ctx context.Context, userID, jobID string, threshold int64) (*repository.LowBalanceCrossing, error) {
+	return r.deduct(ctx, userID, domain.CreditTxJobExecution, "job_id", jobID, threshold)
 }
 
-func (r *CreditRepo) DeductForBufferItem(ctx context.Context, userID, bufferItemID string) error {
-	return r.deduct(ctx, userID, domain.CreditTxBufferExecution, "buffer_item_id", bufferItemID)
+func (r *CreditRepo) DeductForBufferItem(ctx context.Context, userID, bufferItemID string, threshold int64) (*repository.LowBalanceCrossing, error) {
+	return r.deduct(ctx, userID, domain.CreditTxBufferExecution, "buffer_item_id", bufferItemID, threshold)
 }
 
 // deduct subtracts 1 credit and records a ledger row referencing refColumn (a
 // jobs or buffer_items FK). Per-attempt billing: not idempotent, no uniqueness
 // on the reference column.
-func (r *CreditRepo) deduct(ctx context.Context, userID string, txType domain.CreditTxType, refColumn, refID string) error {
+//
+// It also detects a downward crossing of the low-balance threshold. The UPDATE
+// returns the new balance and atomically flips low_balance_notified TRUE only on
+// the crossing edge (new balance below threshold, old balance at-or-above it,
+// latch not already set). Because the latch flip is part of the same UPDATE,
+// concurrent workers race on a single row and exactly one observes the
+// crossing — the others see low_balance_notified already TRUE and return nil.
+func (r *CreditRepo) deduct(ctx context.Context, userID string, txType domain.CreditTxType, refColumn, refID string, threshold int64) (crossing *repository.LowBalanceCrossing, err error) {
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return nil, fmt.Errorf("begin tx: %w", err)
 	}
 	defer func() {
 		if err != nil {
@@ -145,12 +154,23 @@ func (r *CreditRepo) deduct(ctx context.Context, userID string, txType domain.Cr
 		}
 	}()
 
-	_, err = tx.Exec(ctx,
-		`UPDATE user_credits SET balance = balance - 1, updated_at = NOW() WHERE user_id = $1`,
-		userID,
-	)
+	// The CTE flips the latch and returns whether this UPDATE was the crossing
+	// edge. crossed is TRUE for exactly one concurrent deduction.
+	var newBalance int64
+	var crossed bool
+	err = tx.QueryRow(ctx,
+		`UPDATE user_credits
+		 SET balance              = balance - 1,
+		     low_balance_notified = low_balance_notified
+		         OR ($2 > 0 AND balance - 1 < $2 AND NOT low_balance_notified),
+		     updated_at           = NOW()
+		 WHERE user_id = $1
+		 RETURNING balance,
+		           ($2 > 0 AND balance < $2 AND balance + 1 >= $2)`,
+		userID, threshold,
+	).Scan(&newBalance, &crossed)
 	if err != nil {
-		return fmt.Errorf("deduct credit: %w", err)
+		return nil, fmt.Errorf("deduct credit: %w", err)
 	}
 
 	_, err = tx.Exec(ctx,
@@ -159,13 +179,29 @@ func (r *CreditRepo) deduct(ctx context.Context, userID string, txType domain.Cr
 		userID, txType, refID,
 	)
 	if err != nil {
-		return fmt.Errorf("insert deduct tx: %w", err)
+		return nil, fmt.Errorf("insert deduct tx: %w", err)
+	}
+
+	if crossed {
+		var burn int64
+		// Trailing-window burn (sum of consumption, reported positive).
+		scanErr := tx.QueryRow(ctx,
+			`SELECT COALESCE(-SUM(amount), 0)
+			 FROM credit_transactions
+			 WHERE user_id = $1 AND amount < 0 AND created_at >= NOW() - make_interval(secs => $2)`,
+			userID, int64(domain.CreditLowBurnWindow.Seconds()),
+		).Scan(&burn)
+		if scanErr != nil {
+			err = scanErr
+			return nil, fmt.Errorf("sum recent burn: %w", err)
+		}
+		crossing = &repository.LowBalanceCrossing{Balance: newBalance, Threshold: threshold, RecentBurn: burn}
 	}
 
 	if err = tx.Commit(ctx); err != nil {
-		return fmt.Errorf("commit: %w", err)
+		return nil, fmt.Errorf("commit: %w", err)
 	}
-	return nil
+	return crossing, nil
 }
 
 func (r *CreditRepo) TopUp(ctx context.Context, userID string, amount int64, stripePaymentIntentID string) error {
@@ -180,7 +216,9 @@ func (r *CreditRepo) TopUp(ctx context.Context, userID string, amount int64, str
 	}()
 
 	_, err = tx.Exec(ctx,
-		`UPDATE user_credits SET balance = balance + $2, updated_at = NOW() WHERE user_id = $1`,
+		`UPDATE user_credits
+		 SET balance = balance + $2, low_balance_notified = FALSE, updated_at = NOW()
+		 WHERE user_id = $1`,
 		userID, amount,
 	)
 	if err != nil {

--- a/internal/infrastructure/postgres/billing_repo_buffer_integration_test.go
+++ b/internal/infrastructure/postgres/billing_repo_buffer_integration_test.go
@@ -50,7 +50,7 @@ func TestBillingRepo_DeductForBufferItem(t *testing.T) {
 	itemID := seedBufferItem(t, pool, userID)
 
 	balanceBefore, _ := repo.GetBalance(ctx, userID)
-	if err := repo.DeductForBufferItem(ctx, userID, itemID); err != nil {
+	if _, err := repo.DeductForBufferItem(ctx, userID, itemID, 0); err != nil {
 		t.Fatalf("deduct for buffer item: %v", err)
 	}
 	balanceAfter, _ := repo.GetBalance(ctx, userID)
@@ -83,7 +83,7 @@ func TestBillingRepo_DeductForBufferItem_PerAttempt(t *testing.T) {
 
 	balanceBefore, _ := repo.GetBalance(ctx, userID)
 	for i := 0; i < 2; i++ {
-		if err := repo.DeductForBufferItem(ctx, userID, itemID); err != nil {
+		if _, err := repo.DeductForBufferItem(ctx, userID, itemID, 0); err != nil {
 			t.Fatalf("deduct attempt %d: %v", i, err)
 		}
 	}

--- a/internal/infrastructure/postgres/billing_repo_integration_test.go
+++ b/internal/infrastructure/postgres/billing_repo_integration_test.go
@@ -82,7 +82,7 @@ func TestBillingRepo_Deduct(t *testing.T) {
 	}
 
 	balanceBefore, _ := repo.GetBalance(ctx, userID)
-	if err := repo.Deduct(ctx, userID, created.ID); err != nil {
+	if _, err := repo.Deduct(ctx, userID, created.ID, 0); err != nil {
 		t.Fatalf("deduct: %v", err)
 	}
 	balanceAfter, _ := repo.GetBalance(ctx, userID)
@@ -149,7 +149,7 @@ func TestBillingRepo_ListTransactions_Pagination(t *testing.T) {
 		if err != nil {
 			t.Fatalf("create job %d: %v", i, err)
 		}
-		if err := repo.Deduct(ctx, userID, created.ID); err != nil {
+		if _, err := repo.Deduct(ctx, userID, created.ID, 0); err != nil {
 			t.Fatalf("deduct %d: %v", i, err)
 		}
 	}

--- a/internal/infrastructure/postgres/billing_repo_integration_test.go
+++ b/internal/infrastructure/postgres/billing_repo_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func setupBillingRepo(t *testing.T) (*postgres.CreditRepo, string) {
@@ -176,5 +177,109 @@ func TestBillingRepo_ListTransactions_Pagination(t *testing.T) {
 	}
 	if cursor2 != "" {
 		t.Fatalf("expected empty cursor on last page, got %s", cursor2)
+	}
+}
+
+// setBalance forces a user's credit balance for threshold-crossing tests.
+func setBalance(t *testing.T, pool *pgxpool.Pool, userID string, balance int64) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE user_credits SET balance = $2 WHERE user_id = $1`, userID, balance,
+	); err != nil {
+		t.Fatalf("set balance: %v", err)
+	}
+}
+
+// TestBillingRepo_Deduct_LowBalanceCrossing exercises the latch-based crossing
+// detection in deduct(): a crossing fires exactly once on the downward edge,
+// stays silent below the threshold, and re-arms after a top-up.
+func TestBillingRepo_Deduct_LowBalanceCrossing(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	repo := postgres.NewCreditRepository(pool)
+	jobRepo := postgres.NewJobRepository(pool)
+	ctx := context.Background()
+
+	const threshold int64 = 5
+
+	mkJob := func() string {
+		t.Helper()
+		created, err := jobRepo.Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
+		if err != nil {
+			t.Fatalf("create job: %v", err)
+		}
+		return created.ID
+	}
+
+	// Sitting exactly at the threshold; the next deduction crosses it.
+	setBalance(t, pool, userID, threshold)
+
+	crossing, err := repo.Deduct(ctx, userID, mkJob(), threshold)
+	if err != nil {
+		t.Fatalf("deduct (crossing): %v", err)
+	}
+	if crossing == nil {
+		t.Fatal("expected a low-balance crossing, got nil")
+	}
+	if crossing.Balance != threshold-1 {
+		t.Fatalf("crossing balance = %d, want %d", crossing.Balance, threshold-1)
+	}
+	if crossing.Threshold != threshold {
+		t.Fatalf("crossing threshold = %d, want %d", crossing.Threshold, threshold)
+	}
+	if crossing.RecentBurn < 1 {
+		t.Fatalf("crossing recent burn = %d, want >= 1", crossing.RecentBurn)
+	}
+
+	// Already below the threshold: the latch is set, so no further crossing.
+	crossing2, err := repo.Deduct(ctx, userID, mkJob(), threshold)
+	if err != nil {
+		t.Fatalf("deduct (latched): %v", err)
+	}
+	if crossing2 != nil {
+		t.Fatalf("expected no second crossing while latched, got %+v", crossing2)
+	}
+
+	// A top-up re-arms the latch; dropping back to the threshold crosses again.
+	if err := repo.TopUp(ctx, userID, 100, "pi_test_lowbalance"); err != nil {
+		t.Fatalf("top up: %v", err)
+	}
+	setBalance(t, pool, userID, threshold)
+
+	crossing3, err := repo.Deduct(ctx, userID, mkJob(), threshold)
+	if err != nil {
+		t.Fatalf("deduct (re-armed): %v", err)
+	}
+	if crossing3 == nil {
+		t.Fatal("expected crossing to re-fire after top-up, got nil")
+	}
+}
+
+// TestBillingRepo_Deduct_ThresholdDisabled confirms a zero threshold never
+// reports a crossing, even as the balance falls through small values.
+func TestBillingRepo_Deduct_ThresholdDisabled(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	repo := postgres.NewCreditRepository(pool)
+	jobRepo := postgres.NewJobRepository(pool)
+	ctx := context.Background()
+
+	setBalance(t, pool, userID, 2)
+	for i := 0; i < 2; i++ {
+		created, err := jobRepo.Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
+		if err != nil {
+			t.Fatalf("create job: %v", err)
+		}
+		crossing, err := repo.Deduct(ctx, userID, created.ID, 0)
+		if err != nil {
+			t.Fatalf("deduct %d: %v", i, err)
+		}
+		if crossing != nil {
+			t.Fatalf("threshold 0 must never cross, got %+v", crossing)
+		}
 	}
 }

--- a/internal/infrastructure/postgres/stats_repo_integration_test.go
+++ b/internal/infrastructure/postgres/stats_repo_integration_test.go
@@ -113,14 +113,14 @@ func TestStatsRepo_UsageSeries(t *testing.T) {
 	// 2 job executions + 1 buffer execution, all today.
 	job1, _ := postgres.NewJobRepository(pool).Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
 	job2, _ := postgres.NewJobRepository(pool).Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
-	if err := creditRepo.Deduct(ctx, userID, job1.ID); err != nil {
+	if _, err := creditRepo.Deduct(ctx, userID, job1.ID, 0); err != nil {
 		t.Fatalf("deduct job1: %v", err)
 	}
-	if err := creditRepo.Deduct(ctx, userID, job2.ID); err != nil {
+	if _, err := creditRepo.Deduct(ctx, userID, job2.ID, 0); err != nil {
 		t.Fatalf("deduct job2: %v", err)
 	}
 	itemID := seedBufferItem(t, pool, userID)
-	if err := creditRepo.DeductForBufferItem(ctx, userID, itemID); err != nil {
+	if _, err := creditRepo.DeductForBufferItem(ctx, userID, itemID, 0); err != nil {
 		t.Fatalf("deduct buffer item: %v", err)
 	}
 

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -1,0 +1,53 @@
+// Package mailer is the outbound port for transactional email. It defines the
+// Provider interface consumed by the alert usecase (verification emails) and
+// the scheduler's AlertNotifier (failure / low-balance emails), plus a Resend
+// implementation and a no-op fallback used when no provider is configured.
+//
+// The no-op mirrors the nil-AlertNotifier convention: email alerting is an
+// opt-in dependency the service can run without. Callers should never assume an
+// email was actually delivered — like the other channel types, delivery is
+// best-effort.
+package mailer
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Email is a single transactional message.
+type Email struct {
+	To      string
+	Subject string
+	// Text is the plain-text body. HTML is intentionally omitted — alert and
+	// verification mails are short and render fine as text, and skipping HTML
+	// keeps the provider surface minimal.
+	Text string
+}
+
+// Provider sends transactional email. Implementations must be safe for
+// concurrent use.
+type Provider interface {
+	// Send delivers msg. It returns an error only for a definitive failure to
+	// hand the message to the provider; callers treat email as best-effort and
+	// log rather than propagate.
+	Send(ctx context.Context, msg Email) error
+}
+
+// NoopProvider is the fallback Provider used when no mail credentials are
+// configured. It logs at debug level and reports success without sending.
+type NoopProvider struct {
+	logger *slog.Logger
+}
+
+// NewNoopProvider returns a Provider that drops every message. Used when
+// RESEND_API_KEY is unset so the rest of the system behaves identically whether
+// or not email is wired up.
+func NewNoopProvider(logger *slog.Logger) *NoopProvider {
+	return &NoopProvider{logger: logger.With("component", "mailer", "provider", "noop")}
+}
+
+func (p *NoopProvider) Send(ctx context.Context, msg Email) error {
+	p.logger.DebugContext(ctx, "email dropped (no mail provider configured)",
+		"to", msg.To, "subject", msg.Subject)
+	return nil
+}

--- a/internal/mailer/resend.go
+++ b/internal/mailer/resend.go
@@ -1,0 +1,79 @@
+package mailer
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// resendEndpoint is the Resend transactional-email API. The host is fixed and
+// provider-owned, so no SSRF-safe dialer is needed (unlike user-supplied
+// webhook targets).
+const resendEndpoint = "https://api.resend.com/emails"
+
+// ResendProvider sends email via the Resend HTTP API (https://resend.com).
+type ResendProvider struct {
+	apiKey string
+	from   string
+	client *http.Client
+}
+
+// NewResendProvider returns a Provider backed by Resend. apiKey is the
+// RESEND_API_KEY secret; from is the verified sender address (ALERT_EMAIL_FROM).
+func NewResendProvider(apiKey, from string) *ResendProvider {
+	return &ResendProvider{
+		apiKey: apiKey,
+		from:   from,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+			},
+		},
+	}
+}
+
+type resendRequest struct {
+	From    string   `json:"from"`
+	To      []string `json:"to"`
+	Subject string   `json:"subject"`
+	Text    string   `json:"text"`
+}
+
+func (p *ResendProvider) Send(ctx context.Context, msg Email) error {
+	body, err := json.Marshal(resendRequest{
+		From:    p.from,
+		To:      []string{msg.To},
+		Subject: msg.Subject,
+		Text:    msg.Text,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal resend request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resendEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build resend request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("resend send: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("resend send: unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/repository/alert.go
+++ b/internal/repository/alert.go
@@ -15,7 +15,15 @@ type AlertChannelRepository interface {
 	SetEnabled(ctx context.Context, id, userID string, enabled bool) error
 	Delete(ctx context.Context, id, userID string) error
 
+	// MarkVerified flips an email channel to verified + enabled. It is keyed by
+	// id alone (no user scope): the caller proves ownership by holding a signed
+	// confirm token, not a session. Returns domain.ErrAlertChannelNotFound if no
+	// such channel exists. Idempotent — re-confirming a verified channel is a
+	// no-op success.
+	MarkVerified(ctx context.Context, id string) error
+
 	// ListEnabled returns the user's enabled channels. Called by the scheduler
-	// when a job or buffer item is permanently failed, to fan out the alert.
+	// when a job or buffer item is permanently failed, or on a low-balance
+	// crossing, to fan out the alert.
 	ListEnabled(ctx context.Context, userID string) ([]*domain.AlertChannel, error)
 }

--- a/internal/repository/billing.go
+++ b/internal/repository/billing.go
@@ -6,6 +6,19 @@ import (
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
 )
 
+// LowBalanceCrossing reports a downward crossing of the low-balance threshold,
+// returned by Deduct/DeductForBufferItem when the deduction that just ran took
+// the balance below the threshold for the first time since the last top-up.
+type LowBalanceCrossing struct {
+	// Balance is the balance after the deduction (at the moment of crossing).
+	Balance int64
+	// Threshold is the floor that was crossed.
+	Threshold int64
+	// RecentBurn is the credits spent over the trailing
+	// domain.CreditLowBurnWindow, for the "you'll run dry in ~N" hint.
+	RecentBurn int64
+}
+
 // CreditRepository manages per-user credit balances and the immutable audit ledger.
 type CreditRepository interface {
 	// EnsureExists inserts a default credit row for the user if one does not already exist.
@@ -25,12 +38,20 @@ type CreditRepository interface {
 	// Called after every execution attempt (success or failure). A brief
 	// negative balance is acceptable; the creation gate (HasCredits) prevents
 	// sustained overdraft.
-	Deduct(ctx context.Context, userID, jobID string) error
+	//
+	// threshold is the low-balance warning floor (0 disables it). When this
+	// deduction takes the balance from at-or-above threshold to below it — and
+	// the user has not already been notified for this crossing — a non-nil
+	// LowBalanceCrossing is returned so the caller can fan out a credit_low
+	// alert. The hysteresis latch is updated atomically in the same transaction,
+	// so concurrent workers fire at most once per crossing.
+	Deduct(ctx context.Context, userID, jobID string, threshold int64) (*LowBalanceCrossing, error)
 
 	// DeductForBufferItem subtracts 1 credit and records a buffer_item_execution
 	// transaction. Like Deduct, it is called once per execution attempt (success
-	// or failure) and is intentionally not idempotent.
-	DeductForBufferItem(ctx context.Context, userID, bufferItemID string) error
+	// or failure), is intentionally not idempotent, and reports a low-balance
+	// crossing under the same hysteresis rules.
+	DeductForBufferItem(ctx context.Context, userID, bufferItemID string, threshold int64) (*LowBalanceCrossing, error)
 
 	// TopUp adds credits and records a stripe_topup transaction. Called by the
 	// Stripe webhook handler on checkout.session.completed.

--- a/internal/scheduler/alert.go
+++ b/internal/scheduler/alert.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/mailer"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/metrics"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/safedialer"
@@ -36,12 +37,13 @@ type alertWebhookPayload struct {
 // permanently failed.
 type AlertNotifier struct {
 	client *http.Client
+	mailer mailer.Provider
 	repo   repository.AlertChannelRepository
 	logger *slog.Logger
 }
 
-func NewAlertNotifier(logger *slog.Logger, repo repository.AlertChannelRepository) *AlertNotifier {
-	return newAlertNotifier(logger, repo, &http.Client{
+func NewAlertNotifier(logger *slog.Logger, repo repository.AlertChannelRepository, mail mailer.Provider) *AlertNotifier {
+	return newAlertNotifier(logger, repo, mail, &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
@@ -52,9 +54,10 @@ func NewAlertNotifier(logger *slog.Logger, repo repository.AlertChannelRepositor
 
 // newAlertNotifier lets tests inject a client without the SSRF-safe dialer so
 // they can deliver to a loopback httptest server.
-func newAlertNotifier(logger *slog.Logger, repo repository.AlertChannelRepository, client *http.Client) *AlertNotifier {
+func newAlertNotifier(logger *slog.Logger, repo repository.AlertChannelRepository, mail mailer.Provider, client *http.Client) *AlertNotifier {
 	return &AlertNotifier{
 		client: client,
+		mailer: mail,
 		repo:   repo,
 		logger: logger.With("component", "alert_notifier"),
 	}
@@ -76,6 +79,60 @@ func (n *AlertNotifier) NotifyFailureAsync(ctx context.Context, event domain.Ale
 	}()
 }
 
+// LowBalanceConfig carries the low-balance warning settings the worker and
+// drainer pass through to the credit repo and the credit_low event. Threshold
+// of 0 disables the warning entirely.
+type LowBalanceConfig struct {
+	Threshold int64
+	TopUpURL  string
+}
+
+// fireCreditLow builds and fans out a credit_low event from a deduction's
+// low-balance crossing. No-op when crossing or the notifier is nil.
+func fireCreditLow(ctx context.Context, alerts *AlertNotifier, cfg LowBalanceConfig, userID string, crossing *repository.LowBalanceCrossing) {
+	if crossing == nil {
+		return
+	}
+	alerts.NotifyCreditLowAsync(ctx, domain.CreditLowEvent{
+		UserID:     userID,
+		Balance:    crossing.Balance,
+		Threshold:  crossing.Threshold,
+		RecentBurn: crossing.RecentBurn,
+		TopUpURL:   cfg.TopUpURL,
+		CrossedAt:  time.Now(),
+	})
+}
+
+// NotifyCreditLowAsync loads the user's enabled channels and delivers a
+// low-balance warning to each in a background goroutine. Best-effort, like
+// NotifyFailureAsync. Safe to call on a nil receiver.
+func (n *AlertNotifier) NotifyCreditLowAsync(ctx context.Context, event domain.CreditLowEvent) {
+	if n == nil {
+		return
+	}
+	go func() {
+		dctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+		n.notifyCreditLow(dctx, event)
+	}()
+}
+
+func (n *AlertNotifier) notifyCreditLow(ctx context.Context, event domain.CreditLowEvent) {
+	channels, err := n.repo.ListEnabled(ctx, event.UserID)
+	if err != nil {
+		n.logger.WarnContext(ctx, "load alert channels failed", "user_id", event.UserID, "error", err)
+		return
+	}
+	for _, ch := range channels {
+		body, buildErr := buildCreditLowBody(ch.Type, event)
+		if buildErr != nil {
+			n.logger.ErrorContext(ctx, "build credit_low body", "channel_id", ch.ID, "error", buildErr)
+			continue
+		}
+		n.dispatch(ctx, ch, body, creditLowSubject)
+	}
+}
+
 func (n *AlertNotifier) notifyFailure(ctx context.Context, event domain.AlertEvent) {
 	channels, err := n.repo.ListEnabled(ctx, event.UserID)
 	if err != nil {
@@ -83,17 +140,37 @@ func (n *AlertNotifier) notifyFailure(ctx context.Context, event domain.AlertEve
 		return
 	}
 	for _, ch := range channels {
-		n.deliver(ctx, ch, event)
+		body, buildErr := buildAlertBody(ch.Type, event)
+		if buildErr != nil {
+			n.logger.ErrorContext(ctx, "build alert body", "channel_id", ch.ID, "error", buildErr)
+			continue
+		}
+		n.dispatch(ctx, ch, body, alertEmailSubject)
 	}
 }
 
-func (n *AlertNotifier) deliver(ctx context.Context, ch *domain.AlertChannel, event domain.AlertEvent) {
-	body, err := buildAlertBody(ch.Type, event)
-	if err != nil {
-		n.logger.ErrorContext(ctx, "build alert body", "channel_id", ch.ID, "error", err)
+// dispatch routes a prepared body to the channel's transport: email channels go
+// through the mailer (the body is plain text), webhook/slack channels are POSTed
+// to their target URL (the body is JSON).
+func (n *AlertNotifier) dispatch(ctx context.Context, ch *domain.AlertChannel, body []byte, subject string) {
+	if ch.Type == domain.AlertChannelEmail {
+		n.deliverEmail(ctx, ch, subject, string(body))
 		return
 	}
+	n.deliverHTTP(ctx, ch, body)
+}
 
+func (n *AlertNotifier) deliverEmail(ctx context.Context, ch *domain.AlertChannel, subject, text string) {
+	if err := n.mailer.Send(ctx, mailer.Email{To: ch.Target, Subject: subject, Text: text}); err != nil {
+		metrics.AlertDeliveriesTotal.WithLabelValues(string(ch.Type), "failure").Inc()
+		n.logger.WarnContext(ctx, "alert email delivery failed", "channel_id", ch.ID, "error", err)
+		return
+	}
+	metrics.AlertDeliveriesTotal.WithLabelValues(string(ch.Type), "success").Inc()
+	n.logger.InfoContext(ctx, "alert email delivered", "channel_id", ch.ID, "type", ch.Type)
+}
+
+func (n *AlertNotifier) deliverHTTP(ctx context.Context, ch *domain.AlertChannel, body []byte) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ch.Target, bytes.NewReader(body))
 	if err != nil {
 		metrics.AlertDeliveriesTotal.WithLabelValues(string(ch.Type), "failure").Inc()
@@ -117,7 +194,7 @@ func (n *AlertNotifier) deliver(ctx context.Context, ch *domain.AlertChannel, ev
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		metrics.AlertDeliveriesTotal.WithLabelValues(string(ch.Type), "success").Inc()
 		n.logger.InfoContext(ctx, "alert delivered",
-			"channel_id", ch.ID, "type", ch.Type, "resource_id", event.ResourceID, "status_code", resp.StatusCode)
+			"channel_id", ch.ID, "type", ch.Type, "status_code", resp.StatusCode)
 		return
 	}
 	metrics.AlertDeliveriesTotal.WithLabelValues(string(ch.Type), "failure").Inc()
@@ -125,27 +202,73 @@ func (n *AlertNotifier) deliver(ctx context.Context, ch *domain.AlertChannel, ev
 		"channel_id", ch.ID, "type", ch.Type, "status_code", resp.StatusCode)
 }
 
-// buildAlertBody renders the event into the body shape expected by the channel
-// type: a Slack incoming-webhook message, or a structured JSON webhook payload.
-func buildAlertBody(t domain.AlertChannelType, event domain.AlertEvent) ([]byte, error) {
-	if t == domain.AlertChannelSlack {
-		return json.Marshal(map[string]string{"text": alertMessage(event)})
-	}
-	return json.Marshal(alertWebhookPayload{
-		Event:        "failure",
-		ResourceType: string(event.ResourceType),
-		ResourceID:   event.ResourceID,
-		BufferID:     event.BufferID,
-		URL:          event.URL,
-		Method:       event.Method,
-		LastError:    event.LastError,
-		StatusCode:   event.StatusCode,
-		Attempts:     event.Attempts,
-		FailedAt:     event.FailedAt.UTC().Format(time.RFC3339),
-	})
+// Email subjects for the two event kinds.
+const (
+	alertEmailSubject = "🔴 Fliq: an endpoint failed permanently"
+	creditLowSubject  = "⚠️ Fliq: your credit balance is low"
+)
+
+// creditLowWebhookPayload is the JSON body POSTed to a webhook channel for a
+// low-balance warning.
+type creditLowWebhookPayload struct {
+	Event      string `json:"event"`
+	Balance    int64  `json:"balance"`
+	Threshold  int64  `json:"threshold"`
+	RecentBurn int64  `json:"recent_burn"`
+	TopUpURL   string `json:"top_up_url,omitempty"`
+	CrossedAt  string `json:"crossed_at"`
 }
 
-// alertMessage formats a human-readable one-liner for Slack-type channels.
+// buildAlertBody renders a failure event into the body shape expected by the
+// channel type: a plain-text message for email, a Slack incoming-webhook
+// message, or a structured JSON webhook payload.
+func buildAlertBody(t domain.AlertChannelType, event domain.AlertEvent) ([]byte, error) {
+	switch t {
+	case domain.AlertChannelEmail:
+		return []byte(alertMessage(event)), nil
+	case domain.AlertChannelSlack:
+		return json.Marshal(map[string]string{"text": alertMessage(event)})
+	case domain.AlertChannelWebhook:
+		fallthrough
+	default:
+		return json.Marshal(alertWebhookPayload{
+			Event:        "failure",
+			ResourceType: string(event.ResourceType),
+			ResourceID:   event.ResourceID,
+			BufferID:     event.BufferID,
+			URL:          event.URL,
+			Method:       event.Method,
+			LastError:    event.LastError,
+			StatusCode:   event.StatusCode,
+			Attempts:     event.Attempts,
+			FailedAt:     event.FailedAt.UTC().Format(time.RFC3339),
+		})
+	}
+}
+
+// buildCreditLowBody renders a low-balance warning into the channel's body
+// shape. Same dispatch rules as buildAlertBody.
+func buildCreditLowBody(t domain.AlertChannelType, event domain.CreditLowEvent) ([]byte, error) {
+	switch t {
+	case domain.AlertChannelEmail:
+		return []byte(creditLowMessage(event)), nil
+	case domain.AlertChannelSlack:
+		return json.Marshal(map[string]string{"text": creditLowMessage(event)})
+	case domain.AlertChannelWebhook:
+		fallthrough
+	default:
+		return json.Marshal(creditLowWebhookPayload{
+			Event:      "credit_low",
+			Balance:    event.Balance,
+			Threshold:  event.Threshold,
+			RecentBurn: event.RecentBurn,
+			TopUpURL:   event.TopUpURL,
+			CrossedAt:  event.CrossedAt.UTC().Format(time.RFC3339),
+		})
+	}
+}
+
+// alertMessage formats a human-readable one-liner for Slack/email failure alerts.
 func alertMessage(e domain.AlertEvent) string {
 	noun := "Job"
 	if e.ResourceType == domain.AlertResourceBufferItem {
@@ -157,4 +280,16 @@ func alertMessage(e domain.AlertEvent) string {
 	}
 	return fmt.Sprintf("🔴 Fliq: %s %s failed permanently after %d attempt(s)%s — %s %s\nLast error: %s",
 		noun, e.ResourceID, e.Attempts, status, e.Method, e.URL, e.LastError)
+}
+
+// creditLowMessage formats a human-readable low-balance warning for Slack/email.
+func creditLowMessage(e domain.CreditLowEvent) string {
+	msg := fmt.Sprintf(
+		"⚠️ Fliq: your credit balance is low — %d credits left (warning threshold %d).\n"+
+			"You've burned %d credits in the last %s.",
+		e.Balance, e.Threshold, e.RecentBurn, domain.CreditLowBurnWindow)
+	if e.TopUpURL != "" {
+		msg += "\nTop up to avoid dropped executions: " + e.TopUpURL
+	}
+	return msg
 }

--- a/internal/scheduler/alert_test.go
+++ b/internal/scheduler/alert_test.go
@@ -94,7 +94,7 @@ func TestNotifyFailureAsync_DeliversToEnabledChannels(t *testing.T) {
 			}, nil
 		},
 	}
-	n := newAlertNotifier(slog.Default(), repo, srv.Client())
+	n := newAlertNotifier(slog.Default(), repo, &testutil.FakeMailer{}, srv.Client())
 
 	n.NotifyFailureAsync(context.Background(), domain.AlertEvent{
 		UserID: "user-1", ResourceType: domain.AlertResourceJob, ResourceID: "job-1",
@@ -119,9 +119,139 @@ func TestNotifyFailure_RepoErrorTolerated(t *testing.T) {
 			return nil, context.DeadlineExceeded
 		},
 	}
-	n := NewAlertNotifier(slog.Default(), repo)
+	n := NewAlertNotifier(slog.Default(), repo, &testutil.FakeMailer{})
 	// notifyFailure swallows the repo error (logged, not returned).
 	n.notifyFailure(context.Background(), domain.AlertEvent{UserID: "user-1"})
+}
+
+func TestBuildAlertBody_Email(t *testing.T) {
+	event := domain.AlertEvent{
+		ResourceType: domain.AlertResourceJob,
+		ResourceID:   "job-9",
+		URL:          "https://api.example.com",
+		Method:       "POST",
+		LastError:    "boom",
+		Attempts:     4,
+	}
+	body, err := buildAlertBody(domain.AlertChannelEmail, event)
+	if err != nil {
+		t.Fatalf("buildAlertBody: %v", err)
+	}
+	// Email body is plain text, not JSON.
+	text := string(body)
+	for _, want := range []string{"job-9", "boom", "4 attempt"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("email body %q missing %q", text, want)
+		}
+	}
+}
+
+func TestBuildCreditLowBody_Webhook(t *testing.T) {
+	event := domain.CreditLowEvent{
+		Balance: 42, Threshold: 100, RecentBurn: 500,
+		TopUpURL: "https://fliq.sh/billing", CrossedAt: time.Now(),
+	}
+	body, err := buildCreditLowBody(domain.AlertChannelWebhook, event)
+	if err != nil {
+		t.Fatalf("buildCreditLowBody: %v", err)
+	}
+	var payload creditLowWebhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if payload.Event != "credit_low" || payload.Balance != 42 || payload.Threshold != 100 || payload.RecentBurn != 500 {
+		t.Errorf("payload = %+v, want credit_low/42/100/500", payload)
+	}
+}
+
+func TestBuildCreditLowBody_SlackAndEmail(t *testing.T) {
+	event := domain.CreditLowEvent{Balance: 42, Threshold: 100, RecentBurn: 500, TopUpURL: "https://fliq.sh/billing"}
+
+	slackBody, err := buildCreditLowBody(domain.AlertChannelSlack, event)
+	if err != nil {
+		t.Fatalf("slack: %v", err)
+	}
+	var slack map[string]string
+	if err = json.Unmarshal(slackBody, &slack); err != nil {
+		t.Fatalf("unmarshal slack: %v", err)
+	}
+	if !strings.Contains(slack["text"], "42") || !strings.Contains(slack["text"], "billing") {
+		t.Errorf("slack text missing balance/link: %q", slack["text"])
+	}
+
+	emailBody, err := buildCreditLowBody(domain.AlertChannelEmail, event)
+	if err != nil {
+		t.Fatalf("email: %v", err)
+	}
+	if !strings.Contains(string(emailBody), "42") {
+		t.Errorf("email body missing balance: %q", emailBody)
+	}
+}
+
+func TestNotifyFailure_EmailChannelUsesMailer(t *testing.T) {
+	mail := &testutil.FakeMailer{}
+	repo := &testutil.MockAlertChannelRepository{
+		ListEnabledFn: func(_ context.Context, _ string) ([]*domain.AlertChannel, error) {
+			return []*domain.AlertChannel{
+				{ID: "e", Type: domain.AlertChannelEmail, Target: "ops@example.com", Enabled: true, Verified: true},
+			}, nil
+		},
+	}
+	n := newAlertNotifier(slog.Default(), repo, mail, http.DefaultClient)
+
+	// Synchronous path — no goroutine, deterministic assertion.
+	n.notifyFailure(context.Background(), domain.AlertEvent{
+		UserID: "user-1", ResourceType: domain.AlertResourceJob, ResourceID: "job-1", LastError: "down",
+	})
+
+	msgs := mail.Messages()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 email, got %d", len(msgs))
+	}
+	if msgs[0].To != "ops@example.com" || !strings.Contains(msgs[0].Text, "job-1") {
+		t.Errorf("email = %+v, want to ops@example.com mentioning job-1", msgs[0])
+	}
+}
+
+func TestNotifyCreditLow_FansOutToEmailAndWebhook(t *testing.T) {
+	mail := &testutil.FakeMailer{}
+	var mu sync.Mutex
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		hits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	repo := &testutil.MockAlertChannelRepository{
+		ListEnabledFn: func(_ context.Context, _ string) ([]*domain.AlertChannel, error) {
+			return []*domain.AlertChannel{
+				{ID: "e", Type: domain.AlertChannelEmail, Target: "ops@example.com", Enabled: true, Verified: true},
+				{ID: "w", Type: domain.AlertChannelWebhook, Target: srv.URL, Enabled: true, Verified: true},
+			}, nil
+		},
+	}
+	n := newAlertNotifier(slog.Default(), repo, mail, srv.Client())
+
+	n.notifyCreditLow(context.Background(), domain.CreditLowEvent{
+		UserID: "user-1", Balance: 10, Threshold: 100, RecentBurn: 1000, TopUpURL: "https://fliq.sh/billing",
+	})
+
+	if got := len(mail.Messages()); got != 1 {
+		t.Errorf("email count = %d, want 1", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if hits != 1 {
+		t.Errorf("webhook hits = %d, want 1", hits)
+	}
+}
+
+func TestNotifyCreditLowAsync_NilReceiverSafe(t *testing.T) {
+	var n *AlertNotifier
+	n.NotifyCreditLowAsync(context.Background(), domain.CreditLowEvent{UserID: "user-1"})
 }
 
 func waitFor(t *testing.T, cond func() bool) {

--- a/internal/scheduler/drainer.go
+++ b/internal/scheduler/drainer.go
@@ -26,6 +26,7 @@ type BufferDrainer struct {
 	executor       *Executor
 	notifier       *WebhookNotifier
 	alerts         *AlertNotifier
+	lowBalance     LowBalanceConfig
 	logger         *slog.Logger
 	pollInterval   time.Duration
 	concurrency    int
@@ -38,6 +39,7 @@ func NewBufferDrainer(
 	signingSecrets repository.SigningSecretRepository,
 	notifier *WebhookNotifier,
 	alerts *AlertNotifier,
+	lowBalance LowBalanceConfig,
 	logger *slog.Logger,
 	pollInterval time.Duration,
 	concurrency int,
@@ -52,6 +54,7 @@ func NewBufferDrainer(
 		executor:       NewExecutor(logger),
 		notifier:       notifier,
 		alerts:         alerts,
+		lowBalance:     lowBalance,
 		logger:         logger.With("component", "buffer_drainer", "worker_id", id),
 		pollInterval:   pollInterval,
 		concurrency:    concurrency,
@@ -187,8 +190,11 @@ func (d *BufferDrainer) runItem(ctx context.Context, buf *domain.Buffer, item *d
 	result := d.executor.Run(ctx, job, signingSecret)
 
 	// Deduct credit
-	if deductErr := d.credits.DeductForBufferItem(ctx, item.UserID, item.ID); deductErr != nil {
+	crossing, deductErr := d.credits.DeductForBufferItem(ctx, item.UserID, item.ID, d.lowBalance.Threshold)
+	if deductErr != nil {
 		d.logger.WarnContext(ctx, "credit deduction failed", "item_id", item.ID, "error", deductErr)
+	} else {
+		fireCreditLow(ctx, d.alerts, d.lowBalance, item.UserID, crossing)
 	}
 
 	// 429 — rate limited by target API

--- a/internal/scheduler/worker.go
+++ b/internal/scheduler/worker.go
@@ -25,6 +25,7 @@ type Worker struct {
 	executor       *Executor
 	notifier       *WebhookNotifier
 	alerts         *AlertNotifier
+	lowBalance     LowBalanceConfig
 	logger         *slog.Logger
 	pollInterval   time.Duration
 	concurrency    int
@@ -37,6 +38,7 @@ func NewWorker(
 	credits repository.CreditRepository,
 	notifier *WebhookNotifier,
 	alerts *AlertNotifier,
+	lowBalance LowBalanceConfig,
 	logger *slog.Logger,
 	pollInterval time.Duration,
 	concurrency int,
@@ -53,6 +55,7 @@ func NewWorker(
 		executor:       NewExecutor(logger),
 		notifier:       notifier,
 		alerts:         alerts,
+		lowBalance:     lowBalance,
 		logger:         logger.With("worker_id", id),
 		pollInterval:   pollInterval,
 		concurrency:    concurrency,
@@ -187,9 +190,12 @@ func (w *Worker) runJob(ctx context.Context, job *domain.Job) {
 	// Placed here (after HTTP call, before outcome branch) so we always charge
 	// for work done. A crash between Run() and here means the job is re-attempted
 	// by the reaper; the user gets one free attempt in that rare case — acceptable.
-	if deductErr := w.credits.Deduct(ctx, job.UserID, job.ID); deductErr != nil {
+	crossing, deductErr := w.credits.Deduct(ctx, job.UserID, job.ID, w.lowBalance.Threshold)
+	if deductErr != nil {
 		w.logger.WarnContext(ctx, "credit deduction failed", "job_id", job.ID, "error", deductErr)
 		// Non-fatal: job outcome is not affected.
+	} else {
+		fireCreditLow(ctx, w.alerts, w.lowBalance, job.UserID, crossing)
 	}
 
 	if result.Err == nil && result.StatusCode == http.StatusOK {

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -2,11 +2,40 @@ package testutil
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/mailer"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
 )
+
+// ---------- FakeMailer ----------
+
+// FakeMailer is an in-memory mailer.Provider that records every message it is
+// asked to send. Safe for concurrent use so scheduler goroutines can hit it.
+type FakeMailer struct {
+	mu   sync.Mutex
+	Sent []mailer.Email
+	// Err, if set, is returned from Send (and the message is still recorded).
+	Err error
+}
+
+func (m *FakeMailer) Send(_ context.Context, msg mailer.Email) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Sent = append(m.Sent, msg)
+	return m.Err
+}
+
+// Messages returns a copy of the recorded messages.
+func (m *FakeMailer) Messages() []mailer.Email {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]mailer.Email, len(m.Sent))
+	copy(out, m.Sent)
+	return out
+}
 
 // ---------- MockJobRepository ----------
 
@@ -147,8 +176,8 @@ type MockCreditRepository struct {
 	EnsureExistsFn        func(ctx context.Context, userID string) error
 	GetBalanceFn          func(ctx context.Context, userID string) (*domain.CreditBalance, error)
 	HasCreditsFn          func(ctx context.Context, userID string) (bool, error)
-	DeductFn              func(ctx context.Context, userID, jobID string) error
-	DeductForBufferItemFn func(ctx context.Context, userID, bufferItemID string) error
+	DeductFn              func(ctx context.Context, userID, jobID string, threshold int64) (*repository.LowBalanceCrossing, error)
+	DeductForBufferItemFn func(ctx context.Context, userID, bufferItemID string, threshold int64) (*repository.LowBalanceCrossing, error)
 	TopUpFn               func(ctx context.Context, userID string, amount int64, stripePaymentIntentID string) error
 	UpdatePlanFn          func(ctx context.Context, userID string, plan domain.Plan) error
 	ListTransactionsFn    func(ctx context.Context, userID string, cursor string, limit int) ([]domain.CreditTransaction, string, error)
@@ -175,18 +204,18 @@ func (m *MockCreditRepository) HasCredits(ctx context.Context, userID string) (b
 	return true, nil
 }
 
-func (m *MockCreditRepository) Deduct(ctx context.Context, userID, jobID string) error {
+func (m *MockCreditRepository) Deduct(ctx context.Context, userID, jobID string, threshold int64) (*repository.LowBalanceCrossing, error) {
 	if m.DeductFn != nil {
-		return m.DeductFn(ctx, userID, jobID)
+		return m.DeductFn(ctx, userID, jobID, threshold)
 	}
-	return nil
+	return nil, nil
 }
 
-func (m *MockCreditRepository) DeductForBufferItem(ctx context.Context, userID, bufferItemID string) error {
+func (m *MockCreditRepository) DeductForBufferItem(ctx context.Context, userID, bufferItemID string, threshold int64) (*repository.LowBalanceCrossing, error) {
 	if m.DeductForBufferItemFn != nil {
-		return m.DeductForBufferItemFn(ctx, userID, bufferItemID)
+		return m.DeductForBufferItemFn(ctx, userID, bufferItemID, threshold)
 	}
-	return nil
+	return nil, nil
 }
 
 func (m *MockCreditRepository) TopUp(ctx context.Context, userID string, amount int64, stripePaymentIntentID string) error {
@@ -355,12 +384,13 @@ func (m *MockStripeCustomerRepository) Save(ctx context.Context, userID, stripeC
 // ---------- MockAlertChannelRepository ----------
 
 type MockAlertChannelRepository struct {
-	CreateFn      func(ctx context.Context, ch *domain.AlertChannel) (*domain.AlertChannel, error)
-	GetByIDFn     func(ctx context.Context, id, userID string) (*domain.AlertChannel, error)
-	ListFn        func(ctx context.Context, userID string) ([]*domain.AlertChannel, error)
-	SetEnabledFn  func(ctx context.Context, id, userID string, enabled bool) error
-	DeleteFn      func(ctx context.Context, id, userID string) error
-	ListEnabledFn func(ctx context.Context, userID string) ([]*domain.AlertChannel, error)
+	CreateFn       func(ctx context.Context, ch *domain.AlertChannel) (*domain.AlertChannel, error)
+	GetByIDFn      func(ctx context.Context, id, userID string) (*domain.AlertChannel, error)
+	ListFn         func(ctx context.Context, userID string) ([]*domain.AlertChannel, error)
+	SetEnabledFn   func(ctx context.Context, id, userID string, enabled bool) error
+	DeleteFn       func(ctx context.Context, id, userID string) error
+	MarkVerifiedFn func(ctx context.Context, id string) error
+	ListEnabledFn  func(ctx context.Context, userID string) ([]*domain.AlertChannel, error)
 }
 
 func (m *MockAlertChannelRepository) Create(ctx context.Context, ch *domain.AlertChannel) (*domain.AlertChannel, error) {
@@ -397,6 +427,13 @@ func (m *MockAlertChannelRepository) SetEnabled(ctx context.Context, id, userID 
 func (m *MockAlertChannelRepository) Delete(ctx context.Context, id, userID string) error {
 	if m.DeleteFn != nil {
 		return m.DeleteFn(ctx, id, userID)
+	}
+	return nil
+}
+
+func (m *MockAlertChannelRepository) MarkVerified(ctx context.Context, id string) error {
+	if m.MarkVerifiedFn != nil {
+		return m.MarkVerifiedFn(ctx, id)
 	}
 	return nil
 }

--- a/internal/usecase/alert.go
+++ b/internal/usecase/alert.go
@@ -5,15 +5,23 @@ import (
 	"fmt"
 
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/emailverify"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/mailer"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
 )
 
 type AlertUsecase struct {
-	repo repository.AlertChannelRepository
+	repo    repository.AlertChannelRepository
+	mailer  mailer.Provider
+	signer  *emailverify.Signer
+	baseURL string
 }
 
-func NewAlertUsecase(repo repository.AlertChannelRepository) *AlertUsecase {
-	return &AlertUsecase{repo: repo}
+// NewAlertUsecase wires the alert-channel store with the email-verification
+// dependencies. mailer and signer are only exercised for email channels; for a
+// webhook/slack-only deployment they can be a NoopProvider and any signer.
+func NewAlertUsecase(repo repository.AlertChannelRepository, mail mailer.Provider, signer *emailverify.Signer, baseURL string) *AlertUsecase {
+	return &AlertUsecase{repo: repo, mailer: mail, signer: signer, baseURL: baseURL}
 }
 
 type CreateAlertChannelInput struct {
@@ -28,19 +36,63 @@ func (u *AlertUsecase) CreateChannel(ctx context.Context, input CreateAlertChann
 		return nil, domain.ErrInvalidAlertChannelType
 	}
 
+	// Email channels start disabled+unverified: we must confirm the address owns
+	// itself before delivering, so Fliq cannot be used to spam third parties.
+	// webhook/slack channels are enabled and verified on creation (the target is
+	// a caller-owned URL).
+	verified := !input.Type.RequiresVerification()
+
 	ch := &domain.AlertChannel{
-		UserID:  input.UserID,
-		Type:    input.Type,
-		Target:  input.Target,
-		Name:    input.Name,
-		Enabled: true,
+		UserID:   input.UserID,
+		Type:     input.Type,
+		Target:   input.Target,
+		Name:     input.Name,
+		Enabled:  verified,
+		Verified: verified,
 	}
 
 	created, err := u.repo.Create(ctx, ch)
 	if err != nil {
 		return nil, fmt.Errorf("create alert channel: %w", err)
 	}
+
+	if input.Type.RequiresVerification() {
+		// Best-effort: a failed verification send must not fail channel creation.
+		// The channel stays disabled until confirmed; the user can re-trigger by
+		// recreating it. (Live send requires RESEND_API_KEY; otherwise the noop
+		// mailer drops it.)
+		u.sendVerificationEmail(ctx, created)
+	}
+
 	return created, nil
+}
+
+// sendVerificationEmail mails a signed confirm link to the channel's target
+// address. Best-effort — errors are swallowed (channel stays unverified).
+func (u *AlertUsecase) sendVerificationEmail(ctx context.Context, ch *domain.AlertChannel) {
+	token := u.signer.Sign(ch.ID)
+	link := fmt.Sprintf("%s/alerts/verify?token=%s", u.baseURL, token)
+	_ = u.mailer.Send(ctx, mailer.Email{
+		To:      ch.Target,
+		Subject: "Confirm your Fliq alert email",
+		Text: fmt.Sprintf(
+			"You (or someone) added this address as a Fliq failure-alert destination.\n\n"+
+				"Confirm it to start receiving alerts:\n%s\n\n"+
+				"If you didn't request this, ignore this email — no alerts will be sent.",
+			link),
+	})
+}
+
+// VerifyChannel confirms an email channel from a signed token, enabling it.
+func (u *AlertUsecase) VerifyChannel(ctx context.Context, token string) error {
+	channelID, err := u.signer.Verify(token)
+	if err != nil {
+		return fmt.Errorf("verify alert channel token: %w", err)
+	}
+	if err := u.repo.MarkVerified(ctx, channelID); err != nil {
+		return fmt.Errorf("mark alert channel verified: %w", err)
+	}
+	return nil
 }
 
 func (u *AlertUsecase) ListChannels(ctx context.Context, userID string) ([]*domain.AlertChannel, error) {
@@ -60,6 +112,18 @@ func (u *AlertUsecase) GetChannel(ctx context.Context, id, userID string) (*doma
 }
 
 func (u *AlertUsecase) SetEnabled(ctx context.Context, id, userID string, enabled bool) error {
+	// An unverified email channel can never be enabled via the API — only the
+	// confirm-token endpoint flips it. This closes the obvious bypass of the
+	// verification gate (PATCH enabled=true on a freshly created email channel).
+	if enabled {
+		ch, err := u.repo.GetByID(ctx, id, userID)
+		if err != nil {
+			return fmt.Errorf("get alert channel: %w", err)
+		}
+		if !ch.Verified {
+			return domain.ErrAlertChannelNotVerified
+		}
+	}
 	if err := u.repo.SetEnabled(ctx, id, userID, enabled); err != nil {
 		return fmt.Errorf("set alert channel enabled: %w", err)
 	}

--- a/internal/usecase/alert_test.go
+++ b/internal/usecase/alert_test.go
@@ -3,12 +3,24 @@ package usecase_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/emailverify"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/mailer"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/usecase"
 )
+
+const testSecret = "test-secret-32-chars-long-xxxxxx"
+
+func newTestAlertUsecase(repo *testutil.MockAlertChannelRepository, mail mailer.Provider) *usecase.AlertUsecase {
+	if mail == nil {
+		mail = &testutil.FakeMailer{}
+	}
+	return usecase.NewAlertUsecase(repo, mail, emailverify.NewSigner([]byte(testSecret)), "https://api.fliq.test")
+}
 
 func TestCreateAlertChannel_HappyPath(t *testing.T) {
 	t.Parallel()
@@ -21,7 +33,7 @@ func TestCreateAlertChannel_HappyPath(t *testing.T) {
 			return ch, nil
 		},
 	}
-	uc := usecase.NewAlertUsecase(repo)
+	uc := newTestAlertUsecase(repo, nil)
 
 	got, err := uc.CreateChannel(context.Background(), usecase.CreateAlertChannelInput{
 		UserID: "user-1",
@@ -35,8 +47,45 @@ func TestCreateAlertChannel_HappyPath(t *testing.T) {
 	if got.ID != "alert-1" {
 		t.Errorf("id = %q, want alert-1", got.ID)
 	}
-	if !saved.Enabled {
-		t.Error("new channel should be enabled by default")
+	if !saved.Enabled || !saved.Verified {
+		t.Error("webhook/slack channel should be enabled and verified by default")
+	}
+}
+
+func TestCreateAlertChannel_Email_StartsDisabledAndSendsVerification(t *testing.T) {
+	t.Parallel()
+
+	var saved *domain.AlertChannel
+	repo := &testutil.MockAlertChannelRepository{
+		CreateFn: func(_ context.Context, ch *domain.AlertChannel) (*domain.AlertChannel, error) {
+			ch.ID = "alert-email-1"
+			saved = ch
+			return ch, nil
+		},
+	}
+	mail := &testutil.FakeMailer{}
+	uc := newTestAlertUsecase(repo, mail)
+
+	_, err := uc.CreateChannel(context.Background(), usecase.CreateAlertChannelInput{
+		UserID: "user-1",
+		Type:   domain.AlertChannelEmail,
+		Target: "ops@example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if saved.Enabled || saved.Verified {
+		t.Error("email channel must start disabled + unverified until confirmed")
+	}
+	msgs := mail.Messages()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 verification email, got %d", len(msgs))
+	}
+	if msgs[0].To != "ops@example.com" {
+		t.Errorf("verification email To = %q, want ops@example.com", msgs[0].To)
+	}
+	if !strings.Contains(msgs[0].Text, "/alerts/verify?token=") {
+		t.Errorf("verification email missing confirm link: %q", msgs[0].Text)
 	}
 }
 
@@ -49,15 +98,94 @@ func TestCreateAlertChannel_InvalidType(t *testing.T) {
 			return nil, nil
 		},
 	}
-	uc := usecase.NewAlertUsecase(repo)
+	uc := newTestAlertUsecase(repo, nil)
 
 	_, err := uc.CreateChannel(context.Background(), usecase.CreateAlertChannelInput{
 		UserID: "user-1",
-		Type:   domain.AlertChannelType("email"),
-		Target: "ops@example.com",
+		Type:   domain.AlertChannelType("carrier_pigeon"),
+		Target: "coop-3",
 	})
 	if !errors.Is(err, domain.ErrInvalidAlertChannelType) {
 		t.Errorf("err = %v, want ErrInvalidAlertChannelType", err)
+	}
+}
+
+func TestVerifyChannel_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var verifiedID string
+	repo := &testutil.MockAlertChannelRepository{
+		CreateFn: func(_ context.Context, ch *domain.AlertChannel) (*domain.AlertChannel, error) {
+			ch.ID = "alert-email-1"
+			return ch, nil
+		},
+		MarkVerifiedFn: func(_ context.Context, id string) error {
+			verifiedID = id
+			return nil
+		},
+	}
+	mail := &testutil.FakeMailer{}
+	uc := newTestAlertUsecase(repo, mail)
+
+	created, err := uc.CreateChannel(context.Background(), usecase.CreateAlertChannelInput{
+		UserID: "user-1",
+		Type:   domain.AlertChannelEmail,
+		Target: "ops@example.com",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Pull the token straight out of the email the usecase just sent.
+	text := mail.Messages()[0].Text
+	i := strings.Index(text, "token=")
+	if i < 0 {
+		t.Fatal("no token in verification email")
+	}
+	token := strings.Fields(text[i+len("token="):])[0]
+
+	if err := uc.VerifyChannel(context.Background(), token); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if verifiedID != created.ID {
+		t.Errorf("verified id = %q, want %q", verifiedID, created.ID)
+	}
+}
+
+func TestVerifyChannel_BadToken(t *testing.T) {
+	t.Parallel()
+
+	repo := &testutil.MockAlertChannelRepository{
+		MarkVerifiedFn: func(_ context.Context, _ string) error {
+			t.Fatal("MarkVerified must not be called for a bad token")
+			return nil
+		},
+	}
+	uc := newTestAlertUsecase(repo, nil)
+
+	err := uc.VerifyChannel(context.Background(), "not.a.token")
+	if !errors.Is(err, domain.ErrInvalidVerificationToken) {
+		t.Errorf("err = %v, want ErrInvalidVerificationToken", err)
+	}
+}
+
+func TestSetEnabled_UnverifiedEmailRejected(t *testing.T) {
+	t.Parallel()
+
+	repo := &testutil.MockAlertChannelRepository{
+		GetByIDFn: func(_ context.Context, _, _ string) (*domain.AlertChannel, error) {
+			return &domain.AlertChannel{ID: "e", Type: domain.AlertChannelEmail, Verified: false}, nil
+		},
+		SetEnabledFn: func(_ context.Context, _, _ string, _ bool) error {
+			t.Fatal("SetEnabled must not be called for an unverified email channel")
+			return nil
+		},
+	}
+	uc := newTestAlertUsecase(repo, nil)
+
+	err := uc.SetEnabled(context.Background(), "e", "user-1", true)
+	if !errors.Is(err, domain.ErrAlertChannelNotVerified) {
+		t.Errorf("err = %v, want ErrAlertChannelNotVerified", err)
 	}
 }
 
@@ -69,8 +197,9 @@ func TestAlertChannel_SetEnabled_NotFound(t *testing.T) {
 			return domain.ErrAlertChannelNotFound
 		},
 	}
-	uc := usecase.NewAlertUsecase(repo)
+	uc := newTestAlertUsecase(repo, nil)
 
+	// Disable path skips the verification check, so this exercises the repo error.
 	err := uc.SetEnabled(context.Background(), "missing", "user-1", false)
 	if !errors.Is(err, domain.ErrAlertChannelNotFound) {
 		t.Errorf("err = %v, want ErrAlertChannelNotFound", err)
@@ -85,7 +214,7 @@ func TestAlertChannel_List(t *testing.T) {
 			return []*domain.AlertChannel{{ID: "a"}, {ID: "b"}}, nil
 		},
 	}
-	uc := usecase.NewAlertUsecase(repo)
+	uc := newTestAlertUsecase(repo, nil)
 
 	got, err := uc.ListChannels(context.Background(), "user-1")
 	if err != nil {

--- a/migrations/20260613000000_alert_email_verification.sql
+++ b/migrations/20260613000000_alert_email_verification.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+
+-- Email alert channels require address verification before they are enabled, so
+-- Fliq cannot be used to send unsolicited mail to third-party addresses. A
+-- channel is created with enabled = FALSE, verified = FALSE; the confirm-token
+-- endpoint flips both to TRUE. webhook/slack channels backfill as verified
+-- (nothing to verify — the target is a caller-owned URL).
+ALTER TABLE alert_channels
+    ADD COLUMN verified BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE alert_channels SET verified = TRUE WHERE type IN ('webhook', 'slack');
+
+-- +goose Down
+ALTER TABLE alert_channels DROP COLUMN verified;

--- a/migrations/20260613000001_user_credits_low_balance_notified.sql
+++ b/migrations/20260613000001_user_credits_low_balance_notified.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+
+-- low_balance_notified is the hysteresis latch for proactive low-balance alerts.
+-- It is set TRUE in the same transaction that takes the balance below the
+-- warning threshold, so concurrent workers fire the warning at most once per
+-- downward crossing. It is reset to FALSE on top-up and on the daily free
+-- refresh, re-arming the warning for the next time the user runs low.
+ALTER TABLE user_credits
+    ADD COLUMN low_balance_notified BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- +goose Down
+ALTER TABLE user_credits DROP COLUMN low_balance_notified;


### PR DESCRIPTION
Implements core-api#47 and #48.

## Email alert channel (#47)
- Adds `email` to `AlertChannelType`; webhook/slack still don't need verification.
- **Mailer port** (`internal/mailer`): `Provider` interface + a **Resend** impl + a **no-op fallback** used when `RESEND_API_KEY` is unset — same convention as the nil `AlertNotifier`, so the service behaves identically with or without email wired up.
- **Address verification** (`internal/emailverify`): email channels are created `enabled=false, verified=false`; a signed HMAC-SHA256 confirm token (keyed by `JWT_SECRET`, 48h TTL, constant-time compare, stateless) flips them live via public `GET /alerts/verify`. Prevents Fliq being used to spam third-party addresses.
- Migration adds `alert_channels.verified` (webhook/slack backfilled true).

## Low-balance warning (#48)
- Fires a `credit_low` alert through the user's enabled channels when a deduction crosses below `LOW_BALANCE_THRESHOLD`.
- **Hysteresis** is a `user_credits.low_balance_notified` latch flipped in the *same UPDATE* as the deduction (edge-detected in `RETURNING`), so concurrent workers fire **at most once per crossing**. Resets on top-up and the daily free refresh.

## Verified
`go build`, `go vet`, `go test ./...`, and `golangci-lint run ./...` all clean. Email delivery + low-balance fan-out unit-tested with a fake mailer; the crossing SQL uses `make_interval` (not a Go duration string) so the burn query is valid Postgres.

## Operator action to enable email live
Set in the server+scheduler env: **`RESEND_API_KEY`** (Resend key), **`ALERT_EMAIL_FROM`** (a sender on a Resend-verified domain; default `alerts@fliq.sh`), **`APP_BASE_URL`** (e.g. `https://api.fliq.sh` for confirm links). Tune `LOW_BALANCE_THRESHOLD` (default 10000; note the free daily limit is 5000, so consider lowering it for free-tier relevance). Without `RESEND_API_KEY` everything works except actual email send (no-op).