### PR TITLE
Self-host quickstart (+ fix the broken migrate image)

### DIFF
--- a/Dockerfile.migrate
+++ b/Dockerfile.migrate
@@ -12,7 +12,11 @@ FROM gcr.io/distroless/static-debian12
 COPY --from=builder /go/bin/goose /goose
 COPY migrations /migrations
 
-# Usage: docker run --rm -e DATABASE_URL=... migrate
-# Passes DATABASE_URL and any extra args to goose
-ENTRYPOINT ["/goose", "-dir", "/migrations", "postgres"]
+# goose reads its config from GOOSE_* env vars, so this works on distroless (no
+# shell to splice $DATABASE_URL into an argv). Supply your Postgres connection
+# string at runtime via GOOSE_DBSTRING; driver + migration dir default below.
+#   docker run --rm -e GOOSE_DBSTRING="postgres://user:pass@host:5432/db?sslmode=disable" migrate
+ENV GOOSE_DRIVER=postgres
+ENV GOOSE_MIGRATION_DIR=/migrations
+ENTRYPOINT ["/goose"]
 CMD ["up"]

--- a/README.md
+++ b/README.md
@@ -93,6 +93,72 @@ See `CLAUDE.md` for the full local setup guide and coding conventions.
 
 ---
 
+## Self-host
+
+Fliq is open source and runs the whole stack — API, scheduler, and Postgres — from
+one `docker compose`. No Clerk account, no Redis, no external services. Only Docker
+is required.
+
+```bash
+git clone https://github.com/fliq-sh/core-api.git && cd core-api
+
+# Build + start Postgres, run migrations, then bring up the server + scheduler.
+docker compose --profile migrate --profile app up --build
+```
+
+That's it — the API is live on `http://localhost:8080`:
+
+```bash
+curl localhost:8080/health
+# {"status":"ok","version":"dev","time":"..."}
+```
+
+### Get a first credential (no Clerk)
+
+Self-hosted Fliq authenticates with **HS256 JWTs** signed by `JWT_SECRET` (set in
+`docker-compose.yml` — override it for anything real). Mint one for any user id;
+the first authenticated request auto-provisions that user with free credits.
+
+```bash
+SECRET='dev-only-change-me-0123456789abcdef0123456789'   # must match the server's JWT_SECRET
+b64() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+h=$(printf '{"alg":"HS256","typ":"JWT"}' | b64)
+p=$(printf '{"sub":"local-user","exp":%d}' "$(($(date +%s)+31536000))" | b64)
+s=$(printf '%s.%s' "$h" "$p" | openssl dgst -sha256 -hmac "$SECRET" -binary | b64)
+JWT="$h.$p.$s"
+
+# Exchange the JWT for a long-lived API token (fliq_sk_*) you can use everywhere:
+curl -s -X POST localhost:8080/tokens \
+  -H "Authorization: Bearer $JWT" -H 'Content-Type: application/json' \
+  -d '{"name":"self-host"}'
+# → {"token":"fliq_sk_...", ...}
+```
+
+Then schedule a job with the `fliq_sk_*` token:
+
+```bash
+curl -X POST localhost:8080/jobs \
+  -H "Authorization: Bearer fliq_sk_..." -H 'Content-Type: application/json' \
+  -d '{"url":"https://httpbin.org/post","method":"POST","scheduled_at":"2030-01-01T00:00:00Z"}'
+```
+
+### Configuration
+
+Everything is env-driven (`caarlos0/env`); the compose file sets sane local defaults.
+The ones that matter when self-hosting:
+
+| Var | Purpose |
+|---|---|
+| `DATABASE_URL` | Postgres connection string |
+| `JWT_SECRET` | HS256 signing secret for local auth (min 32 chars) — **change it** |
+| `CLERK_JWKS_URL` | set only to use Clerk RS256 auth instead of the HS256 path |
+| `WORKER_COUNT` / `POLL_INTERVAL_SEC` | scheduler concurrency + poll cadence |
+| `STRIPE_*` | optional — only needed for paid top-ups |
+
+To run the binaries directly instead of in Docker, see **Local dev** above.
+
+---
+
 ## Roadmap
 
 ### Phase 1 — Core backend ✅

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       context: .
       dockerfile: Dockerfile.migrate
     environment:
-      DATABASE_URL: postgres://scheduler:scheduler@postgres:5432/scheduler?sslmode=disable
+      GOOSE_DBSTRING: postgres://scheduler:scheduler@postgres:5432/scheduler?sslmode=disable
     depends_on:
       postgres:
         condition: service_healthy
@@ -35,11 +35,16 @@ services:
       ENV: local
       PORT: 8080
       DATABASE_URL: postgres://scheduler:scheduler@postgres:5432/scheduler?sslmode=disable
+      # Self-host without Clerk: HS256 local auth. Override with your own secret
+      # (min 32 chars). Leave CLERK_JWKS_URL unset to keep this HS256 path.
+      JWT_SECRET: "${JWT_SECRET:-dev-only-change-me-0123456789abcdef0123456789}"
     ports:
       - "8080:8080"
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     profiles: [app]
 
   scheduler:
@@ -54,6 +59,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     profiles: [app]
 
 volumes:


### PR DESCRIPTION
Implements core-api#49.

## Self-host in one command
`docker compose --profile migrate --profile app up --build` now boots the whole stack — Postgres, migrations, server, scheduler — from a clean clone. No Clerk, no Redis. README gets a **Self-host** section: the command, a health check, and a **no-Clerk first-credential flow** (mint an HS256 JWT with `openssl` → exchange for a `fliq_sk_` token → schedule a job). The first authenticated request auto-provisions the user with free credits.

## Bug fix: the migrate image didn't work outside k8s
`Dockerfile.migrate`'s entrypoint was `/goose -dir /migrations postgres` + `up`, which left goose's connection-string positional arg filled by `"up"` — so it printed help and exited 1. (Prod survived only because the k8s job overrides the command entirely with `GOOSE_*` env.) Switched the image to goose's native `GOOSE_*` env vars (works on distroless — no shell needed to splice `$DATABASE_URL`), and pointed compose at `GOOSE_DBSTRING`. **Prod is unaffected** — the migrate job still overrides the command.

## Compose changes
- `server`/`scheduler` now `depends_on` migrate `service_completed_successfully` (correct ordering on a single `up`).
- `server` gets a dev `JWT_SECRET` default (overridable) for the no-Clerk HS256 path.

## Verified live
Built the images, brought the full stack up, ran migrations (exit 0), and exercised the exact README snippet: `/health` ok → JWT → `fliq_sk_` token → `POST /jobs` 201 → balance shows free credits. Tore the test stack down after.

Note (not changed here): the live free tier is 100,000/day, but the README pricing table still says 5,000/day — flagging rather than changing pricing copy without your call.