### PR TITLE
feat(scheduler): automate job_attempts partition rotation (Phase 3, cont.)

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -85,6 +85,13 @@ func main() {
 	bufferReaper := scheduler.NewBufferReaper(bufferRepo, logger, 30*time.Second, 30*time.Second)
 	go bufferReaper.Start(ctx)
 
+	partitionMaintainer := scheduler.NewPartitionMaintainer(
+		postgres.NewAttemptPartitionRepository(pool), logger,
+		time.Duration(cfg.PartitionMaintainIntervalSec)*time.Second,
+		cfg.PartitionMonthsAhead, cfg.JobAttemptRetentionMonths,
+	)
+	go partitionMaintainer.Start(ctx)
+
 	metricsSrv := metrics.NewServer(":"+cfg.MetricsPort, checker)
 	go func() {
 		logger.Info("metrics server started", "port", cfg.MetricsPort)

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,12 @@ type Config struct {
 	DispatchIntervalSec  int  `env:"DISPATCH_INTERVAL_SEC" envDefault:"5" validate:"min=1,max=60"`
 	DrainerConcurrency   int  `env:"DRAINER_CONCURRENCY" envDefault:"10" validate:"min=1,max=100"`
 	DrainerPollIntervalSec int `env:"DRAINER_POLL_INTERVAL_SEC" envDefault:"1" validate:"min=1,max=10"`
+	// Partition maintenance for job_attempts (range-partitioned by month).
+	PartitionMaintainIntervalSec int `env:"PARTITION_MAINTAIN_INTERVAL_SEC" envDefault:"21600" validate:"min=60"`
+	PartitionMonthsAhead         int `env:"PARTITION_MONTHS_AHEAD" envDefault:"3" validate:"min=1,max=24"`
+	// 0 = keep all attempt history forever (default). >0 drops partitions older
+	// than this many months — opt-in because attempts are billing records.
+	JobAttemptRetentionMonths int `env:"JOB_ATTEMPT_RETENTION_MONTHS" envDefault:"0" validate:"min=0,max=120"`
 
 	MetricsPort string `env:"METRICS_PORT" envDefault:"9090"`
 	LogLevel    string `env:"LOG_LEVEL" envDefault:"info" validate:"required,oneof=debug info warn error"`

--- a/docs/design/db-vacuum-tuning.md
+++ b/docs/design/db-vacuum-tuning.md
@@ -126,11 +126,15 @@ tuples):
 DROP TABLE job_attempts_2026_03;   -- e.g. keep the last N months
 ```
 
-**Partition rotation (operational follow-up).** Monthly partitions are
-pre-created through 2027-12 plus a `DEFAULT`. Before then, a periodic job must
-create next month's partition and drop expired ones — either a small scheduler
-task or `pg_partman`. Until automated, the `DEFAULT` partition absorbs overflow
-(keep it empty by pre-creating ahead so future `CREATE PARTITION` stays fast).
+**Partition rotation (automated).** The scheduler runs a `PartitionMaintainer`
+(`internal/scheduler/partition.go`) that, every `PARTITION_MAINTAIN_INTERVAL_SEC`
+(default 6h), ensures the current month + `PARTITION_MONTHS_AHEAD` (default 3)
+partitions exist. **Creation is always on** so the `DEFAULT` partition stays
+empty and there's no future cliff. **Dropping is opt-in:** with
+`JOB_ATTEMPT_RETENTION_MONTHS = 0` (default) nothing is ever dropped — attempts
+are billing records, so retention is a deliberate policy. Set it > 0 to have the
+maintainer drop partitions older than that many months (logged at WARN). The
+manual `DROP TABLE job_attempts_YYYY_MM` runbook above still works for one-offs.
 
 **Operational note.** The conversion copies all rows under a lock for the copy's
 duration. `job_attempts` is small today; on a large table, run during a

--- a/internal/infrastructure/postgres/partition_repo.go
+++ b/internal/infrastructure/postgres/partition_repo.go
@@ -1,0 +1,102 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// AttemptPartitionRepository manages job_attempts' monthly partitions.
+type AttemptPartitionRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewAttemptPartitionRepository(pool *pgxpool.Pool) *AttemptPartitionRepository {
+	return &AttemptPartitionRepository{pool: pool}
+}
+
+func monthStart(t time.Time) time.Time {
+	t = t.UTC()
+	return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+}
+
+func partitionName(m time.Time) string { return "job_attempts_" + m.Format("2006_01") }
+
+func (r *AttemptPartitionRepository) EnsureMonthlyPartitions(ctx context.Context, now time.Time, monthsAhead int) ([]string, error) {
+	var created []string
+	start := monthStart(now)
+	for i := 0; i <= monthsAhead; i++ {
+		m := start.AddDate(0, i, 0)
+		name := partitionName(m)
+
+		var exists bool
+		if err := r.pool.QueryRow(ctx,
+			`SELECT to_regclass('public.' || $1) IS NOT NULL`, name).Scan(&exists); err != nil {
+			return created, fmt.Errorf("check partition %s: %w", name, err)
+		}
+		if exists {
+			continue
+		}
+
+		next := m.AddDate(0, 1, 0)
+		// Identifiers/dates are derived from a time value, not user input. DDL
+		// can't be parameterized, so build the statement from sanitized parts.
+		ddl := fmt.Sprintf(
+			`CREATE TABLE IF NOT EXISTS %s PARTITION OF job_attempts FOR VALUES FROM ('%s') TO ('%s') `+
+				`WITH (fillfactor=85, autovacuum_vacuum_scale_factor=0.05, `+
+				`autovacuum_vacuum_insert_scale_factor=0.1, autovacuum_analyze_scale_factor=0.05)`,
+			pgx.Identifier{name}.Sanitize(), m.Format("2006-01-02"), next.Format("2006-01-02"))
+		if _, err := r.pool.Exec(ctx, ddl); err != nil {
+			return created, fmt.Errorf("create partition %s: %w", name, err)
+		}
+		created = append(created, name)
+	}
+	return created, nil
+}
+
+func (r *AttemptPartitionRepository) DropPartitionsBefore(ctx context.Context, cutoff time.Time) ([]string, error) {
+	cutoffMonth := monthStart(cutoff)
+
+	rows, err := r.pool.Query(ctx, `
+		SELECT c.relname
+		FROM pg_inherits i
+		JOIN pg_class c ON c.oid = i.inhrelid
+		JOIN pg_class p ON p.oid = i.inhparent
+		WHERE p.relname = 'job_attempts'
+		  AND c.relname ~ '^job_attempts_[0-9]{4}_[0-9]{2}$'`)
+	if err != nil {
+		return nil, fmt.Errorf("list partitions: %w", err)
+	}
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan partition name: %w", err)
+		}
+		names = append(names, n)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate partitions: %w", err)
+	}
+
+	var dropped []string
+	for _, name := range names {
+		m, perr := time.Parse("2006_01", name[len("job_attempts_"):])
+		if perr != nil {
+			continue // not a monthly partition we manage
+		}
+		if !m.UTC().Before(cutoffMonth) {
+			continue // keep current/future months
+		}
+		if _, err := r.pool.Exec(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, pgx.Identifier{name}.Sanitize())); err != nil {
+			return dropped, fmt.Errorf("drop partition %s: %w", name, err)
+		}
+		dropped = append(dropped, name)
+	}
+	return dropped, nil
+}

--- a/internal/infrastructure/postgres/partition_repo_integration_test.go
+++ b/internal/infrastructure/postgres/partition_repo_integration_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+)
+
+func TestPartition_EnsureCreatesFutureMonths(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	ctx := context.Background()
+	repo := postgres.NewAttemptPartitionRepository(pool)
+
+	// Far future so we never collide with the migration's pre-created set.
+	now := time.Date(2099, 1, 15, 0, 0, 0, 0, time.UTC)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DROP TABLE IF EXISTS job_attempts_2099_01, job_attempts_2099_02`)
+	})
+
+	created, err := repo.EnsureMonthlyPartitions(ctx, now, 1) // current + 1 ahead = 2
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if len(created) != 2 {
+		t.Fatalf("created %v, want 2 (2099_01, 2099_02)", created)
+	}
+	for _, name := range []string{"job_attempts_2099_01", "job_attempts_2099_02"} {
+		var exists bool
+		if err := pool.QueryRow(ctx, `SELECT to_regclass('public.'||$1) IS NOT NULL`, name).Scan(&exists); err != nil || !exists {
+			t.Fatalf("partition %s should exist (exists=%v err=%v)", name, exists, err)
+		}
+	}
+
+	// Idempotent: a second call creates nothing.
+	again, err := repo.EnsureMonthlyPartitions(ctx, now, 1)
+	if err != nil || len(again) != 0 {
+		t.Fatalf("second ensure should be a no-op, got %v err=%v", again, err)
+	}
+}
+
+func TestPartition_DropPartitionsBefore(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	ctx := context.Background()
+	repo := postgres.NewAttemptPartitionRepository(pool)
+
+	// A partition older than every migration-created one (which start 2026-01).
+	if _, err := pool.Exec(ctx,
+		`CREATE TABLE IF NOT EXISTS job_attempts_2025_12 PARTITION OF job_attempts
+		 FOR VALUES FROM ('2025-12-01') TO ('2026-01-01')`); err != nil {
+		t.Fatalf("create 2025_12: %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), `DROP TABLE IF EXISTS job_attempts_2025_12`) })
+
+	// Cutoff = 2026-01: only months strictly before 2026-01 are dropped, i.e.
+	// just our 2025_12 — the real 2026_* partitions are kept.
+	dropped, err := repo.DropPartitionsBefore(ctx, time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("drop: %v", err)
+	}
+	found := false
+	for _, n := range dropped {
+		if n == "job_attempts_2025_12" {
+			found = true
+		}
+		if n == "job_attempts_2026_06" {
+			t.Fatalf("dropped a current-era partition %s — cutoff should have kept it", n)
+		}
+	}
+	if !found {
+		t.Fatalf("expected job_attempts_2025_12 to be dropped, got %v", dropped)
+	}
+	var stillThere bool
+	if err := pool.QueryRow(ctx, `SELECT to_regclass('public.job_attempts_2026_06') IS NOT NULL`).Scan(&stillThere); err != nil || !stillThere {
+		t.Fatalf("job_attempts_2026_06 should still exist (exists=%v err=%v)", stillThere, err)
+	}
+}

--- a/internal/repository/partition.go
+++ b/internal/repository/partition.go
@@ -1,0 +1,20 @@
+package repository
+
+import (
+	"context"
+	"time"
+)
+
+// AttemptPartitionRepository manages the monthly partitions of job_attempts.
+// It is consumed by the scheduler's PartitionMaintainer.
+type AttemptPartitionRepository interface {
+	// EnsureMonthlyPartitions creates the partition for the month containing
+	// `now` plus the next `monthsAhead` months, if they don't already exist.
+	// Idempotent; returns the names actually created.
+	EnsureMonthlyPartitions(ctx context.Context, now time.Time, monthsAhead int) ([]string, error)
+
+	// DropPartitionsBefore drops every monthly partition whose month starts
+	// strictly before the month containing `cutoff`. This deletes data, so the
+	// caller gates it behind an explicit retention policy. Returns dropped names.
+	DropPartitionsBefore(ctx context.Context, cutoff time.Time) ([]string, error)
+}

--- a/internal/scheduler/partition.go
+++ b/internal/scheduler/partition.go
@@ -1,0 +1,73 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
+)
+
+// PartitionMaintainer keeps job_attempts' monthly partitions provisioned ahead of
+// time and (optionally) prunes expired ones. Creating partitions is always on;
+// dropping is gated by retentionMonths (0 = never drop — attempts are billing
+// records, so deletion is opt-in).
+type PartitionMaintainer struct {
+	repo            repository.AttemptPartitionRepository
+	logger          *slog.Logger
+	interval        time.Duration
+	monthsAhead     int
+	retentionMonths int
+}
+
+func NewPartitionMaintainer(repo repository.AttemptPartitionRepository, logger *slog.Logger, interval time.Duration, monthsAhead, retentionMonths int) *PartitionMaintainer {
+	return &PartitionMaintainer{
+		repo:            repo,
+		logger:          logger.With("component", "partition_maintainer"),
+		interval:        interval,
+		monthsAhead:     monthsAhead,
+		retentionMonths: retentionMonths,
+	}
+}
+
+func (m *PartitionMaintainer) Start(ctx context.Context) {
+	m.logger.InfoContext(ctx, "partition maintainer started",
+		"interval", m.interval, "months_ahead", m.monthsAhead, "retention_months", m.retentionMonths)
+
+	m.maintain(ctx) // run once immediately so partitions exist before the first tick
+
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			m.logger.InfoContext(ctx, "partition maintainer shut down")
+			return
+		case <-ticker.C:
+			m.maintain(ctx)
+		}
+	}
+}
+
+func (m *PartitionMaintainer) maintain(ctx context.Context) {
+	now := time.Now().UTC()
+
+	created, err := m.repo.EnsureMonthlyPartitions(ctx, now, m.monthsAhead)
+	if err != nil {
+		m.logger.ErrorContext(ctx, "ensure monthly partitions", "error", err)
+	} else if len(created) > 0 {
+		m.logger.InfoContext(ctx, "created job_attempts partitions", "partitions", created)
+	}
+
+	if m.retentionMonths <= 0 {
+		return // retention disabled — keep all history
+	}
+	cutoff := now.AddDate(0, -m.retentionMonths, 0)
+	dropped, err := m.repo.DropPartitionsBefore(ctx, cutoff)
+	if err != nil {
+		m.logger.ErrorContext(ctx, "drop expired partitions", "error", err)
+	} else if len(dropped) > 0 {
+		// WARN: this deleted attempt history (billing records).
+		m.logger.WarnContext(ctx, "dropped expired job_attempts partitions", "partitions", dropped, "retention_months", m.retentionMonths)
+	}
+}


### PR DESCRIPTION
Stacked on #55. Completes Phase 3 by making the partitioning self-sustaining — without this, the `DEFAULT` partition silently fills and someone must hand-create partitions before 2028.

## What
A `PartitionMaintainer` scheduler component (mirrors Reaper/Dispatcher):
- **Create — always on.** Every `PARTITION_MAINTAIN_INTERVAL_SEC` (default 6h) + once at startup, ensures the current month + `PARTITION_MONTHS_AHEAD` (default 3) partitions exist. Idempotent (`CREATE TABLE IF NOT EXISTS … PARTITION OF`). Keeps `DEFAULT` empty → no cliff, fast future `CREATE`.
- **Drop — opt-in, off by default.** `JOB_ATTEMPT_RETENTION_MONTHS = 0` (default) never deletes anything — **attempts are billing records**, so retention is a deliberate policy. Set > 0 to drop partitions older than N months (logged at WARN).

`AttemptPartitionRepository` (`EnsureMonthlyPartitions` / `DropPartitionsBefore`) in the postgres layer, behind a `repository.AttemptPartitionRepository` interface, wired into `cmd/scheduler`.

## Tests / no regression
- `go build` + `go test -race ./...` green; full `postgres` integration suite passes.
- New integration tests: `EnsureMonthlyPartitions` creates the right months and is idempotent; `DropPartitionsBefore` drops only months strictly before the cutoff (verified it removes a pre-2026 partition while keeping the real `2026_*` set).

## On the other follow-up (pg_repack)
Left as a one-time **operator** step (documented in the design doc): reclaiming pre-existing bloat is a production-DB mutation and is only relevant post-deploy — not something to automate here.