### PR TITLE
perf(db): partition job_attempts by month for retention (Phase 3)

### DIFF
--- a/docs/design/db-vacuum-tuning.md
+++ b/docs/design/db-vacuum-tuning.md
@@ -108,11 +108,33 @@ sidecar, the reaper sees a stale/absent heartbeat and reschedules. This touches
 claim/heartbeat/reschedule/reaper, so it ships as its own PR with integration +
 crash tests. It is the change that actually removes the write-amplification.
 
-## Phase 3 — retention / partitioning (future)
+## Phase 3 — partition `job_attempts` by month (migration `20260614000003`)
 
-Range-partition `job_attempts` (and optionally completed `jobs`) by month so old
-data is dropped with `DROP PARTITION` (no vacuum cost) instead of `DELETE` (which
-generates more dead tuples). Keep hot partitions small → cheap autovacuum.
+Status: **done.** `job_attempts` is now `PARTITION BY RANGE (started_at)`, monthly,
+with a `DEFAULT` catch-all. PK is `(id, started_at)` and the unique guard is
+`(job_id, attempt_num, started_at)` (the partition key must be in every unique
+key). `CompleteAttempt` now passes `started_at`, so the completion UPDATE prunes
+to a single partition. The conversion migration renames the old table, frees the
+colliding constraint/index names, creates the partitioned table + partitions, and
+copies the data (validated: existing rows are preserved and routed to the right
+month). `job_attempts` has no inbound FKs, so this is clean.
+
+**Retention runbook.** Drop expired months instead of `DELETE` (instant, no dead
+tuples):
+
+```sql
+DROP TABLE job_attempts_2026_03;   -- e.g. keep the last N months
+```
+
+**Partition rotation (operational follow-up).** Monthly partitions are
+pre-created through 2027-12 plus a `DEFAULT`. Before then, a periodic job must
+create next month's partition and drop expired ones — either a small scheduler
+task or `pg_partman`. Until automated, the `DEFAULT` partition absorbs overflow
+(keep it empty by pre-creating ahead so future `CREATE PARTITION` stays fast).
+
+**Operational note.** The conversion copies all rows under a lock for the copy's
+duration. `job_attempts` is small today; on a large table, run during a
+low-traffic window or migrate online (e.g. `pg_partman` + background copy).
 
 ## Benchmarks
 

--- a/internal/infrastructure/postgres/attempt_repo.go
+++ b/internal/infrastructure/postgres/attempt_repo.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -27,15 +28,17 @@ func (r *AttemptRepository) CreateAttempt(ctx context.Context, a *domain.JobAtte
 	return scanAttempt(row)
 }
 
-func (r *AttemptRepository) CompleteAttempt(ctx context.Context, id string, statusCode *int, errMsg *string, durationMS int64) error {
+func (r *AttemptRepository) CompleteAttempt(ctx context.Context, id string, startedAt time.Time, statusCode *int, errMsg *string, durationMS int64) error {
+	// started_at is the partition key — including it prunes the UPDATE to the one
+	// partition holding this attempt.
 	_, err := r.pool.Exec(ctx, `
 		UPDATE job_attempts
 		SET completed_at = NOW(),
-		    status_code  = $2,
-		    error        = $3,
-		    duration_ms  = $4
-		WHERE id = $1`,
-		id, statusCode, errMsg, durationMS,
+		    status_code  = $3,
+		    error        = $4,
+		    duration_ms  = $5
+		WHERE id = $1 AND started_at = $2`,
+		id, startedAt, statusCode, errMsg, durationMS,
 	)
 	if err != nil {
 		return fmt.Errorf("complete attempt: %w", err)

--- a/internal/infrastructure/postgres/attempt_repo_integration_test.go
+++ b/internal/infrastructure/postgres/attempt_repo_integration_test.go
@@ -55,7 +55,7 @@ func TestAttemptRepo_CreateAndComplete(t *testing.T) {
 	// Complete the attempt
 	statusCode := 200
 	var durationMS int64 = 150
-	if err := attemptRepo.CompleteAttempt(ctx, attempt.ID, &statusCode, nil, durationMS); err != nil {
+	if err := attemptRepo.CompleteAttempt(ctx, attempt.ID, attempt.StartedAt, &statusCode, nil, durationMS); err != nil {
 		t.Fatalf("complete attempt: %v", err)
 	}
 }

--- a/internal/infrastructure/postgres/hotpath_bench_test.go
+++ b/internal/infrastructure/postgres/hotpath_bench_test.go
@@ -98,7 +98,7 @@ func BenchmarkAttemptCreateComplete(b *testing.B) {
 		if err != nil {
 			b.Fatalf("create attempt: %v", err)
 		}
-		if err := attempts.CompleteAttempt(ctx, a.ID, &statusCode, nil, 12); err != nil {
+		if err := attempts.CompleteAttempt(ctx, a.ID, a.StartedAt, &statusCode, nil, 12); err != nil {
 			b.Fatalf("complete attempt: %v", err)
 		}
 	}

--- a/internal/infrastructure/postgres/job_attempts_partition_integration_test.go
+++ b/internal/infrastructure/postgres/job_attempts_partition_integration_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+)
+
+func TestJobAttempts_IsRangePartitioned(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	ctx := context.Background()
+	var relkind string
+	if err := pool.QueryRow(ctx,
+		`SELECT relkind::text FROM pg_class WHERE relname = 'job_attempts'`).Scan(&relkind); err != nil {
+		t.Fatalf("query relkind: %v", err)
+	}
+	if relkind != "p" { // 'p' = partitioned table
+		t.Fatalf("job_attempts relkind = %q, want 'p' (partitioned)", relkind)
+	}
+}
+
+// An attempt's row lands in the monthly partition for its started_at, and the
+// completion UPDATE (which now passes started_at) finds and updates it.
+func TestJobAttempts_RowRoutesToMonthlyPartition(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	ctx := context.Background()
+
+	jobRepo := postgres.NewJobRepository(pool)
+	attempts := postgres.NewAttemptRepository(pool)
+
+	job, err := jobRepo.Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+
+	started := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC) // -> job_attempts_2026_03
+	a, err := attempts.CreateAttempt(ctx, &domain.JobAttempt{
+		JobID: job.ID, AttemptNum: 1, WorkerID: "w1", StartedAt: started,
+	})
+	if err != nil {
+		t.Fatalf("create attempt: %v", err)
+	}
+
+	var part string
+	if err := pool.QueryRow(ctx,
+		`SELECT tableoid::regclass::text FROM job_attempts WHERE id = $1 AND started_at = $2`,
+		a.ID, a.StartedAt).Scan(&part); err != nil {
+		t.Fatalf("locate partition: %v", err)
+	}
+	if part != "job_attempts_2026_03" {
+		t.Fatalf("row landed in %q, want job_attempts_2026_03", part)
+	}
+
+	sc := 200
+	if err := attempts.CompleteAttempt(ctx, a.ID, a.StartedAt, &sc, nil, 42); err != nil {
+		t.Fatalf("complete attempt: %v", err)
+	}
+	got, err := attempts.ListByJobID(ctx, job.ID)
+	if err != nil || len(got) != 1 || got[0].CompletedAt == nil {
+		t.Fatalf("expected 1 completed attempt, got %+v err=%v", got, err)
+	}
+}
+
+// Retention: dropping an old partition removes its rows with no DELETE/vacuum.
+func TestJobAttempts_DropPartitionRetention(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	ctx := context.Background()
+
+	jobRepo := postgres.NewJobRepository(pool)
+	attempts := postgres.NewAttemptRepository(pool)
+	job, err := jobRepo.Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+
+	// A dedicated far-future partition so we never disturb the migration's set.
+	if _, err := pool.Exec(ctx,
+		`CREATE TABLE IF NOT EXISTS job_attempts_test_2031_01 PARTITION OF job_attempts
+		 FOR VALUES FROM ('2031-01-01') TO ('2031-02-01')`); err != nil {
+		t.Fatalf("create test partition: %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), `DROP TABLE IF EXISTS job_attempts_test_2031_01`) })
+
+	if _, err := attempts.CreateAttempt(ctx, &domain.JobAttempt{
+		JobID: job.ID, AttemptNum: 1, WorkerID: "w1", StartedAt: time.Date(2031, 1, 10, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("create attempt: %v", err)
+	}
+	if got, _ := attempts.ListByJobID(ctx, job.ID); len(got) != 1 {
+		t.Fatalf("expected 1 attempt before drop, got %d", len(got))
+	}
+
+	// Retention = drop the whole partition (instant, no dead tuples).
+	if _, err := pool.Exec(ctx, `DROP TABLE job_attempts_test_2031_01`); err != nil {
+		t.Fatalf("drop partition: %v", err)
+	}
+	if got, _ := attempts.ListByJobID(ctx, job.ID); len(got) != 0 {
+		t.Fatalf("expected 0 attempts after dropping the partition, got %d", len(got))
+	}
+}

--- a/internal/infrastructure/postgres/stats_repo_integration_test.go
+++ b/internal/infrastructure/postgres/stats_repo_integration_test.go
@@ -32,7 +32,7 @@ func seedCompletedAttempt(t *testing.T, jobRepo *postgres.JobRepository, attempt
 		t.Fatalf("seed attempt: %v", err)
 	}
 	sc := statusCode
-	if err := attemptRepo.CompleteAttempt(ctx, attempt.ID, &sc, errMsg, durationMS); err != nil {
+	if err := attemptRepo.CompleteAttempt(ctx, attempt.ID, attempt.StartedAt, &sc, errMsg, durationMS); err != nil {
 		t.Fatalf("complete attempt: %v", err)
 	}
 }

--- a/internal/repository/attempt.go
+++ b/internal/repository/attempt.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"time"
 
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
 )
@@ -13,9 +14,11 @@ type AttemptRepository interface {
 	CreateAttempt(ctx context.Context, attempt *domain.JobAttempt) (*domain.JobAttempt, error)
 
 	// CompleteAttempt closes an open attempt record with the execution outcome.
+	// startedAt is the attempt's started_at (from CreateAttempt's return value);
+	// it is the partition key, so passing it prunes the UPDATE to one partition.
 	// statusCode is nil when the HTTP request never received a response.
 	// errMsg is nil on success.
-	CompleteAttempt(ctx context.Context, id string, statusCode *int, errMsg *string, durationMS int64) error
+	CompleteAttempt(ctx context.Context, id string, startedAt time.Time, statusCode *int, errMsg *string, durationMS int64) error
 
 	// ListByJobID returns all attempts for a job, ordered by started_at ASC.
 	// Ownership is assumed to have been verified by the caller.

--- a/internal/scheduler/worker.go
+++ b/internal/scheduler/worker.go
@@ -247,7 +247,7 @@ func (w *Worker) runJob(ctx context.Context, job *domain.Job) {
 
 // closeAttempt writes the execution outcome to the attempt record.
 func (w *Worker) closeAttempt(ctx context.Context, attempt *domain.JobAttempt, statusCode *int, errMsg *string, durationMS int64) {
-	if err := w.attempts.CompleteAttempt(ctx, attempt.ID, statusCode, errMsg, durationMS); err != nil {
+	if err := w.attempts.CompleteAttempt(ctx, attempt.ID, attempt.StartedAt, statusCode, errMsg, durationMS); err != nil {
 		w.logger.ErrorContext(ctx, "complete attempt record", "job_id", attempt.JobID, "error", err)
 	}
 }

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -115,7 +115,7 @@ func (m *MockJobRepository) ListByScheduleID(ctx context.Context, scheduleID str
 
 type MockAttemptRepository struct {
 	CreateAttemptFn   func(ctx context.Context, attempt *domain.JobAttempt) (*domain.JobAttempt, error)
-	CompleteAttemptFn func(ctx context.Context, id string, statusCode *int, errMsg *string, durationMS int64) error
+	CompleteAttemptFn func(ctx context.Context, id string, startedAt time.Time, statusCode *int, errMsg *string, durationMS int64) error
 	ListByJobIDFn     func(ctx context.Context, jobID string) ([]*domain.JobAttempt, error)
 }
 
@@ -127,9 +127,9 @@ func (m *MockAttemptRepository) CreateAttempt(ctx context.Context, attempt *doma
 	return attempt, nil
 }
 
-func (m *MockAttemptRepository) CompleteAttempt(ctx context.Context, id string, statusCode *int, errMsg *string, durationMS int64) error {
+func (m *MockAttemptRepository) CompleteAttempt(ctx context.Context, id string, startedAt time.Time, statusCode *int, errMsg *string, durationMS int64) error {
 	if m.CompleteAttemptFn != nil {
-		return m.CompleteAttemptFn(ctx, id, statusCode, errMsg, durationMS)
+		return m.CompleteAttemptFn(ctx, id, startedAt, statusCode, errMsg, durationMS)
 	}
 	return nil
 }

--- a/migrations/20260614000003_partition_job_attempts.sql
+++ b/migrations/20260614000003_partition_job_attempts.sql
@@ -1,0 +1,90 @@
+-- +goose Up
+-- Range-partition job_attempts by month (on started_at) so retention is a cheap
+-- DROP TABLE of an old partition instead of a bloat-generating DELETE, and so
+-- autovacuum/scans stay bounded as history grows forever.
+--
+-- job_attempts has no inbound FKs, so it converts cleanly. The partition key
+-- (started_at) must be part of every unique key, hence PK (id, started_at) and
+-- UNIQUE (job_id, attempt_num, started_at). CompleteAttempt now passes started_at
+-- so the UPDATE prunes to a single partition.
+--
+-- NOTE: the data copy below holds a lock for its duration. job_attempts is small
+-- today; on a large table run this during a low-traffic window (or migrate with
+-- pg_partman/online tooling). See docs/design/db-vacuum-tuning.md.
+
+ALTER TABLE job_attempts RENAME TO job_attempts_old;
+
+-- A table rename keeps its constraint/index names, which would collide with the
+-- new table's. Free them (data stays; the copy below is a seq scan).
+ALTER TABLE job_attempts_old DROP CONSTRAINT IF EXISTS job_attempts_pkey;
+ALTER TABLE job_attempts_old DROP CONSTRAINT IF EXISTS job_attempts_job_id_fkey;
+DROP INDEX IF EXISTS idx_attempts_job_id;
+
+CREATE TABLE job_attempts (
+    id           TEXT        NOT NULL DEFAULT gen_random_uuid()::text,
+    job_id       TEXT        NOT NULL REFERENCES jobs(id),
+    attempt_num  INT         NOT NULL,
+    worker_id    TEXT        NOT NULL,
+    started_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    status_code  INT,
+    error        TEXT,
+    duration_ms  BIGINT,
+    PRIMARY KEY (id, started_at),
+    UNIQUE (job_id, attempt_num, started_at)
+) PARTITION BY RANGE (started_at);
+
+-- Partitioned index (propagates to every partition).
+CREATE INDEX idx_attempts_job_id ON job_attempts (job_id);
+
+-- Monthly partitions covering existing data and ~1.5 years forward, plus a
+-- DEFAULT catch-all so an insert never fails if partition rotation lags.
+-- (Ongoing rotation — create next month, drop expired — is a periodic op;
+-- see the retention runbook in the design doc.)
+-- +goose StatementBegin
+DO $$
+DECLARE
+    d date := date '2026-01-01';
+BEGIN
+    WHILE d < date '2028-01-01' LOOP
+        EXECUTE format(
+            'CREATE TABLE %I PARTITION OF job_attempts FOR VALUES FROM (%L) TO (%L) '
+            || 'WITH (fillfactor=85, autovacuum_vacuum_scale_factor=0.05, '
+            || 'autovacuum_vacuum_insert_scale_factor=0.1, autovacuum_analyze_scale_factor=0.05)',
+            'job_attempts_' || to_char(d, 'YYYY_MM'), d, (d + interval '1 month')::date);
+        d := (d + interval '1 month')::date;
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+CREATE TABLE job_attempts_default PARTITION OF job_attempts DEFAULT
+    WITH (fillfactor = 85, autovacuum_vacuum_scale_factor = 0.05);
+
+INSERT INTO job_attempts (id, job_id, attempt_num, worker_id, started_at, completed_at, status_code, error, duration_ms)
+SELECT id, job_id, attempt_num, worker_id, started_at, completed_at, status_code, error, duration_ms
+FROM job_attempts_old;
+
+DROP TABLE job_attempts_old;
+
+-- +goose Down
+ALTER TABLE job_attempts RENAME TO job_attempts_part;
+
+CREATE TABLE job_attempts (
+    id           TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    job_id       TEXT        NOT NULL REFERENCES jobs(id),
+    attempt_num  INT         NOT NULL,
+    worker_id    TEXT        NOT NULL,
+    started_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    status_code  INT,
+    error        TEXT,
+    duration_ms  BIGINT,
+    UNIQUE (job_id, attempt_num)
+) WITH (fillfactor = 85, autovacuum_vacuum_scale_factor = 0.05, autovacuum_vacuum_insert_scale_factor = 0.1, autovacuum_analyze_scale_factor = 0.05);
+CREATE INDEX idx_attempts_job_id ON job_attempts (job_id);
+
+INSERT INTO job_attempts (id, job_id, attempt_num, worker_id, started_at, completed_at, status_code, error, duration_ms)
+SELECT id, job_id, attempt_num, worker_id, started_at, completed_at, status_code, error, duration_ms
+FROM job_attempts_part;
+
+DROP TABLE job_attempts_part;


### PR DESCRIPTION
Stacked on #54. `job_attempts` grows forever (history + billing) and was never pruned, so vacuum/scan cost only rises. This range-partitions it by month so retention is a `DROP TABLE` of an old partition (instant, no dead tuples) instead of a bloat-generating `DELETE`.

## Change
- `job_attempts` → `PARTITION BY RANGE (started_at)`, monthly partitions (pre-created through 2027-12) + a `DEFAULT` catch-all.
- PK `(id, started_at)`, unique guard `(job_id, attempt_num, started_at)` — the partition key must be in every unique key.
- `CompleteAttempt` now takes `started_at` (threaded through the `AttemptRepository` interface + worker) so the completion UPDATE **prunes to one partition**. The worker already has it from `CreateAttempt`'s RETURNING.
- Conversion migration renames the old table, frees colliding constraint/index names (`job_attempts_pkey`, `_job_id_fkey`, `idx_attempts_job_id`), recreates partitioned, and **copies existing rows**.

`job_attempts` has no inbound FKs, so the conversion is clean.

## Tests / no regression
- Real **goose** applies the chain; `go build` + `go test -race ./...` green; full `postgres` integration suite passes.
- Validated the **data copy on a populated table**: seeded 3 attempts pre-migration → all preserved and routed to `job_attempts_2026_03/04/05`.
- New integration tests: table is partitioned, rows route to the month partition, and **DROP-PARTITION retention** removes a partition's rows with no DELETE.

## Operational notes (for the merge decision)
- The conversion **copies all rows under a lock** for the copy's duration — fine while small; on a large table run during low traffic or migrate online (pg_partman).
- **Partition rotation** (create next month / drop expired) is an operational follow-up — a small scheduler task or pg_partman. Until then the `DEFAULT` partition absorbs overflow and the retention runbook is a manual `DROP TABLE job_attempts_YYYY_MM`. Documented in `docs/design/db-vacuum-tuning.md`.