### PR TITLE
perf(db): move job heartbeat to a sidecar table (Phase 2)

### DIFF
--- a/docs/design/db-vacuum-tuning.md
+++ b/docs/design/db-vacuum-tuning.md
@@ -68,7 +68,16 @@ one-time `pg_repack` (online, no long lock) on `jobs`, `buffer_items`,
 `job_attempts` after deploy to compact what's already there. `VACUUM FULL` also
 works but takes an exclusive lock — avoid on the live scheduler.
 
-## Phase 2 — heartbeat sidecar (proposed, not yet implemented)
+## Phase 2 — heartbeat sidecar (implemented for `jobs`, migration `20260614000001`)
+
+Status: **done for the jobs scheduler path.** `buffer_items` has the identical
+shape (`idx_buffer_items_stale`, full-row heartbeat) and gets the same treatment
+in a follow-up PR (validated by the `crash.js` buffer chaos test).
+
+Measured on the migrated schema (50 running jobs × 360 beats/hr, autovacuum off
+to show raw churn): the old full-row heartbeat left **15.4k dead tuples / ~21 MB**
+of churn on `jobs`; the sidecar moves that to a **~1.5 MB** table (mostly HOT) and
+`jobs` now takes **zero** heartbeat writes.
 
 Move the volatile heartbeat out of the heavy row:
 

--- a/internal/infrastructure/postgres/job_heartbeat_integration_test.go
+++ b/internal/infrastructure/postgres/job_heartbeat_integration_test.go
@@ -1,0 +1,177 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// setupJobRepoPool is like setupJobRepo but also returns the pool so tests can
+// inspect the job_heartbeats sidecar directly.
+func setupJobRepoPool(t *testing.T) (*postgres.JobRepository, *pgxpool.Pool, string) {
+	t.Helper()
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	return postgres.NewJobRepository(pool), pool, userID
+}
+
+func heartbeatRow(t *testing.T, pool *pgxpool.Pool, jobID string) (time.Time, bool) {
+	t.Helper()
+	var hb time.Time
+	err := pool.QueryRow(context.Background(),
+		`SELECT heartbeat_at FROM job_heartbeats WHERE job_id = $1`, jobID).Scan(&hb)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return hb, true
+}
+
+func claimOne(t *testing.T, repo *postgres.JobRepository, userID string) *domain.Job {
+	t.Helper()
+	ctx := context.Background()
+	job := testutil.NewJob(testutil.WithUserID(userID), testutil.WithScheduledAt(time.Now().Add(-time.Minute)))
+	if _, err := repo.Create(ctx, job); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	claimed, err := repo.Claim(ctx, "worker-1", 10)
+	if err != nil || len(claimed) != 1 {
+		t.Fatalf("claim: err=%v n=%d", err, len(claimed))
+	}
+	return claimed[0]
+}
+
+func TestHeartbeat_ClaimSeedsSidecar(t *testing.T) {
+	repo, pool, userID := setupJobRepoPool(t)
+	job := claimOne(t, repo, userID)
+	if _, ok := heartbeatRow(t, pool, job.ID); !ok {
+		t.Fatal("expected a job_heartbeats row after claim")
+	}
+}
+
+// UpdateHeartbeat must advance the sidecar and NOT touch the heavy jobs row.
+func TestHeartbeat_UpdateWritesSidecarOnly(t *testing.T) {
+	repo, pool, userID := setupJobRepoPool(t)
+	ctx := context.Background()
+	job := claimOne(t, repo, userID)
+
+	before, ok := heartbeatRow(t, pool, job.ID)
+	if !ok {
+		t.Fatal("no sidecar row after claim")
+	}
+	var jobsHBBefore time.Time
+	if err := pool.QueryRow(ctx, `SELECT heartbeat_at FROM jobs WHERE id=$1`, job.ID).Scan(&jobsHBBefore); err != nil {
+		t.Fatalf("read jobs.heartbeat_at: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	if err := repo.UpdateHeartbeat(ctx, job.ID); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+
+	after, _ := heartbeatRow(t, pool, job.ID)
+	if !after.After(before) {
+		t.Fatalf("sidecar heartbeat did not advance: before=%v after=%v", before, after)
+	}
+	var jobsHBAfter time.Time
+	if err := pool.QueryRow(ctx, `SELECT heartbeat_at FROM jobs WHERE id=$1`, job.ID).Scan(&jobsHBAfter); err != nil {
+		t.Fatalf("read jobs.heartbeat_at: %v", err)
+	}
+	if !jobsHBAfter.Equal(jobsHBBefore) {
+		t.Fatalf("jobs.heartbeat_at changed (%v -> %v) — heartbeat should not touch the jobs row", jobsHBBefore, jobsHBAfter)
+	}
+}
+
+func TestHeartbeat_UpdateIgnoredWhenNotRunning(t *testing.T) {
+	repo, pool, userID := setupJobRepoPool(t)
+	ctx := context.Background()
+	job := claimOne(t, repo, userID)
+	if err := repo.Complete(ctx, job.ID); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	// Completing dropped the row; a stray heartbeat must not resurrect it.
+	if err := repo.UpdateHeartbeat(ctx, job.ID); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+	if _, ok := heartbeatRow(t, pool, job.ID); ok {
+		t.Fatal("heartbeat row should not exist for a completed job")
+	}
+}
+
+func TestHeartbeat_TerminalTransitionsDropSidecar(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		act  func(repo *postgres.JobRepository, id string) error
+	}{
+		{"complete", func(r *postgres.JobRepository, id string) error { return r.Complete(context.Background(), id) }},
+		{"fail", func(r *postgres.JobRepository, id string) error { return r.Fail(context.Background(), id, "boom") }},
+		{"reschedule", func(r *postgres.JobRepository, id string) error {
+			return r.Reschedule(context.Background(), id, "boom", time.Now().Add(time.Minute))
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, pool, userID := setupJobRepoPool(t)
+			job := claimOne(t, repo, userID)
+			if _, ok := heartbeatRow(t, pool, job.ID); !ok {
+				t.Fatal("expected sidecar row after claim")
+			}
+			if err := tc.act(repo, job.ID); err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if _, ok := heartbeatRow(t, pool, job.ID); ok {
+				t.Fatalf("%s should have dropped the sidecar row", tc.name)
+			}
+		})
+	}
+}
+
+func TestHeartbeat_RescheduleStaleUsesSidecarAndCleansUp(t *testing.T) {
+	repo, pool, userID := setupJobRepoPool(t)
+	ctx := context.Background()
+	job := claimOne(t, repo, userID)
+
+	n, err := repo.RescheduleStale(ctx, time.Now().Add(time.Hour), 100) // everything is stale
+	if err != nil {
+		t.Fatalf("reschedule stale: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("rescheduled %d, want 1", n)
+	}
+	if _, ok := heartbeatRow(t, pool, job.ID); ok {
+		t.Fatal("reschedule-stale should drop the sidecar row")
+	}
+	got, _ := repo.GetByID(ctx, job.ID, userID)
+	if got.Status != domain.StatusPending {
+		t.Fatalf("status = %s, want pending", got.Status)
+	}
+}
+
+// A running job whose sidecar row went missing must be treated as stale even if
+// the cutoff is in the past (defensive: a lost heartbeat == a dead worker).
+func TestHeartbeat_MissingSidecarRowIsStale(t *testing.T) {
+	repo, pool, userID := setupJobRepoPool(t)
+	ctx := context.Background()
+	job := claimOne(t, repo, userID)
+
+	if _, err := pool.Exec(ctx, `DELETE FROM job_heartbeats WHERE job_id=$1`, job.ID); err != nil {
+		t.Fatalf("delete sidecar: %v", err)
+	}
+
+	// Cutoff one hour in the PAST: a live heartbeat would NOT be stale, so this
+	// only reschedules because the row is missing.
+	n, err := repo.RescheduleStale(ctx, time.Now().Add(-time.Hour), 100)
+	if err != nil {
+		t.Fatalf("reschedule stale: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("rescheduled %d, want 1 (missing heartbeat must be treated as stale)", n)
+	}
+}

--- a/internal/infrastructure/postgres/job_repo.go
+++ b/internal/infrastructure/postgres/job_repo.go
@@ -80,26 +80,40 @@ func (r *JobRepository) GetByID(ctx context.Context, id, userID string) (*domain
 
 func (r *JobRepository) Claim(ctx context.Context, workerID string, limit int) ([]*domain.Job, error) {
 	// FOR UPDATE SKIP LOCKED prevents double-execution across workers.
+	// The `hb` CTE seeds the heartbeat sidecar atomically with the claim so a
+	// freshly-running job always has a heartbeat row (the reaper relies on it).
 	query := `
-		UPDATE jobs
-		SET    status       = 'running',
-		       claimed_at   = NOW(),
-		       claimed_by   = $1,
-		       heartbeat_at = NOW(),
-		       updated_at   = NOW()
-		WHERE id IN (
-			SELECT id FROM jobs
-			WHERE  status       = 'pending'
-			  AND  scheduled_at <= NOW()
-			ORDER BY scheduled_at ASC
-			LIMIT $2
-			FOR UPDATE SKIP LOCKED
+		WITH claimed AS (
+			UPDATE jobs
+			SET    status       = 'running',
+			       claimed_at   = NOW(),
+			       claimed_by   = $1,
+			       heartbeat_at = NOW(),
+			       updated_at   = NOW()
+			WHERE id IN (
+				SELECT id FROM jobs
+				WHERE  status       = 'pending'
+				  AND  scheduled_at <= NOW()
+				ORDER BY scheduled_at ASC
+				LIMIT $2
+				FOR UPDATE SKIP LOCKED
+			)
+			RETURNING id, user_id, idempotency_key, url, method, headers, body,
+			          timeout_seconds, status, scheduled_at, retry_count,
+			          max_retries, backoff, claimed_at, claimed_by,
+			          heartbeat_at, completed_at, last_error, created_at, updated_at, schedule_id,
+			          webhook_url, webhook_headers, replay_of
+		), hb AS (
+			INSERT INTO job_heartbeats (job_id, heartbeat_at)
+			SELECT id, NOW() FROM claimed
+			ON CONFLICT (job_id) DO UPDATE SET heartbeat_at = EXCLUDED.heartbeat_at
 		)
-		RETURNING id, user_id, idempotency_key, url, method, headers, body,
-		          timeout_seconds, status, scheduled_at, retry_count,
-		          max_retries, backoff, claimed_at, claimed_by,
-		          heartbeat_at, completed_at, last_error, created_at, updated_at, schedule_id,
-		          webhook_url, webhook_headers, replay_of`
+		SELECT id, user_id, idempotency_key, url, method, headers, body,
+		       timeout_seconds, status, scheduled_at, retry_count,
+		       max_retries, backoff, claimed_at, claimed_by,
+		       heartbeat_at, completed_at, last_error, created_at, updated_at, schedule_id,
+		       webhook_url, webhook_headers, replay_of
+		FROM claimed`
 
 	rows, err := r.pool.Query(ctx, query, workerID, limit)
 	if err != nil {
@@ -119,80 +133,113 @@ func (r *JobRepository) Claim(ctx context.Context, workerID string, limit int) (
 }
 
 func (r *JobRepository) UpdateHeartbeat(ctx context.Context, jobID string) error {
+	// Writes only the tiny sidecar row (a HOT update — no index churn, no rewrite
+	// of the heavy jobs row). Guarded so we never heartbeat a job that has left
+	// 'running'; upsert so a missing row self-heals. See migration 20260614000001.
 	_, err := r.pool.Exec(ctx,
-		`UPDATE jobs SET heartbeat_at = NOW(), updated_at = NOW()
-		WHERE id = $1 AND status = 'running'`, jobID)
+		`INSERT INTO job_heartbeats (job_id, heartbeat_at)
+		 SELECT $1, NOW()
+		 WHERE EXISTS (SELECT 1 FROM jobs WHERE id = $1 AND status = 'running')
+		 ON CONFLICT (job_id) DO UPDATE SET heartbeat_at = EXCLUDED.heartbeat_at`, jobID)
 	return err
 }
 
 func (r *JobRepository) Complete(ctx context.Context, jobID string) error {
+	// Leaving 'running' → drop the heartbeat sidecar row so it stays tiny.
 	_, err := r.pool.Exec(ctx,
-		`UPDATE jobs SET status = 'completed', completed_at = NOW(), updated_at = NOW()
-		WHERE id = $1`, jobID)
+		`WITH done AS (
+			UPDATE jobs SET status = 'completed', completed_at = NOW(), updated_at = NOW()
+			WHERE id = $1 RETURNING id
+		 )
+		 DELETE FROM job_heartbeats WHERE job_id IN (SELECT id FROM done)`, jobID)
 	return err
 }
 
 func (r *JobRepository) Fail(ctx context.Context, jobID string, lastError string) error {
 	_, err := r.pool.Exec(ctx,
-		`UPDATE jobs SET status = 'failed', last_error = $2, updated_at = NOW()
-		WHERE id = $1`, jobID, lastError)
+		`WITH done AS (
+			UPDATE jobs SET status = 'failed', last_error = $2, updated_at = NOW()
+			WHERE id = $1 RETURNING id
+		 )
+		 DELETE FROM job_heartbeats WHERE job_id IN (SELECT id FROM done)`, jobID, lastError)
 	return err
 }
 
 func (r *JobRepository) Reschedule(ctx context.Context, jobID string, lastError string, retryAt time.Time) error {
 	// make sure that retry_count is not over-incremented due to multiple workers trying to re-schedule same jobs
 	_, err := r.pool.Exec(ctx,
-		`UPDATE jobs
-		SET    status       = 'pending',
-		       retry_count  = retry_count + 1,
-		       last_error   = $2,
-		       scheduled_at = $3,
-		       claimed_at   = NULL,
-		       claimed_by   = NULL,
-		       heartbeat_at = NULL,
-		       updated_at   = NOW()
-		WHERE id = $1`, jobID, lastError, retryAt)
+		`WITH done AS (
+			UPDATE jobs
+			SET    status       = 'pending',
+			       retry_count  = retry_count + 1,
+			       last_error   = $2,
+			       scheduled_at = $3,
+			       claimed_at   = NULL,
+			       claimed_by   = NULL,
+			       heartbeat_at = NULL,
+			       updated_at   = NOW()
+			WHERE id = $1 RETURNING id
+		 )
+		 DELETE FROM job_heartbeats WHERE job_id IN (SELECT id FROM done)`, jobID, lastError, retryAt)
 	return err
 }
 
 func (r *JobRepository) RescheduleStale(ctx context.Context, staleCutoff time.Time, limit int) (int, error) {
-	tag, err := r.pool.Exec(ctx, `
-		UPDATE jobs
-		SET    status       = 'pending',
-		       retry_count  = retry_count + 1,
-		       last_error   = 'worker timeout',
-		       claimed_at   = NULL,
-		       claimed_by   = NULL,
-		       heartbeat_at = NULL,
-		       updated_at   = NOW()
-		WHERE id IN (
-			SELECT id FROM jobs
-			WHERE  status       = 'running'
-			  AND  heartbeat_at < $1
-			  AND  retry_count  < max_retries
-			ORDER BY heartbeat_at ASC
+	// Staleness comes from the sidecar. A running job whose heartbeat row is
+	// missing (h.heartbeat_at IS NULL) is treated as stale too — defensive.
+	var n int
+	err := r.pool.QueryRow(ctx, `
+		WITH stale AS (
+			SELECT j.id FROM jobs j
+			LEFT JOIN job_heartbeats h ON h.job_id = j.id
+			WHERE  j.status      = 'running'
+			  AND  (h.heartbeat_at IS NULL OR h.heartbeat_at < $1)
+			  AND  j.retry_count  < j.max_retries
+			ORDER BY h.heartbeat_at ASC NULLS FIRST
 			LIMIT $2
-			FOR UPDATE SKIP LOCKED
-		)`, staleCutoff, limit)
-	return int(tag.RowsAffected()), err
+			FOR UPDATE OF j SKIP LOCKED
+		), upd AS (
+			UPDATE jobs
+			SET    status       = 'pending',
+			       retry_count  = retry_count + 1,
+			       last_error   = 'worker timeout',
+			       claimed_at   = NULL,
+			       claimed_by   = NULL,
+			       heartbeat_at = NULL,
+			       updated_at   = NOW()
+			WHERE id IN (SELECT id FROM stale)
+			RETURNING id
+		), del AS (
+			DELETE FROM job_heartbeats WHERE job_id IN (SELECT id FROM upd)
+		)
+		SELECT count(*) FROM upd`, staleCutoff, limit).Scan(&n)
+	return n, err
 }
 
 func (r *JobRepository) FailStale(ctx context.Context, staleCutoff time.Time, limit int) (int, error) {
-	tag, err := r.pool.Exec(ctx, `
-		UPDATE jobs
-		SET    status      = 'failed',
-		       last_error  = 'worker timeout: max retries exceeded',
-		       updated_at  = NOW()
-		WHERE id IN (
-			SELECT id FROM jobs
-			WHERE  status       = 'running'
-			  AND  heartbeat_at < $1
-			  AND  retry_count  >= max_retries
-			ORDER BY heartbeat_at ASC
+	var n int
+	err := r.pool.QueryRow(ctx, `
+		WITH stale AS (
+			SELECT j.id FROM jobs j
+			LEFT JOIN job_heartbeats h ON h.job_id = j.id
+			WHERE  j.status      = 'running'
+			  AND  (h.heartbeat_at IS NULL OR h.heartbeat_at < $1)
+			  AND  j.retry_count  >= j.max_retries
+			ORDER BY h.heartbeat_at ASC NULLS FIRST
 			LIMIT $2
-			FOR UPDATE SKIP LOCKED
-		)`, staleCutoff, limit)
-	return int(tag.RowsAffected()), err
+			FOR UPDATE OF j SKIP LOCKED
+		), upd AS (
+			UPDATE jobs
+			SET    status      = 'failed',
+			       last_error  = 'worker timeout: max retries exceeded',
+			       updated_at  = NOW()
+			WHERE id IN (SELECT id FROM stale)
+			RETURNING id
+		), del AS (
+			DELETE FROM job_heartbeats WHERE job_id IN (SELECT id FROM upd)
+		)
+		SELECT count(*) FROM upd`, staleCutoff, limit).Scan(&n)
+	return n, err
 }
 
 func (r *JobRepository) Cancel(ctx context.Context, jobID, userID string) error {

--- a/migrations/20260614000001_job_heartbeat_sidecar.sql
+++ b/migrations/20260614000001_job_heartbeat_sidecar.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+-- Heartbeat sidecar: move the every-10s heartbeat write off the heavy `jobs` row.
+--
+-- A running job's heartbeat used to rewrite the whole jobs row (url/headers/body,
+-- ~1.3KB) every 10s, and because heartbeat_at was indexed (idx_jobs_stale) the
+-- update could never be HOT. That is the dominant source of dead tuples / WAL on
+-- this table (measured: ~24MB dead heap+index per hour per 50 running jobs).
+--
+-- This table holds ONE tiny row per *currently running* job. It has no secondary
+-- index, so the heartbeat UPDATE is a HOT update (self-cleaning, no index churn),
+-- and the table stays tiny because rows are deleted when a job leaves 'running'.
+CREATE TABLE job_heartbeats (
+    job_id       TEXT PRIMARY KEY REFERENCES jobs(id) ON DELETE CASCADE,
+    heartbeat_at TIMESTAMPTZ NOT NULL
+) WITH (
+    fillfactor                      = 70,   -- headroom so updates stay HOT
+    autovacuum_vacuum_scale_factor  = 0.05,
+    autovacuum_vacuum_threshold     = 50,
+    autovacuum_analyze_scale_factor = 0.1
+);
+
+-- Keep in-flight jobs alive across the deploy: seed their heartbeat so the reaper
+-- doesn't immediately treat every running job as crashed.
+INSERT INTO job_heartbeats (job_id, heartbeat_at)
+SELECT id, COALESCE(heartbeat_at, NOW()) FROM jobs WHERE status = 'running'
+ON CONFLICT (job_id) DO NOTHING;
+
+-- The reaper now derives staleness from job_heartbeats, so this index is dead
+-- weight (and dropping it stops claim from maintaining it).
+DROP INDEX IF EXISTS idx_jobs_stale;
+
+-- +goose Down
+CREATE INDEX idx_jobs_stale ON jobs (heartbeat_at) WHERE status = 'running';
+DROP TABLE job_heartbeats;


### PR DESCRIPTION
Stacked on #52. The actual fix for the heartbeat write-amplification flagged in #52.

## Problem
A running job's heartbeat (`UPDATE jobs SET heartbeat_at=NOW()` every 10s) rewrote the **whole ~1.3 KB row** (url/headers/body) and could **never be HOT** because `heartbeat_at` was indexed (`idx_jobs_stale`). That's the dominant source of dead tuples + WAL on the hottest table.

## Change (jobs path only; interface unchanged)
- New `job_heartbeats(job_id PK → jobs ON DELETE CASCADE, heartbeat_at)` — **no secondary index**, `fillfactor 70`. One tiny row per *currently running* job.
- `UpdateHeartbeat` writes **only** the sidecar (HOT update, self-healing upsert, guarded to running jobs).
- `Claim` seeds the sidecar atomically in the same CTE; `Complete`/`Fail`/`Reschedule` drop the row so the table stays tiny.
- **Reaper** (`RescheduleStale`/`FailStale`) derives staleness from the sidecar via `LEFT JOIN`; a running job whose heartbeat row is **missing** is treated as stale too (defensive — a lost heartbeat == a dead worker). `idx_jobs_stale` dropped.
- Migration **backfills** in-flight running jobs so the reaper doesn't rescue them all on deploy.

`jobs.heartbeat_at` is kept (set at claim, cleared on reschedule) so the API field and `domain.Job` are unchanged.

## Impact (measured on the migrated schema, 50 running jobs × 360 beats/hr, autovacuum off)
| | dead tuples on `jobs` | churn table size |
|---|---|---|
| before | 15,426 | ~21 MB |
| after | **0** (jobs gets no heartbeat writes) | **~1.5 MB** sidecar, mostly HOT |

## Tests / no regression
- Real **goose** applies the full chain cleanly; `go build ./...` + `go test -race ./...` (CI parity) green.
- `internal/infrastructure/postgres` integration suite passes, incl. existing reaper tests (`RescheduleStale`/`FailStale`) and **new** sidecar tests: claim seeds it, heartbeat hits only the sidecar (asserts `jobs.heartbeat_at` unchanged), terminal transitions drop it, reaper uses it, and the missing-row-is-stale defensive path.
- Heartbeat benchmark latency unchanged (~835µs; the win is write-volume/bloat, not per-op latency).

Crash recovery is preserved: a dead worker stops updating the sidecar → reaper sees stale/absent heartbeat → reschedules. `buffer_items` has the identical shape and gets the same treatment in a follow-up PR (validated by the `crash.js` buffer chaos test).