### PR TITLE
perf(db): partition job_attempts by month + automate rotation (Phase 3)

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -100,6 +100,13 @@ func main() {
 	bufferReaper := scheduler.NewBufferReaper(bufferRepo, logger, 30*time.Second, 30*time.Second)
 	go bufferReaper.Start(ctx)
 
+	partitionMaintainer := scheduler.NewPartitionMaintainer(
+		postgres.NewAttemptPartitionRepository(pool), logger,
+		time.Duration(cfg.PartitionMaintainIntervalSec)*time.Second,
+		cfg.PartitionMonthsAhead, cfg.JobAttemptRetentionMonths,
+	)
+	go partitionMaintainer.Start(ctx)
+
 	metricsSrv := metrics.NewServer(":"+cfg.MetricsPort, checker)
 	go func() {
 		logger.Info("metrics server started", "port", cfg.MetricsPort)

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,12 @@ type Config struct {
 	DispatchIntervalSec  int  `env:"DISPATCH_INTERVAL_SEC" envDefault:"5" validate:"min=1,max=60"`
 	DrainerConcurrency   int  `env:"DRAINER_CONCURRENCY" envDefault:"10" validate:"min=1,max=100"`
 	DrainerPollIntervalSec int `env:"DRAINER_POLL_INTERVAL_SEC" envDefault:"1" validate:"min=1,max=10"`
+	// Partition maintenance for job_attempts (range-partitioned by month).
+	PartitionMaintainIntervalSec int `env:"PARTITION_MAINTAIN_INTERVAL_SEC" envDefault:"21600" validate:"min=60"`
+	PartitionMonthsAhead         int `env:"PARTITION_MONTHS_AHEAD" envDefault:"3" validate:"min=1,max=24"`
+	// 0 = keep all attempt history forever (default). >0 drops partitions older
+	// than this many months — opt-in because attempts are billing records.
+	JobAttemptRetentionMonths int `env:"JOB_ATTEMPT_RETENTION_MONTHS" envDefault:"0" validate:"min=0,max=120"`
 
 	MetricsPort string `env:"METRICS_PORT" envDefault:"9090"`
 	LogLevel    string `env:"LOG_LEVEL" envDefault:"info" validate:"required,oneof=debug info warn error"`

--- a/docs/design/db-vacuum-tuning.md
+++ b/docs/design/db-vacuum-tuning.md
@@ -126,11 +126,15 @@ tuples):
 DROP TABLE job_attempts_2026_03;   -- e.g. keep the last N months
 ```
 
-**Partition rotation (operational follow-up).** Monthly partitions are
-pre-created through 2027-12 plus a `DEFAULT`. Before then, a periodic job must
-create next month's partition and drop expired ones — either a small scheduler
-task or `pg_partman`. Until automated, the `DEFAULT` partition absorbs overflow
-(keep it empty by pre-creating ahead so future `CREATE PARTITION` stays fast).
+**Partition rotation (automated).** The scheduler runs a `PartitionMaintainer`
+(`internal/scheduler/partition.go`) that, every `PARTITION_MAINTAIN_INTERVAL_SEC`
+(default 6h), ensures the current month + `PARTITION_MONTHS_AHEAD` (default 3)
+partitions exist. **Creation is always on** so the `DEFAULT` partition stays
+empty and there's no future cliff. **Dropping is opt-in:** with
+`JOB_ATTEMPT_RETENTION_MONTHS = 0` (default) nothing is ever dropped — attempts
+are billing records, so retention is a deliberate policy. Set it > 0 to have the
+maintainer drop partitions older than that many months (logged at WARN). The
+manual `DROP TABLE job_attempts_YYYY_MM` runbook above still works for one-offs.
 
 **Operational note.** The conversion copies all rows under a lock for the copy's
 duration. `job_attempts` is small today; on a large table, run during a

--- a/docs/design/db-vacuum-tuning.md
+++ b/docs/design/db-vacuum-tuning.md
@@ -108,11 +108,33 @@ sidecar, the reaper sees a stale/absent heartbeat and reschedules. This touches
 claim/heartbeat/reschedule/reaper, so it ships as its own PR with integration +
 crash tests. It is the change that actually removes the write-amplification.
 
-## Phase 3 — retention / partitioning (future)
+## Phase 3 — partition `job_attempts` by month (migration `20260614000003`)
 
-Range-partition `job_attempts` (and optionally completed `jobs`) by month so old
-data is dropped with `DROP PARTITION` (no vacuum cost) instead of `DELETE` (which
-generates more dead tuples). Keep hot partitions small → cheap autovacuum.
+Status: **done.** `job_attempts` is now `PARTITION BY RANGE (started_at)`, monthly,
+with a `DEFAULT` catch-all. PK is `(id, started_at)` and the unique guard is
+`(job_id, attempt_num, started_at)` (the partition key must be in every unique
+key). `CompleteAttempt` now passes `started_at`, so the completion UPDATE prunes
+to a single partition. The conversion migration renames the old table, frees the
+colliding constraint/index names, creates the partitioned table + partitions, and
+copies the data (validated: existing rows are preserved and routed to the right
+month). `job_attempts` has no inbound FKs, so this is clean.
+
+**Retention runbook.** Drop expired months instead of `DELETE` (instant, no dead
+tuples):
+
+```sql
+DROP TABLE job_attempts_2026_03;   -- e.g. keep the last N months
+```
+
+**Partition rotation (operational follow-up).** Monthly partitions are
+pre-created through 2027-12 plus a `DEFAULT`. Before then, a periodic job must
+create next month's partition and drop expired ones — either a small scheduler
+task or `pg_partman`. Until automated, the `DEFAULT` partition absorbs overflow
+(keep it empty by pre-creating ahead so future `CREATE PARTITION` stays fast).
+
+**Operational note.** The conversion copies all rows under a lock for the copy's
+duration. `job_attempts` is small today; on a large table, run during a
+low-traffic window or migrate online (e.g. `pg_partman` + background copy).
 
 ## Benchmarks
 

--- a/internal/infrastructure/postgres/attempt_repo.go
+++ b/internal/infrastructure/postgres/attempt_repo.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -27,15 +28,17 @@ func (r *AttemptRepository) CreateAttempt(ctx context.Context, a *domain.JobAtte
 	return scanAttempt(row)
 }
 
-func (r *AttemptRepository) CompleteAttempt(ctx context.Context, id string, statusCode *int, errMsg *string, durationMS int64) error {
+func (r *AttemptRepository) CompleteAttempt(ctx context.Context, id string, startedAt time.Time, statusCode *int, errMsg *string, durationMS int64) error {
+	// started_at is the partition key — including it prunes the UPDATE to the one
+	// partition holding this attempt.
 	_, err := r.pool.Exec(ctx, `
 		UPDATE job_attempts
 		SET completed_at = NOW(),
-		    status_code  = $2,
-		    error        = $3,
-		    duration_ms  = $4
-		WHERE id = $1`,
-		id, statusCode, errMsg, durationMS,
+		    status_code  = $3,
+		    error        = $4,
+		    duration_ms  = $5
+		WHERE id = $1 AND started_at = $2`,
+		id, startedAt, statusCode, errMsg, durationMS,
 	)
 	if err != nil {
 		return fmt.Errorf("complete attempt: %w", err)

--- a/internal/infrastructure/postgres/attempt_repo_integration_test.go
+++ b/internal/infrastructure/postgres/attempt_repo_integration_test.go
@@ -55,7 +55,7 @@ func TestAttemptRepo_CreateAndComplete(t *testing.T) {
 	// Complete the attempt
 	statusCode := 200
 	var durationMS int64 = 150
-	if err := attemptRepo.CompleteAttempt(ctx, attempt.ID, &statusCode, nil, durationMS); err != nil {
+	if err := attemptRepo.CompleteAttempt(ctx, attempt.ID, attempt.StartedAt, &statusCode, nil, durationMS); err != nil {
 		t.Fatalf("complete attempt: %v", err)
 	}
 }

--- a/internal/infrastructure/postgres/hotpath_bench_test.go
+++ b/internal/infrastructure/postgres/hotpath_bench_test.go
@@ -98,7 +98,7 @@ func BenchmarkAttemptCreateComplete(b *testing.B) {
 		if err != nil {
 			b.Fatalf("create attempt: %v", err)
 		}
-		if err := attempts.CompleteAttempt(ctx, a.ID, &statusCode, nil, 12); err != nil {
+		if err := attempts.CompleteAttempt(ctx, a.ID, a.StartedAt, &statusCode, nil, 12); err != nil {
 			b.Fatalf("complete attempt: %v", err)
 		}
 	}

--- a/internal/infrastructure/postgres/job_attempts_partition_integration_test.go
+++ b/internal/infrastructure/postgres/job_attempts_partition_integration_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+)
+
+func TestJobAttempts_IsRangePartitioned(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	ctx := context.Background()
+	var relkind string
+	if err := pool.QueryRow(ctx,
+		`SELECT relkind::text FROM pg_class WHERE relname = 'job_attempts'`).Scan(&relkind); err != nil {
+		t.Fatalf("query relkind: %v", err)
+	}
+	if relkind != "p" { // 'p' = partitioned table
+		t.Fatalf("job_attempts relkind = %q, want 'p' (partitioned)", relkind)
+	}
+}
+
+// An attempt's row lands in the monthly partition for its started_at, and the
+// completion UPDATE (which now passes started_at) finds and updates it.
+func TestJobAttempts_RowRoutesToMonthlyPartition(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	ctx := context.Background()
+
+	jobRepo := postgres.NewJobRepository(pool)
+	attempts := postgres.NewAttemptRepository(pool)
+
+	job, err := jobRepo.Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+
+	started := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC) // -> job_attempts_2026_03
+	a, err := attempts.CreateAttempt(ctx, &domain.JobAttempt{
+		JobID: job.ID, AttemptNum: 1, WorkerID: "w1", StartedAt: started,
+	})
+	if err != nil {
+		t.Fatalf("create attempt: %v", err)
+	}
+
+	var part string
+	if err := pool.QueryRow(ctx,
+		`SELECT tableoid::regclass::text FROM job_attempts WHERE id = $1 AND started_at = $2`,
+		a.ID, a.StartedAt).Scan(&part); err != nil {
+		t.Fatalf("locate partition: %v", err)
+	}
+	if part != "job_attempts_2026_03" {
+		t.Fatalf("row landed in %q, want job_attempts_2026_03", part)
+	}
+
+	sc := 200
+	if err := attempts.CompleteAttempt(ctx, a.ID, a.StartedAt, &sc, nil, 42); err != nil {
+		t.Fatalf("complete attempt: %v", err)
+	}
+	got, err := attempts.ListByJobID(ctx, job.ID)
+	if err != nil || len(got) != 1 || got[0].CompletedAt == nil {
+		t.Fatalf("expected 1 completed attempt, got %+v err=%v", got, err)
+	}
+}
+
+// Retention: dropping an old partition removes its rows with no DELETE/vacuum.
+func TestJobAttempts_DropPartitionRetention(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	ctx := context.Background()
+
+	jobRepo := postgres.NewJobRepository(pool)
+	attempts := postgres.NewAttemptRepository(pool)
+	job, err := jobRepo.Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+
+	// A dedicated far-future partition so we never disturb the migration's set.
+	if _, err := pool.Exec(ctx,
+		`CREATE TABLE IF NOT EXISTS job_attempts_test_2031_01 PARTITION OF job_attempts
+		 FOR VALUES FROM ('2031-01-01') TO ('2031-02-01')`); err != nil {
+		t.Fatalf("create test partition: %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), `DROP TABLE IF EXISTS job_attempts_test_2031_01`) })
+
+	if _, err := attempts.CreateAttempt(ctx, &domain.JobAttempt{
+		JobID: job.ID, AttemptNum: 1, WorkerID: "w1", StartedAt: time.Date(2031, 1, 10, 0, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("create attempt: %v", err)
+	}
+	if got, _ := attempts.ListByJobID(ctx, job.ID); len(got) != 1 {
+		t.Fatalf("expected 1 attempt before drop, got %d", len(got))
+	}
+
+	// Retention = drop the whole partition (instant, no dead tuples).
+	if _, err := pool.Exec(ctx, `DROP TABLE job_attempts_test_2031_01`); err != nil {
+		t.Fatalf("drop partition: %v", err)
+	}
+	if got, _ := attempts.ListByJobID(ctx, job.ID); len(got) != 0 {
+		t.Fatalf("expected 0 attempts after dropping the partition, got %d", len(got))
+	}
+}

--- a/internal/infrastructure/postgres/partition_repo.go
+++ b/internal/infrastructure/postgres/partition_repo.go
@@ -1,0 +1,102 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// AttemptPartitionRepository manages job_attempts' monthly partitions.
+type AttemptPartitionRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewAttemptPartitionRepository(pool *pgxpool.Pool) *AttemptPartitionRepository {
+	return &AttemptPartitionRepository{pool: pool}
+}
+
+func monthStart(t time.Time) time.Time {
+	t = t.UTC()
+	return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+}
+
+func partitionName(m time.Time) string { return "job_attempts_" + m.Format("2006_01") }
+
+func (r *AttemptPartitionRepository) EnsureMonthlyPartitions(ctx context.Context, now time.Time, monthsAhead int) ([]string, error) {
+	var created []string
+	start := monthStart(now)
+	for i := 0; i <= monthsAhead; i++ {
+		m := start.AddDate(0, i, 0)
+		name := partitionName(m)
+
+		var exists bool
+		if err := r.pool.QueryRow(ctx,
+			`SELECT to_regclass('public.' || $1) IS NOT NULL`, name).Scan(&exists); err != nil {
+			return created, fmt.Errorf("check partition %s: %w", name, err)
+		}
+		if exists {
+			continue
+		}
+
+		next := m.AddDate(0, 1, 0)
+		// Identifiers/dates are derived from a time value, not user input. DDL
+		// can't be parameterized, so build the statement from sanitized parts.
+		ddl := fmt.Sprintf(
+			`CREATE TABLE IF NOT EXISTS %s PARTITION OF job_attempts FOR VALUES FROM ('%s') TO ('%s') `+
+				`WITH (fillfactor=85, autovacuum_vacuum_scale_factor=0.05, `+
+				`autovacuum_vacuum_insert_scale_factor=0.1, autovacuum_analyze_scale_factor=0.05)`,
+			pgx.Identifier{name}.Sanitize(), m.Format("2006-01-02"), next.Format("2006-01-02"))
+		if _, err := r.pool.Exec(ctx, ddl); err != nil {
+			return created, fmt.Errorf("create partition %s: %w", name, err)
+		}
+		created = append(created, name)
+	}
+	return created, nil
+}
+
+func (r *AttemptPartitionRepository) DropPartitionsBefore(ctx context.Context, cutoff time.Time) ([]string, error) {
+	cutoffMonth := monthStart(cutoff)
+
+	rows, err := r.pool.Query(ctx, `
+		SELECT c.relname
+		FROM pg_inherits i
+		JOIN pg_class c ON c.oid = i.inhrelid
+		JOIN pg_class p ON p.oid = i.inhparent
+		WHERE p.relname = 'job_attempts'
+		  AND c.relname ~ '^job_attempts_[0-9]{4}_[0-9]{2}$'`)
+	if err != nil {
+		return nil, fmt.Errorf("list partitions: %w", err)
+	}
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan partition name: %w", err)
+		}
+		names = append(names, n)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate partitions: %w", err)
+	}
+
+	var dropped []string
+	for _, name := range names {
+		m, perr := time.Parse("2006_01", name[len("job_attempts_"):])
+		if perr != nil {
+			continue // not a monthly partition we manage
+		}
+		if !m.UTC().Before(cutoffMonth) {
+			continue // keep current/future months
+		}
+		if _, err := r.pool.Exec(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, pgx.Identifier{name}.Sanitize())); err != nil {
+			return dropped, fmt.Errorf("drop partition %s: %w", name, err)
+		}
+		dropped = append(dropped, name)
+	}
+	return dropped, nil
+}

--- a/internal/infrastructure/postgres/partition_repo_integration_test.go
+++ b/internal/infrastructure/postgres/partition_repo_integration_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+)
+
+func TestPartition_EnsureCreatesFutureMonths(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	ctx := context.Background()
+	repo := postgres.NewAttemptPartitionRepository(pool)
+
+	// Far future so we never collide with the migration's pre-created set.
+	now := time.Date(2099, 1, 15, 0, 0, 0, 0, time.UTC)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DROP TABLE IF EXISTS job_attempts_2099_01, job_attempts_2099_02`)
+	})
+
+	created, err := repo.EnsureMonthlyPartitions(ctx, now, 1) // current + 1 ahead = 2
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if len(created) != 2 {
+		t.Fatalf("created %v, want 2 (2099_01, 2099_02)", created)
+	}
+	for _, name := range []string{"job_attempts_2099_01", "job_attempts_2099_02"} {
+		var exists bool
+		if err := pool.QueryRow(ctx, `SELECT to_regclass('public.'||$1) IS NOT NULL`, name).Scan(&exists); err != nil || !exists {
+			t.Fatalf("partition %s should exist (exists=%v err=%v)", name, exists, err)
+		}
+	}
+
+	// Idempotent: a second call creates nothing.
+	again, err := repo.EnsureMonthlyPartitions(ctx, now, 1)
+	if err != nil || len(again) != 0 {
+		t.Fatalf("second ensure should be a no-op, got %v err=%v", again, err)
+	}
+}
+
+func TestPartition_DropPartitionsBefore(t *testing.T) {
+	pool := testutil.SetupTestDB(t)
+	ctx := context.Background()
+	repo := postgres.NewAttemptPartitionRepository(pool)
+
+	// A partition older than every migration-created one (which start 2026-01).
+	if _, err := pool.Exec(ctx,
+		`CREATE TABLE IF NOT EXISTS job_attempts_2025_12 PARTITION OF job_attempts
+		 FOR VALUES FROM ('2025-12-01') TO ('2026-01-01')`); err != nil {
+		t.Fatalf("create 2025_12: %v", err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), `DROP TABLE IF EXISTS job_attempts_2025_12`) })
+
+	// Cutoff = 2026-01: only months strictly before 2026-01 are dropped, i.e.
+	// just our 2025_12 — the real 2026_* partitions are kept.
+	dropped, err := repo.DropPartitionsBefore(ctx, time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("drop: %v", err)
+	}
+	found := false
+	for _, n := range dropped {
+		if n == "job_attempts_2025_12" {
+			found = true
+		}
+		if n == "job_attempts_2026_06" {
+			t.Fatalf("dropped a current-era partition %s — cutoff should have kept it", n)
+		}
+	}
+	if !found {
+		t.Fatalf("expected job_attempts_2025_12 to be dropped, got %v", dropped)
+	}
+	var stillThere bool
+	if err := pool.QueryRow(ctx, `SELECT to_regclass('public.job_attempts_2026_06') IS NOT NULL`).Scan(&stillThere); err != nil || !stillThere {
+		t.Fatalf("job_attempts_2026_06 should still exist (exists=%v err=%v)", stillThere, err)
+	}
+}

--- a/internal/infrastructure/postgres/stats_repo_integration_test.go
+++ b/internal/infrastructure/postgres/stats_repo_integration_test.go
@@ -32,7 +32,7 @@ func seedCompletedAttempt(t *testing.T, jobRepo *postgres.JobRepository, attempt
 		t.Fatalf("seed attempt: %v", err)
 	}
 	sc := statusCode
-	if err := attemptRepo.CompleteAttempt(ctx, attempt.ID, &sc, errMsg, durationMS); err != nil {
+	if err := attemptRepo.CompleteAttempt(ctx, attempt.ID, attempt.StartedAt, &sc, errMsg, durationMS); err != nil {
 		t.Fatalf("complete attempt: %v", err)
 	}
 }

--- a/internal/repository/attempt.go
+++ b/internal/repository/attempt.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"time"
 
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
 )
@@ -13,9 +14,11 @@ type AttemptRepository interface {
 	CreateAttempt(ctx context.Context, attempt *domain.JobAttempt) (*domain.JobAttempt, error)
 
 	// CompleteAttempt closes an open attempt record with the execution outcome.
+	// startedAt is the attempt's started_at (from CreateAttempt's return value);
+	// it is the partition key, so passing it prunes the UPDATE to one partition.
 	// statusCode is nil when the HTTP request never received a response.
 	// errMsg is nil on success.
-	CompleteAttempt(ctx context.Context, id string, statusCode *int, errMsg *string, durationMS int64) error
+	CompleteAttempt(ctx context.Context, id string, startedAt time.Time, statusCode *int, errMsg *string, durationMS int64) error
 
 	// ListByJobID returns all attempts for a job, ordered by started_at ASC.
 	// Ownership is assumed to have been verified by the caller.

--- a/internal/repository/partition.go
+++ b/internal/repository/partition.go
@@ -1,0 +1,20 @@
+package repository
+
+import (
+	"context"
+	"time"
+)
+
+// AttemptPartitionRepository manages the monthly partitions of job_attempts.
+// It is consumed by the scheduler's PartitionMaintainer.
+type AttemptPartitionRepository interface {
+	// EnsureMonthlyPartitions creates the partition for the month containing
+	// `now` plus the next `monthsAhead` months, if they don't already exist.
+	// Idempotent; returns the names actually created.
+	EnsureMonthlyPartitions(ctx context.Context, now time.Time, monthsAhead int) ([]string, error)
+
+	// DropPartitionsBefore drops every monthly partition whose month starts
+	// strictly before the month containing `cutoff`. This deletes data, so the
+	// caller gates it behind an explicit retention policy. Returns dropped names.
+	DropPartitionsBefore(ctx context.Context, cutoff time.Time) ([]string, error)
+}

--- a/internal/scheduler/partition.go
+++ b/internal/scheduler/partition.go
@@ -1,0 +1,73 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
+)
+
+// PartitionMaintainer keeps job_attempts' monthly partitions provisioned ahead of
+// time and (optionally) prunes expired ones. Creating partitions is always on;
+// dropping is gated by retentionMonths (0 = never drop — attempts are billing
+// records, so deletion is opt-in).
+type PartitionMaintainer struct {
+	repo            repository.AttemptPartitionRepository
+	logger          *slog.Logger
+	interval        time.Duration
+	monthsAhead     int
+	retentionMonths int
+}
+
+func NewPartitionMaintainer(repo repository.AttemptPartitionRepository, logger *slog.Logger, interval time.Duration, monthsAhead, retentionMonths int) *PartitionMaintainer {
+	return &PartitionMaintainer{
+		repo:            repo,
+		logger:          logger.With("component", "partition_maintainer"),
+		interval:        interval,
+		monthsAhead:     monthsAhead,
+		retentionMonths: retentionMonths,
+	}
+}
+
+func (m *PartitionMaintainer) Start(ctx context.Context) {
+	m.logger.InfoContext(ctx, "partition maintainer started",
+		"interval", m.interval, "months_ahead", m.monthsAhead, "retention_months", m.retentionMonths)
+
+	m.maintain(ctx) // run once immediately so partitions exist before the first tick
+
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			m.logger.InfoContext(ctx, "partition maintainer shut down")
+			return
+		case <-ticker.C:
+			m.maintain(ctx)
+		}
+	}
+}
+
+func (m *PartitionMaintainer) maintain(ctx context.Context) {
+	now := time.Now().UTC()
+
+	created, err := m.repo.EnsureMonthlyPartitions(ctx, now, m.monthsAhead)
+	if err != nil {
+		m.logger.ErrorContext(ctx, "ensure monthly partitions", "error", err)
+	} else if len(created) > 0 {
+		m.logger.InfoContext(ctx, "created job_attempts partitions", "partitions", created)
+	}
+
+	if m.retentionMonths <= 0 {
+		return // retention disabled — keep all history
+	}
+	cutoff := now.AddDate(0, -m.retentionMonths, 0)
+	dropped, err := m.repo.DropPartitionsBefore(ctx, cutoff)
+	if err != nil {
+		m.logger.ErrorContext(ctx, "drop expired partitions", "error", err)
+	} else if len(dropped) > 0 {
+		// WARN: this deleted attempt history (billing records).
+		m.logger.WarnContext(ctx, "dropped expired job_attempts partitions", "partitions", dropped, "retention_months", m.retentionMonths)
+	}
+}

--- a/internal/scheduler/worker.go
+++ b/internal/scheduler/worker.go
@@ -268,7 +268,7 @@ func (w *Worker) runJob(ctx context.Context, job *domain.Job) {
 
 // closeAttempt writes the execution outcome to the attempt record.
 func (w *Worker) closeAttempt(ctx context.Context, attempt *domain.JobAttempt, statusCode *int, errMsg *string, durationMS int64) {
-	if err := w.attempts.CompleteAttempt(ctx, attempt.ID, statusCode, errMsg, durationMS); err != nil {
+	if err := w.attempts.CompleteAttempt(ctx, attempt.ID, attempt.StartedAt, statusCode, errMsg, durationMS); err != nil {
 		w.logger.ErrorContext(ctx, "complete attempt record", "job_id", attempt.JobID, "error", err)
 	}
 }

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -144,7 +144,7 @@ func (m *MockJobRepository) ListByScheduleID(ctx context.Context, scheduleID str
 
 type MockAttemptRepository struct {
 	CreateAttemptFn   func(ctx context.Context, attempt *domain.JobAttempt) (*domain.JobAttempt, error)
-	CompleteAttemptFn func(ctx context.Context, id string, statusCode *int, errMsg *string, durationMS int64) error
+	CompleteAttemptFn func(ctx context.Context, id string, startedAt time.Time, statusCode *int, errMsg *string, durationMS int64) error
 	ListByJobIDFn     func(ctx context.Context, jobID string) ([]*domain.JobAttempt, error)
 }
 
@@ -156,9 +156,9 @@ func (m *MockAttemptRepository) CreateAttempt(ctx context.Context, attempt *doma
 	return attempt, nil
 }
 
-func (m *MockAttemptRepository) CompleteAttempt(ctx context.Context, id string, statusCode *int, errMsg *string, durationMS int64) error {
+func (m *MockAttemptRepository) CompleteAttempt(ctx context.Context, id string, startedAt time.Time, statusCode *int, errMsg *string, durationMS int64) error {
 	if m.CompleteAttemptFn != nil {
-		return m.CompleteAttemptFn(ctx, id, statusCode, errMsg, durationMS)
+		return m.CompleteAttemptFn(ctx, id, startedAt, statusCode, errMsg, durationMS)
 	}
 	return nil
 }

--- a/migrations/20260614000003_partition_job_attempts.sql
+++ b/migrations/20260614000003_partition_job_attempts.sql
@@ -1,0 +1,90 @@
+-- +goose Up
+-- Range-partition job_attempts by month (on started_at) so retention is a cheap
+-- DROP TABLE of an old partition instead of a bloat-generating DELETE, and so
+-- autovacuum/scans stay bounded as history grows forever.
+--
+-- job_attempts has no inbound FKs, so it converts cleanly. The partition key
+-- (started_at) must be part of every unique key, hence PK (id, started_at) and
+-- UNIQUE (job_id, attempt_num, started_at). CompleteAttempt now passes started_at
+-- so the UPDATE prunes to a single partition.
+--
+-- NOTE: the data copy below holds a lock for its duration. job_attempts is small
+-- today; on a large table run this during a low-traffic window (or migrate with
+-- pg_partman/online tooling). See docs/design/db-vacuum-tuning.md.
+
+ALTER TABLE job_attempts RENAME TO job_attempts_old;
+
+-- A table rename keeps its constraint/index names, which would collide with the
+-- new table's. Free them (data stays; the copy below is a seq scan).
+ALTER TABLE job_attempts_old DROP CONSTRAINT IF EXISTS job_attempts_pkey;
+ALTER TABLE job_attempts_old DROP CONSTRAINT IF EXISTS job_attempts_job_id_fkey;
+DROP INDEX IF EXISTS idx_attempts_job_id;
+
+CREATE TABLE job_attempts (
+    id           TEXT        NOT NULL DEFAULT gen_random_uuid()::text,
+    job_id       TEXT        NOT NULL REFERENCES jobs(id),
+    attempt_num  INT         NOT NULL,
+    worker_id    TEXT        NOT NULL,
+    started_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    status_code  INT,
+    error        TEXT,
+    duration_ms  BIGINT,
+    PRIMARY KEY (id, started_at),
+    UNIQUE (job_id, attempt_num, started_at)
+) PARTITION BY RANGE (started_at);
+
+-- Partitioned index (propagates to every partition).
+CREATE INDEX idx_attempts_job_id ON job_attempts (job_id);
+
+-- Monthly partitions covering existing data and ~1.5 years forward, plus a
+-- DEFAULT catch-all so an insert never fails if partition rotation lags.
+-- (Ongoing rotation — create next month, drop expired — is a periodic op;
+-- see the retention runbook in the design doc.)
+-- +goose StatementBegin
+DO $$
+DECLARE
+    d date := date '2026-01-01';
+BEGIN
+    WHILE d < date '2028-01-01' LOOP
+        EXECUTE format(
+            'CREATE TABLE %I PARTITION OF job_attempts FOR VALUES FROM (%L) TO (%L) '
+            || 'WITH (fillfactor=85, autovacuum_vacuum_scale_factor=0.05, '
+            || 'autovacuum_vacuum_insert_scale_factor=0.1, autovacuum_analyze_scale_factor=0.05)',
+            'job_attempts_' || to_char(d, 'YYYY_MM'), d, (d + interval '1 month')::date);
+        d := (d + interval '1 month')::date;
+    END LOOP;
+END $$;
+-- +goose StatementEnd
+
+CREATE TABLE job_attempts_default PARTITION OF job_attempts DEFAULT
+    WITH (fillfactor = 85, autovacuum_vacuum_scale_factor = 0.05);
+
+INSERT INTO job_attempts (id, job_id, attempt_num, worker_id, started_at, completed_at, status_code, error, duration_ms)
+SELECT id, job_id, attempt_num, worker_id, started_at, completed_at, status_code, error, duration_ms
+FROM job_attempts_old;
+
+DROP TABLE job_attempts_old;
+
+-- +goose Down
+ALTER TABLE job_attempts RENAME TO job_attempts_part;
+
+CREATE TABLE job_attempts (
+    id           TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    job_id       TEXT        NOT NULL REFERENCES jobs(id),
+    attempt_num  INT         NOT NULL,
+    worker_id    TEXT        NOT NULL,
+    started_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    status_code  INT,
+    error        TEXT,
+    duration_ms  BIGINT,
+    UNIQUE (job_id, attempt_num)
+) WITH (fillfactor = 85, autovacuum_vacuum_scale_factor = 0.05, autovacuum_vacuum_insert_scale_factor = 0.1, autovacuum_analyze_scale_factor = 0.05);
+CREATE INDEX idx_attempts_job_id ON job_attempts (job_id);
+
+INSERT INTO job_attempts (id, job_id, attempt_num, worker_id, started_at, completed_at, status_code, error, duration_ms)
+SELECT id, job_id, attempt_num, worker_id, started_at, completed_at, status_code, error, duration_ms
+FROM job_attempts_part;
+
+DROP TABLE job_attempts_part;


### PR DESCRIPTION
Re-lands the Phase 3 work lost when stacked PRs #55/#56 were orphaned by the cascading branch-deletion during the squash merges (see #59 for the full story). Cherry-picks **#55** (range-partition `job_attempts` by month) and **#56** (partition-rotation maintainer) onto `main` after #59 (Phase 2). No code changes vs the originals.

Validated locally (originals had no CI):
- `goose up` applies the full chain through `20260614000003_partition_job_attempts` on a fresh postgres:16 ✅
- `go build ./...` clean ✅

**Migration safety:** the partition migration renames `job_attempts`, creates the partitioned table, copies rows, and drops the old one — all in a single goose transaction, so concurrent writers block briefly rather than lose writes. Retention/partition-dropping is **opt-in** (`JOB_ATTEMPT_RETENTION_MONTHS` defaults to 0 = keep forever). The data-copy holds a lock for its duration; fine for the current small table (noted in `docs/design/db-vacuum-tuning.md`).

Supersedes #55, #56. Must merge after #59.