### PR TITLE
feat(api): search & filter on GET /jobs (url, method, time range)

### DIFF
--- a/internal/domain/job.go
+++ b/internal/domain/job.go
@@ -9,6 +9,8 @@ var (
 	ErrJobNotFound       = errors.New("job not found")
 	ErrDuplicateJob      = errors.New("job with this idempotency key already exists")
 	ErrInvalidStatus     = errors.New("invalid status value")
+	ErrInvalidMethod     = errors.New("invalid HTTP method filter")
+	ErrInvalidSearch     = errors.New("invalid search query")
 	ErrJobNotCancellable = errors.New("job is not in a cancellable state")
 	ErrJobNotReplayable  = errors.New("job is not in a replayable state")
 )

--- a/internal/http/handler/errors.go
+++ b/internal/http/handler/errors.go
@@ -6,6 +6,9 @@ const (
 	errDuplicateJob      = "Job with this idempotency key already exists"
 	errTokenInvalid      = "Token is invalid or expired"
 	errInvalidStatus     = "Invalid status value"
+	errInvalidMethod     = "method must be one of: GET, POST, PUT, PATCH, DELETE"
+	errInvalidSearch     = "q must be at most 512 characters"
+	errInvalidTimeFilter = "scheduled_after and scheduled_before must be RFC3339 timestamps"
 	errJobNotCancellable = "Job cannot be cancelled in its current state"
 	errJobNotReplayable  = "Only failed jobs can be replayed"
 

--- a/internal/http/handler/job.go
+++ b/internal/http/handler/job.go
@@ -145,19 +145,39 @@ func (h *JobHandler) List(ctx *gin.Context) {
 		return
 	}
 
+	scheduledAfter, err := parseTimeFilter(ctx.Query("scheduled_after"))
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidTimeFilter})
+		return
+	}
+	scheduledBefore, err := parseTimeFilter(ctx.Query("scheduled_before"))
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidTimeFilter})
+		return
+	}
+
 	result, err := h.jobUsecase.ListJobs(ctx.Request.Context(), usecase.ListJobsInput{
-		UserID: ctx.GetString("userID"),
-		Status: ctx.Query("status"),
-		Cursor: ctx.Query("cursor"),
-		Limit:  limit,
+		UserID:          ctx.GetString("userID"),
+		Status:          ctx.Query("status"),
+		Cursor:          ctx.Query("cursor"),
+		Limit:           limit,
+		URLSearch:       ctx.Query("q"),
+		Method:          ctx.Query("method"),
+		ScheduledAfter:  scheduledAfter,
+		ScheduledBefore: scheduledBefore,
 	})
 	if err != nil {
-		if errors.Is(err, domain.ErrInvalidStatus) {
+		switch {
+		case errors.Is(err, domain.ErrInvalidStatus):
 			ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidStatus})
-			return
+		case errors.Is(err, domain.ErrInvalidMethod):
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidMethod})
+		case errors.Is(err, domain.ErrInvalidSearch):
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": errInvalidSearch})
+		default:
+			h.logger.ErrorContext(ctx.Request.Context(), "list jobs", "error", err)
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
 		}
-		h.logger.ErrorContext(ctx.Request.Context(), "list jobs", "error", err)
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
 		return
 	}
 

--- a/internal/http/handler/job_test.go
+++ b/internal/http/handler/job_test.go
@@ -234,6 +234,65 @@ func TestListJobs_InvalidStatus(t *testing.T) {
 	}
 }
 
+// TestListJobs_SearchFiltersForwarded verifies that the q / method /
+// scheduled_after / scheduled_before query params are parsed and forwarded to
+// the repository as the corresponding ListJobsInput fields.
+func TestListJobs_SearchFiltersForwarded(t *testing.T) {
+	var got repository.ListJobsInput
+	jobRepo := &testutil.MockJobRepository{
+		ListJobsFn: func(_ context.Context, in repository.ListJobsInput) ([]*domain.Job, error) {
+			got = in
+			return nil, nil
+		},
+	}
+	r := setupJobRouter(jobRepo, &testutil.MockAttemptRepository{}, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet,
+		"/jobs?q=example.com&method=post&scheduled_after=2026-01-01T00:00:00Z&scheduled_before=2026-12-31T00:00:00Z", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got.URLSearch != "example.com" {
+		t.Errorf("URLSearch = %q, want %q", got.URLSearch, "example.com")
+	}
+	if got.Method != "POST" { // normalized to upper-case
+		t.Errorf("Method = %q, want %q", got.Method, "POST")
+	}
+	if got.ScheduledAfter == nil || !got.ScheduledAfter.Equal(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("ScheduledAfter = %v, want 2026-01-01T00:00:00Z", got.ScheduledAfter)
+	}
+	if got.ScheduledBefore == nil || !got.ScheduledBefore.Equal(time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("ScheduledBefore = %v, want 2026-12-31T00:00:00Z", got.ScheduledBefore)
+	}
+}
+
+func TestListJobs_InvalidMethod(t *testing.T) {
+	r := setupJobRouter(&testutil.MockJobRepository{}, &testutil.MockAttemptRepository{}, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/jobs?method=FETCH", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestListJobs_InvalidTimeFilter(t *testing.T) {
+	r := setupJobRouter(&testutil.MockJobRepository{}, &testutil.MockAttemptRepository{}, &testutil.MockCreditRepository{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/jobs?scheduled_after=not-a-time", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
 func TestCancelJob_HappyPath(t *testing.T) {
 	jobRepo := &testutil.MockJobRepository{
 		CancelFn: func(_ context.Context, _, _ string) error { return nil },

--- a/internal/http/handler/validation.go
+++ b/internal/http/handler/validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-playground/validator/v10"
 )
@@ -21,6 +22,20 @@ func parseLimit(raw string) (int, error) {
 		return 0, fmt.Errorf("invalid limit")
 	}
 	return n, nil
+}
+
+// parseTimeFilter parses an RFC3339 timestamp query parameter. Returns nil
+// (meaning "no filter") when the parameter is empty, and an error when it is
+// present but not a valid RFC3339 timestamp.
+func parseTimeFilter(raw string) (*time.Time, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid time filter: %w", err)
+	}
+	return &t, nil
 }
 
 // formatValidationError converts Gin/validator errors into user-friendly messages.

--- a/internal/infrastructure/postgres/job_repo.go
+++ b/internal/infrastructure/postgres/job_repo.go
@@ -220,6 +220,22 @@ func (r *JobRepository) ListJobs(ctx context.Context, input repository.ListJobsI
 		args = append(args, input.Status)
 		where = append(where, fmt.Sprintf("status = $%d", len(args)))
 	}
+	if input.Method != "" {
+		args = append(args, input.Method)
+		where = append(where, fmt.Sprintf("method = $%d", len(args)))
+	}
+	if input.URLSearch != "" {
+		args = append(args, "%"+escapeLike(input.URLSearch)+"%")
+		where = append(where, fmt.Sprintf("url ILIKE $%d", len(args)))
+	}
+	if input.ScheduledAfter != nil {
+		args = append(args, *input.ScheduledAfter)
+		where = append(where, fmt.Sprintf("scheduled_at >= $%d", len(args)))
+	}
+	if input.ScheduledBefore != nil {
+		args = append(args, *input.ScheduledBefore)
+		where = append(where, fmt.Sprintf("scheduled_at <= $%d", len(args)))
+	}
 	if input.CursorTime != nil {
 		args = append(args, *input.CursorTime, input.CursorID)
 		where = append(where, fmt.Sprintf("(scheduled_at, id) < ($%d, $%d)", len(args)-1, len(args)))
@@ -254,6 +270,15 @@ func (r *JobRepository) ListJobs(ctx context.Context, input repository.ListJobsI
 	}
 	return jobs, nil
 }
+
+// escapeLike escapes the LIKE/ILIKE wildcard metacharacters so that a
+// user-supplied search term is matched literally (the surrounding %...% is the
+// only wildcarding we want). Backslash is the default ILIKE escape character.
+func escapeLike(s string) string {
+	return likeEscaper.Replace(s)
+}
+
+var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
 
 // pgx.Row and pgx.Rows both implement this.
 type rowScanner interface {

--- a/internal/infrastructure/postgres/job_repo_integration_test.go
+++ b/internal/infrastructure/postgres/job_repo_integration_test.go
@@ -312,3 +312,106 @@ func TestJobRepo_ListJobs(t *testing.T) {
 		t.Fatalf("filtered got %d jobs, want 3", len(jobs))
 	}
 }
+
+func TestJobRepo_ListJobs_SearchFilters(t *testing.T) {
+	repo, userID := setupJobRepo(t)
+	ctx := context.Background()
+
+	base := time.Now().Truncate(time.Second)
+	// Three jobs with distinct urls, methods, and scheduled_at.
+	seed := []struct {
+		url    string
+		method string
+		at     time.Time
+	}{
+		{"https://api.example.com/orders", "POST", base.Add(1 * time.Hour)},
+		{"https://api.example.com/users", "GET", base.Add(2 * time.Hour)},
+		{"https://hooks.other.io/notify", "POST", base.Add(3 * time.Hour)},
+	}
+	for i, s := range seed {
+		job := testutil.NewJob(
+			testutil.WithUserID(userID),
+			testutil.WithURL(s.url),
+			testutil.WithMethod(s.method),
+			testutil.WithScheduledAt(s.at),
+		)
+		if _, err := repo.Create(ctx, job); err != nil {
+			t.Fatalf("create %d: %v", i, err)
+		}
+	}
+
+	// URL substring search (case-insensitive) matches the two example.com jobs.
+	jobs, err := repo.ListJobs(ctx, repository.ListJobsInput{UserID: userID, URLSearch: "EXAMPLE.com", Limit: 10})
+	if err != nil {
+		t.Fatalf("list url search: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("url search got %d jobs, want 2", len(jobs))
+	}
+
+	// Method filter matches the two POST jobs.
+	jobs, err = repo.ListJobs(ctx, repository.ListJobsInput{UserID: userID, Method: "POST", Limit: 10})
+	if err != nil {
+		t.Fatalf("list method: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("method filter got %d jobs, want 2", len(jobs))
+	}
+
+	// Combined method + URL search narrows to the single orders job.
+	jobs, err = repo.ListJobs(ctx, repository.ListJobsInput{UserID: userID, Method: "POST", URLSearch: "orders", Limit: 10})
+	if err != nil {
+		t.Fatalf("list method+url: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("method+url got %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].URL != "https://api.example.com/orders" {
+		t.Fatalf("got url %s, want orders job", jobs[0].URL)
+	}
+
+	// Time range: only jobs scheduled within (base+90m, base+150m] → the users job.
+	after := base.Add(90 * time.Minute)
+	before := base.Add(150 * time.Minute)
+	jobs, err = repo.ListJobs(ctx, repository.ListJobsInput{
+		UserID:          userID,
+		ScheduledAfter:  &after,
+		ScheduledBefore: &before,
+		Limit:           10,
+	})
+	if err != nil {
+		t.Fatalf("list time range: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("time range got %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].URL != "https://api.example.com/users" {
+		t.Fatalf("got url %s, want users job", jobs[0].URL)
+	}
+}
+
+// TestJobRepo_ListJobs_SearchEscapesWildcards ensures a search term containing
+// LIKE metacharacters is matched literally rather than as a wildcard.
+func TestJobRepo_ListJobs_SearchEscapesWildcards(t *testing.T) {
+	repo, userID := setupJobRepo(t)
+	ctx := context.Background()
+
+	for _, u := range []string{"https://x.io/a%b", "https://x.io/azzb"} {
+		job := testutil.NewJob(testutil.WithUserID(userID), testutil.WithURL(u))
+		if _, err := repo.Create(ctx, job); err != nil {
+			t.Fatalf("create %s: %v", u, err)
+		}
+	}
+
+	// "a%b" must match only the literal "a%b" url, not "azzb".
+	jobs, err := repo.ListJobs(ctx, repository.ListJobsInput{UserID: userID, URLSearch: "a%b", Limit: 10})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("escaped search got %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].URL != "https://x.io/a%b" {
+		t.Fatalf("got url %s, want literal a%%b job", jobs[0].URL)
+	}
+}

--- a/internal/repository/job.go
+++ b/internal/repository/job.go
@@ -13,6 +13,12 @@ type ListJobsInput struct {
 	CursorTime *time.Time    // nil = first page
 	CursorID   string        // used only when CursorTime is non-nil
 	Limit      int
+
+	// Optional search/filter predicates (validated in the usecase layer).
+	Method          string     // exact HTTP method; empty = all
+	URLSearch       string     // case-insensitive substring match on url; empty = no filter
+	ScheduledAfter  *time.Time // scheduled_at >= this; nil = no lower bound
+	ScheduledBefore *time.Time // scheduled_at <= this; nil = no upper bound
 }
 
 // UseCase depends on interface, not concrete implementation.

--- a/internal/usecase/job.go
+++ b/internal/usecase/job.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
@@ -165,6 +166,19 @@ type ListJobsInput struct {
 	Status string
 	Cursor string // raw base64url from query param
 	Limit  int
+
+	// Optional search/filter predicates. All combine with AND and with Status.
+	URLSearch       string     // case-insensitive substring match on the target URL
+	Method          string     // exact HTTP method (case-insensitive); empty = all
+	ScheduledAfter  *time.Time // scheduled_at >= this; nil = no lower bound
+	ScheduledBefore *time.Time // scheduled_at <= this; nil = no upper bound
+}
+
+// maxSearchLen caps the URL search term to keep ILIKE scans bounded.
+const maxSearchLen = 512
+
+var validMethods = map[string]struct{}{
+	"GET": {}, "POST": {}, "PUT": {}, "PATCH": {}, "DELETE": {},
 }
 
 type ListJobsResult struct {
@@ -219,10 +233,27 @@ func (u *JobUsecase) ListJobs(ctx context.Context, input ListJobsInput) (ListJob
 		}
 	}
 
+	var method string
+	if m := strings.ToUpper(strings.TrimSpace(input.Method)); m != "" {
+		if _, ok := validMethods[m]; !ok {
+			return ListJobsResult{}, domain.ErrInvalidMethod
+		}
+		method = m
+	}
+
+	search := strings.TrimSpace(input.URLSearch)
+	if len(search) > maxSearchLen {
+		return ListJobsResult{}, domain.ErrInvalidSearch
+	}
+
 	repoInput := repository.ListJobsInput{
-		UserID: input.UserID,
-		Status: status,
-		Limit:  limit + 1,
+		UserID:          input.UserID,
+		Status:          status,
+		Method:          method,
+		URLSearch:       search,
+		ScheduledAfter:  input.ScheduledAfter,
+		ScheduledBefore: input.ScheduledBefore,
+		Limit:           limit + 1,
 	}
 
 	if input.Cursor != "" {


### PR DESCRIPTION
Closes part of #17 — a first, self-contained slice of "search job executions".

## What

Adds optional search/filter query params to `GET /jobs`, on top of the existing `status` / `cursor` / `limit`. All predicates combine with `AND` and are compatible with the existing keyset pagination (ordering is unchanged):

| Param | Meaning |
|---|---|
| `q` | case-insensitive substring match on the target URL (`ILIKE`) |
| `method` | exact HTTP method (case-insensitive): `GET`/`POST`/`PUT`/`PATCH`/`DELETE` |
| `scheduled_after` | RFC3339 — `scheduled_at >= t` |
| `scheduled_before` | RFC3339 — `scheduled_at <= t` |

Example: `GET /jobs?q=api.example.com&method=POST&scheduled_after=2026-01-01T00:00:00Z`

## Why this scope

#17 floats "search logs from job executions" as a premium idea. Full-text log search across attempts is a bigger lift; the place users actually start is *finding the right job* in their list. This wires search into the existing `List` endpoint with no schema change, no new index requirement, and full layering compliance — a clean foundation to extend toward attempt/log search later.

## Notes

- **Validation** at the usecase boundary: unknown `method` → `400 ErrInvalidMethod`; `q` longer than 512 chars → `400 ErrInvalidSearch`; malformed time → `400` (handler). Mirrors the existing `status` validation.
- **Wildcard safety**: user `q` is escaped (`escapeLike`) so `%` / `_` / `\` match literally — the surrounding `%…%` is the only wildcarding.
- **Auth unchanged**: still scoped `WHERE user_id = $1`.
- **No leading-wildcard index** (`ILIKE '%…%'` can't use a btree). Fine at current scale; if the jobs table grows large a `pg_trgm` GIN index on `url` is the follow-up. Noted, not silently assumed.

## Tests

- Unit (`handler`): params forwarded to repo (with method upper-casing), invalid method → 400, malformed time → 400.
- Integration (`postgres`, `-tags integration`): URL substring (case-insensitive), method filter, combined method+url, time-range window, and literal-wildcard escaping.

Verified locally against `postgres:17`: `go build ./...`, `golangci-lint run` (0 issues), and the full suite `go test -tags integration -race -count=1 ./...` all green.