### PR TITLE
perf(db): move buffer_item heartbeat to a sidecar table (Phase 2b)

### DIFF
--- a/docs/design/db-vacuum-tuning.md
+++ b/docs/design/db-vacuum-tuning.md
@@ -68,11 +68,15 @@ one-time `pg_repack` (online, no long lock) on `jobs`, `buffer_items`,
 `job_attempts` after deploy to compact what's already there. `VACUUM FULL` also
 works but takes an exclusive lock — avoid on the live scheduler.
 
-## Phase 2 — heartbeat sidecar (implemented for `jobs`, migration `20260614000001`)
+## Phase 2 — heartbeat sidecar (jobs `20260614000001`, buffer_items `20260614000002`)
 
-Status: **done for the jobs scheduler path.** `buffer_items` has the identical
-shape (`idx_buffer_items_stale`, full-row heartbeat) and gets the same treatment
-in a follow-up PR (validated by the `crash.js` buffer chaos test).
+Status: **done for both the jobs scheduler path and the buffer drainer path.**
+`buffer_item_heartbeats` mirrors `job_heartbeats` exactly (claim seeds it via a
+CTE; heartbeat is a HOT sidecar upsert; complete/fail/reschedule drop it; the
+reaper derives staleness via `LEFT JOIN`, a missing row counting as stale). The
+buffer change was validated end-to-end by the `crash.js` chaos test: SIGKILL the
+scheduler mid-flight → restart → reaper rescued every orphaned item to
+`completed`, zero loss.
 
 Measured on the migrated schema (50 running jobs × 360 beats/hr, autovacuum off
 to show raw churn): the old full-row heartbeat left **15.4k dead tuples / ~21 MB**

--- a/internal/infrastructure/postgres/buffer_item_heartbeat_integration_test.go
+++ b/internal/infrastructure/postgres/buffer_item_heartbeat_integration_test.go
@@ -1,0 +1,155 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func setupBufferRepoPool(t *testing.T) (*postgres.BufferRepository, *pgxpool.Pool, string) {
+	t.Helper()
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	return postgres.NewBufferRepository(pool), pool, userID
+}
+
+func bufHeartbeatRow(t *testing.T, pool *pgxpool.Pool, itemID string) (time.Time, bool) {
+	t.Helper()
+	var hb time.Time
+	if err := pool.QueryRow(context.Background(),
+		`SELECT heartbeat_at FROM buffer_item_heartbeats WHERE buffer_item_id = $1`, itemID).Scan(&hb); err != nil {
+		return time.Time{}, false
+	}
+	return hb, true
+}
+
+// claimBufferItem creates a buffer with tokens available + one pending item, then
+// claims it so it is 'running'.
+func claimBufferItem(t *testing.T, repo *postgres.BufferRepository, pool *pgxpool.Pool, userID string) *domain.BufferItem {
+	t.Helper()
+	ctx := context.Background()
+	b := newTestBuffer(t, repo, userID)
+	// Give the token bucket a full balance so the claim isn't gated by refill timing.
+	if _, err := pool.Exec(ctx, `UPDATE buffers SET tokens = 1000, last_refill_at = NOW() WHERE id = $1`, b.ID); err != nil {
+		t.Fatalf("fund token bucket: %v", err)
+	}
+	newTestItem(t, repo, b, domain.BufferItemPending)
+	item, err := repo.ClaimNextItem(ctx, b.ID, "worker-1")
+	if err != nil || item == nil {
+		t.Fatalf("claim next item: err=%v item=%v", err, item)
+	}
+	if item.Status != domain.BufferItemRunning {
+		t.Fatalf("status = %s, want running", item.Status)
+	}
+	return item
+}
+
+func TestBufferHeartbeat_ClaimSeedsSidecar(t *testing.T) {
+	repo, pool, userID := setupBufferRepoPool(t)
+	item := claimBufferItem(t, repo, pool, userID)
+	if _, ok := bufHeartbeatRow(t, pool, item.ID); !ok {
+		t.Fatal("expected a buffer_item_heartbeats row after claim")
+	}
+}
+
+func TestBufferHeartbeat_UpdateWritesSidecarOnly(t *testing.T) {
+	repo, pool, userID := setupBufferRepoPool(t)
+	ctx := context.Background()
+	item := claimBufferItem(t, repo, pool, userID)
+
+	before, ok := bufHeartbeatRow(t, pool, item.ID)
+	if !ok {
+		t.Fatal("no sidecar row after claim")
+	}
+	var rowHBBefore time.Time
+	if err := pool.QueryRow(ctx, `SELECT heartbeat_at FROM buffer_items WHERE id=$1`, item.ID).Scan(&rowHBBefore); err != nil {
+		t.Fatalf("read buffer_items.heartbeat_at: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	if err := repo.UpdateItemHeartbeat(ctx, item.ID); err != nil {
+		t.Fatalf("update heartbeat: %v", err)
+	}
+
+	after, _ := bufHeartbeatRow(t, pool, item.ID)
+	if !after.After(before) {
+		t.Fatalf("sidecar heartbeat did not advance: before=%v after=%v", before, after)
+	}
+	var rowHBAfter time.Time
+	if err := pool.QueryRow(ctx, `SELECT heartbeat_at FROM buffer_items WHERE id=$1`, item.ID).Scan(&rowHBAfter); err != nil {
+		t.Fatalf("read buffer_items.heartbeat_at: %v", err)
+	}
+	if !rowHBAfter.Equal(rowHBBefore) {
+		t.Fatalf("buffer_items.heartbeat_at changed (%v -> %v) — heartbeat should only touch the sidecar", rowHBBefore, rowHBAfter)
+	}
+}
+
+func TestBufferHeartbeat_TerminalTransitionsDropSidecar(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		act  func(repo *postgres.BufferRepository, id string) error
+	}{
+		{"complete", func(r *postgres.BufferRepository, id string) error { return r.CompleteItem(context.Background(), id, 200) }},
+		{"fail", func(r *postgres.BufferRepository, id string) error { return r.FailItem(context.Background(), id, "boom", nil) }},
+		{"reschedule", func(r *postgres.BufferRepository, id string) error {
+			return r.RescheduleItem(context.Background(), id, "boom", nil, time.Now().Add(time.Minute))
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, pool, userID := setupBufferRepoPool(t)
+			item := claimBufferItem(t, repo, pool, userID)
+			if _, ok := bufHeartbeatRow(t, pool, item.ID); !ok {
+				t.Fatal("expected sidecar row after claim")
+			}
+			if err := tc.act(repo, item.ID); err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if _, ok := bufHeartbeatRow(t, pool, item.ID); ok {
+				t.Fatalf("%s should have dropped the sidecar row", tc.name)
+			}
+		})
+	}
+}
+
+func TestBufferHeartbeat_RescheduleStaleUsesSidecar(t *testing.T) {
+	repo, pool, userID := setupBufferRepoPool(t)
+	ctx := context.Background()
+	item := claimBufferItem(t, repo, pool, userID)
+
+	n, err := repo.RescheduleStaleItems(ctx, time.Now().Add(time.Hour), 100)
+	if err != nil {
+		t.Fatalf("reschedule stale items: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("rescheduled %d, want 1", n)
+	}
+	if _, ok := bufHeartbeatRow(t, pool, item.ID); ok {
+		t.Fatal("reschedule-stale should drop the sidecar row")
+	}
+}
+
+func TestBufferHeartbeat_MissingSidecarRowIsStale(t *testing.T) {
+	repo, pool, userID := setupBufferRepoPool(t)
+	ctx := context.Background()
+	item := claimBufferItem(t, repo, pool, userID)
+	if _, err := pool.Exec(ctx, `DELETE FROM buffer_item_heartbeats WHERE buffer_item_id=$1`, item.ID); err != nil {
+		t.Fatalf("delete sidecar: %v", err)
+	}
+	// Past cutoff: only the missing row makes it stale.
+	n, err := repo.RescheduleStaleItems(ctx, time.Now().Add(-time.Hour), 100)
+	if err != nil {
+		t.Fatalf("reschedule stale items: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("rescheduled %d, want 1 (missing heartbeat must be treated as stale)", n)
+	}
+}

--- a/internal/infrastructure/postgres/buffer_repo.go
+++ b/internal/infrastructure/postgres/buffer_repo.go
@@ -315,19 +315,31 @@ func (r *BufferRepository) ClaimNextItem(ctx context.Context, bufferID, workerID
 			  AND  LEAST(b.rate_limit::double precision,
 			             b.tokens + EXTRACT(EPOCH FROM (NOW() - b.last_refill_at)) * b.rate_limit) >= 1
 			RETURNING b.id
+		),
+		claimed AS (
+			UPDATE buffer_items
+			SET    status       = 'running',
+			       claimed_at   = NOW(),
+			       claimed_by   = $1,
+			       heartbeat_at = NOW(),
+			       updated_at   = NOW()
+			WHERE  id IN (SELECT id FROM due)
+			  AND  EXISTS (SELECT 1 FROM bucket)
+			RETURNING id, buffer_id, user_id, url, method, headers, body,
+			          timeout_seconds, backoff, status, retry_count, max_retries,
+			          scheduled_at, claimed_at, claimed_by, heartbeat_at,
+			          completed_at, last_error, status_code, created_at, updated_at, replay_of
+		),
+		hb AS (
+			INSERT INTO buffer_item_heartbeats (buffer_item_id, heartbeat_at)
+			SELECT id, NOW() FROM claimed
+			ON CONFLICT (buffer_item_id) DO UPDATE SET heartbeat_at = EXCLUDED.heartbeat_at
 		)
-		UPDATE buffer_items
-		SET    status       = 'running',
-		       claimed_at   = NOW(),
-		       claimed_by   = $1,
-		       heartbeat_at = NOW(),
-		       updated_at   = NOW()
-		WHERE  id IN (SELECT id FROM due)
-		  AND  EXISTS (SELECT 1 FROM bucket)
-		RETURNING id, buffer_id, user_id, url, method, headers, body,
-		          timeout_seconds, backoff, status, retry_count, max_retries,
-		          scheduled_at, claimed_at, claimed_by, heartbeat_at,
-		          completed_at, last_error, status_code, created_at, updated_at, replay_of`
+		SELECT id, buffer_id, user_id, url, method, headers, body,
+		       timeout_seconds, backoff, status, retry_count, max_retries,
+		       scheduled_at, claimed_at, claimed_by, heartbeat_at,
+		       completed_at, last_error, status_code, created_at, updated_at, replay_of
+		FROM claimed`
 
 	item, err := scanBufferItem(r.pool.QueryRow(ctx, query, workerID, bufferID))
 	if err != nil {
@@ -340,83 +352,113 @@ func (r *BufferRepository) ClaimNextItem(ctx context.Context, bufferID, workerID
 }
 
 func (r *BufferRepository) UpdateItemHeartbeat(ctx context.Context, itemID string) error {
+	// Writes only the tiny sidecar row (HOT update). See migration 20260614000002.
 	_, err := r.pool.Exec(ctx,
-		`UPDATE buffer_items SET heartbeat_at = NOW(), updated_at = NOW()
-		WHERE id = $1 AND status = 'running'`, itemID)
+		`INSERT INTO buffer_item_heartbeats (buffer_item_id, heartbeat_at)
+		 SELECT $1, NOW()
+		 WHERE EXISTS (SELECT 1 FROM buffer_items WHERE id = $1 AND status = 'running')
+		 ON CONFLICT (buffer_item_id) DO UPDATE SET heartbeat_at = EXCLUDED.heartbeat_at`, itemID)
 	return err
 }
 
 func (r *BufferRepository) CompleteItem(ctx context.Context, itemID string, statusCode int) error {
 	_, err := r.pool.Exec(ctx,
-		`UPDATE buffer_items SET status = 'completed', status_code = $2, completed_at = NOW(), updated_at = NOW()
-		WHERE id = $1`, itemID, statusCode)
+		`WITH done AS (
+			UPDATE buffer_items SET status = 'completed', status_code = $2, completed_at = NOW(), updated_at = NOW()
+			WHERE id = $1 RETURNING id
+		 )
+		 DELETE FROM buffer_item_heartbeats WHERE buffer_item_id IN (SELECT id FROM done)`, itemID, statusCode)
 	return err
 }
 
 func (r *BufferRepository) FailItem(ctx context.Context, itemID string, lastError string, statusCode *int) error {
 	_, err := r.pool.Exec(ctx,
-		`UPDATE buffer_items SET status = 'failed', last_error = $2, status_code = $3, completed_at = NOW(), updated_at = NOW()
-		WHERE id = $1`, itemID, lastError, statusCode)
+		`WITH done AS (
+			UPDATE buffer_items SET status = 'failed', last_error = $2, status_code = $3, completed_at = NOW(), updated_at = NOW()
+			WHERE id = $1 RETURNING id
+		 )
+		 DELETE FROM buffer_item_heartbeats WHERE buffer_item_id IN (SELECT id FROM done)`, itemID, lastError, statusCode)
 	return err
 }
 
 func (r *BufferRepository) RescheduleItem(ctx context.Context, itemID string, lastError string, statusCode *int, retryAt time.Time) error {
 	_, err := r.pool.Exec(ctx,
-		`UPDATE buffer_items
-		SET    status       = 'pending',
-		       retry_count  = retry_count + 1,
-		       last_error   = $2,
-		       status_code  = $3,
-		       scheduled_at = $4,
-		       claimed_at   = NULL,
-		       claimed_by   = NULL,
-		       heartbeat_at = NULL,
-		       updated_at   = NOW()
-		WHERE id = $1`, itemID, lastError, statusCode, retryAt)
+		`WITH done AS (
+			UPDATE buffer_items
+			SET    status       = 'pending',
+			       retry_count  = retry_count + 1,
+			       last_error   = $2,
+			       status_code  = $3,
+			       scheduled_at = $4,
+			       claimed_at   = NULL,
+			       claimed_by   = NULL,
+			       heartbeat_at = NULL,
+			       updated_at   = NOW()
+			WHERE id = $1 RETURNING id
+		 )
+		 DELETE FROM buffer_item_heartbeats WHERE buffer_item_id IN (SELECT id FROM done)`, itemID, lastError, statusCode, retryAt)
 	return err
 }
 
 // ── Reaper methods ───────────────────────────────────────────────────────────
 
 func (r *BufferRepository) RescheduleStaleItems(ctx context.Context, staleCutoff time.Time, limit int) (int, error) {
-	tag, err := r.pool.Exec(ctx, `
-		UPDATE buffer_items
-		SET    status       = 'pending',
-		       retry_count  = retry_count + 1,
-		       last_error   = 'worker timeout',
-		       claimed_at   = NULL,
-		       claimed_by   = NULL,
-		       heartbeat_at = NULL,
-		       updated_at   = NOW()
-		WHERE id IN (
-			SELECT id FROM buffer_items
-			WHERE  status       = 'running'
-			  AND  heartbeat_at < $1
-			  AND  retry_count  < max_retries
-			ORDER BY heartbeat_at ASC
+	// Staleness comes from the sidecar; a running item with a missing heartbeat
+	// row is treated as stale too (defensive).
+	var n int
+	err := r.pool.QueryRow(ctx, `
+		WITH stale AS (
+			SELECT bi.id FROM buffer_items bi
+			LEFT JOIN buffer_item_heartbeats h ON h.buffer_item_id = bi.id
+			WHERE  bi.status      = 'running'
+			  AND  (h.heartbeat_at IS NULL OR h.heartbeat_at < $1)
+			  AND  bi.retry_count  < bi.max_retries
+			ORDER BY h.heartbeat_at ASC NULLS FIRST
 			LIMIT $2
-			FOR UPDATE SKIP LOCKED
-		)`, staleCutoff, limit)
-	return int(tag.RowsAffected()), err
+			FOR UPDATE OF bi SKIP LOCKED
+		), upd AS (
+			UPDATE buffer_items
+			SET    status       = 'pending',
+			       retry_count  = retry_count + 1,
+			       last_error   = 'worker timeout',
+			       claimed_at   = NULL,
+			       claimed_by   = NULL,
+			       heartbeat_at = NULL,
+			       updated_at   = NOW()
+			WHERE id IN (SELECT id FROM stale)
+			RETURNING id
+		), del AS (
+			DELETE FROM buffer_item_heartbeats WHERE buffer_item_id IN (SELECT id FROM upd)
+		)
+		SELECT count(*) FROM upd`, staleCutoff, limit).Scan(&n)
+	return n, err
 }
 
 func (r *BufferRepository) FailStaleItems(ctx context.Context, staleCutoff time.Time, limit int) (int, error) {
-	tag, err := r.pool.Exec(ctx, `
-		UPDATE buffer_items
-		SET    status      = 'failed',
-		       last_error  = 'worker timeout: max retries exceeded',
-		       completed_at = NOW(),
-		       updated_at  = NOW()
-		WHERE id IN (
-			SELECT id FROM buffer_items
-			WHERE  status       = 'running'
-			  AND  heartbeat_at < $1
-			  AND  retry_count  >= max_retries
-			ORDER BY heartbeat_at ASC
+	var n int
+	err := r.pool.QueryRow(ctx, `
+		WITH stale AS (
+			SELECT bi.id FROM buffer_items bi
+			LEFT JOIN buffer_item_heartbeats h ON h.buffer_item_id = bi.id
+			WHERE  bi.status      = 'running'
+			  AND  (h.heartbeat_at IS NULL OR h.heartbeat_at < $1)
+			  AND  bi.retry_count  >= bi.max_retries
+			ORDER BY h.heartbeat_at ASC NULLS FIRST
 			LIMIT $2
-			FOR UPDATE SKIP LOCKED
-		)`, staleCutoff, limit)
-	return int(tag.RowsAffected()), err
+			FOR UPDATE OF bi SKIP LOCKED
+		), upd AS (
+			UPDATE buffer_items
+			SET    status      = 'failed',
+			       last_error  = 'worker timeout: max retries exceeded',
+			       completed_at = NOW(),
+			       updated_at  = NOW()
+			WHERE id IN (SELECT id FROM stale)
+			RETURNING id
+		), del AS (
+			DELETE FROM buffer_item_heartbeats WHERE buffer_item_id IN (SELECT id FROM upd)
+		)
+		SELECT count(*) FROM upd`, staleCutoff, limit).Scan(&n)
+	return n, err
 }
 
 // ── Scan helpers ─────────────────────────────────────────────────────────────

--- a/migrations/20260614000002_buffer_item_heartbeat_sidecar.sql
+++ b/migrations/20260614000002_buffer_item_heartbeat_sidecar.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+-- Heartbeat sidecar for buffer_items — mirror of job_heartbeats (migration
+-- 20260614000001). buffer_items has the identical claim -> heartbeat -> drain
+-- shape, so the every-10s heartbeat rewrote the whole item row (url/headers/body)
+-- and could never be HOT because heartbeat_at was indexed (idx_buffer_items_stale).
+CREATE TABLE buffer_item_heartbeats (
+    buffer_item_id TEXT PRIMARY KEY REFERENCES buffer_items(id) ON DELETE CASCADE,
+    heartbeat_at   TIMESTAMPTZ NOT NULL
+) WITH (
+    fillfactor                      = 70,
+    autovacuum_vacuum_scale_factor  = 0.05,
+    autovacuum_vacuum_threshold     = 50,
+    autovacuum_analyze_scale_factor = 0.1
+);
+
+-- Keep in-flight items alive across the deploy.
+INSERT INTO buffer_item_heartbeats (buffer_item_id, heartbeat_at)
+SELECT id, COALESCE(heartbeat_at, NOW()) FROM buffer_items WHERE status = 'running'
+ON CONFLICT (buffer_item_id) DO NOTHING;
+
+DROP INDEX IF EXISTS idx_buffer_items_stale;
+
+-- +goose Down
+CREATE INDEX idx_buffer_items_stale ON buffer_items (heartbeat_at) WHERE status = 'running';
+DROP TABLE buffer_item_heartbeats;


### PR DESCRIPTION
Stacked on #53. Applies the heartbeat-sidecar pattern to the **buffer drainer** path (the GTM wedge), which had the identical write-amplification as `jobs`.

## Change (interface unchanged)
- New `buffer_item_heartbeats(buffer_item_id PK → buffer_items ON DELETE CASCADE, heartbeat_at)` — no secondary index, `fillfactor 70`.
- `ClaimNextItem` seeds the sidecar inside its existing token-bucket CTE.
- `UpdateItemHeartbeat` writes **only** the sidecar (HOT upsert, guarded to running).
- `CompleteItem`/`FailItem`/`RescheduleItem` drop the row.
- `RescheduleStaleItems`/`FailStaleItems` derive staleness via `LEFT JOIN` to the sidecar (missing row = stale, defensive). `idx_buffer_items_stale` dropped; migration backfills in-flight items.

## Tests / no regression
- Real **goose** applies the full chain; `go build` + `go test -race ./...` green.
- New integration tests: claim seeds it, heartbeat hits only the sidecar (asserts `buffer_items.heartbeat_at` unchanged), terminal transitions drop it, reaper uses it, missing-row-is-stale.
- **`crash.js` chaos test passed**: load 10 items behind a stalling sink, SIGKILL the scheduler mid-flight, restart → reaper rescued **all 10 to `completed`, zero loss** (`buffer survived restart` ✓, `all items recovered` ✓).

Same removal of write-amplification as #53: `buffer_items` now takes zero heartbeat writes; the tiny sidecar absorbs them (mostly HOT, isolated cheap vacuum).