### PR TITLE
test: cover alert email/verification/low-balance plumbing

### DIFF
--- a/internal/domain/alert_test.go
+++ b/internal/domain/alert_test.go
@@ -1,0 +1,97 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+)
+
+func TestCrossedLowBalance(t *testing.T) {
+	t.Parallel()
+
+	const threshold = 100
+
+	cases := []struct {
+		name          string
+		prev, current int64
+		threshold     int64
+		want          bool
+	}{
+		{"downward crossing fires", 150, 50, threshold, true},
+		{"exact boundary down fires", threshold, threshold - 1, threshold, true},
+		{"lands exactly on threshold does not fire", 150, threshold, threshold, false},
+		{"already below does not re-fire", 50, 10, threshold, false},
+		{"stays above does not fire", 200, 150, threshold, false},
+		{"upward movement does not fire", 50, 150, threshold, false},
+		{"no change above", 200, 200, threshold, false},
+		{"no change below", 50, 50, threshold, false},
+		{"crossing to zero fires", 150, 0, threshold, true},
+		{"zero threshold disabled", 150, 0, 0, false},
+		{"negative threshold disabled", 150, 50, -1, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := domain.CrossedLowBalance(tc.prev, tc.current, tc.threshold)
+			if got != tc.want {
+				t.Fatalf("CrossedLowBalance(prev=%d, current=%d, threshold=%d) = %v, want %v",
+					tc.prev, tc.current, tc.threshold, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCrossedLowBalance_Hysteresis walks a balance through drop → hover → top-up
+// → drop to assert the latch fires once per downward edge, not while hovering.
+func TestCrossedLowBalance_Hysteresis(t *testing.T) {
+	t.Parallel()
+
+	const threshold = 100
+	balances := []int64{200, 120, 90, 80, 95, 60, 150, 70}
+	// edges marks the steps where a fire is expected (downward crossings).
+	wantFire := map[int]bool{2: true, 7: true}
+
+	for i := 1; i < len(balances); i++ {
+		got := domain.CrossedLowBalance(balances[i-1], balances[i], threshold)
+		if got != wantFire[i] {
+			t.Fatalf("step %d (%d→%d): fired=%v, want %v",
+				i, balances[i-1], balances[i], got, wantFire[i])
+		}
+	}
+}
+
+func TestValidAlertChannelType(t *testing.T) {
+	t.Parallel()
+
+	valid := []domain.AlertChannelType{
+		domain.AlertChannelWebhook,
+		domain.AlertChannelSlack,
+		domain.AlertChannelEmail,
+	}
+	for _, ty := range valid {
+		if !domain.ValidAlertChannelType(ty) {
+			t.Errorf("ValidAlertChannelType(%q) = false, want true", ty)
+		}
+	}
+
+	invalid := []domain.AlertChannelType{"", "sms", "Email", "WEBHOOK", "telegram"}
+	for _, ty := range invalid {
+		if domain.ValidAlertChannelType(ty) {
+			t.Errorf("ValidAlertChannelType(%q) = true, want false", ty)
+		}
+	}
+}
+
+func TestRequiresVerification(t *testing.T) {
+	t.Parallel()
+
+	if !domain.AlertChannelEmail.RequiresVerification() {
+		t.Error("email channel should require verification")
+	}
+	for _, ty := range []domain.AlertChannelType{domain.AlertChannelWebhook, domain.AlertChannelSlack} {
+		if ty.RequiresVerification() {
+			t.Errorf("%q should not require verification", ty)
+		}
+	}
+}

--- a/internal/emailverify/token_test.go
+++ b/internal/emailverify/token_test.go
@@ -1,0 +1,131 @@
+package emailverify
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+)
+
+const secret = "test-secret-32-chars-long-aaaaaa"
+
+// fixedSigner returns a Signer whose clock is pinned to t so expiry behaviour is
+// deterministic. White-box (same package) so it can reach the unexported now.
+func fixedSigner(t time.Time) *Signer {
+	s := NewSigner([]byte(secret))
+	s.now = func() time.Time { return t }
+	return s
+}
+
+func TestSignVerify_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := NewSigner([]byte(secret))
+	const channelID = "alert-channel-123"
+
+	got, err := s.Verify(s.Sign(channelID))
+	if err != nil {
+		t.Fatalf("Verify after Sign: unexpected error: %v", err)
+	}
+	if got != channelID {
+		t.Fatalf("Verify returned channel ID %q, want %q", got, channelID)
+	}
+}
+
+func TestSign_TokenShape(t *testing.T) {
+	t.Parallel()
+
+	tok := NewSigner([]byte(secret)).Sign("c1")
+	if n := strings.Count(tok, "."); n != 2 {
+		t.Fatalf("token %q has %d dots, want 2 (id.exp.mac)", tok, n)
+	}
+	for i, part := range strings.Split(tok, ".") {
+		if part == "" {
+			t.Fatalf("token part %d is empty: %q", i, tok)
+		}
+	}
+}
+
+func TestVerify_RejectsTamperedToken(t *testing.T) {
+	t.Parallel()
+
+	s := NewSigner([]byte(secret))
+	valid := s.Sign("alert-channel-123")
+	parts := strings.Split(valid, ".")
+
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{"flipped id", b64("other-channel") + "." + parts[1] + "." + parts[2]},
+		{"flipped expiry", parts[0] + "." + b64("9999999999") + "." + parts[2]},
+		{"truncated mac", parts[0] + "." + parts[1] + "." + parts[2][:len(parts[2])-2]},
+		{"empty string", ""},
+		{"too few parts", parts[0] + "." + parts[1]},
+		{"too many parts", valid + ".extra"},
+		{"non-base64 mac", parts[0] + "." + parts[1] + ".!!!notb64!!!"},
+		{"non-base64 expiry", parts[0] + ".!!!." + parts[2]},
+		{"non-numeric expiry", parts[0] + "." + b64("not-a-number") + "." + parts[2]},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := s.Verify(tc.token)
+			if !errors.Is(err, domain.ErrInvalidVerificationToken) {
+				t.Fatalf("Verify(%q) error = %v, want ErrInvalidVerificationToken", tc.token, err)
+			}
+		})
+	}
+}
+
+func TestVerify_RejectsForeignSecret(t *testing.T) {
+	t.Parallel()
+
+	// A token minted with one secret must not validate under another — otherwise
+	// anyone could forge a confirm link.
+	minted := NewSigner([]byte(secret)).Sign("alert-channel-123")
+	other := NewSigner([]byte("a-completely-different-secret-key"))
+
+	if _, err := other.Verify(minted); !errors.Is(err, domain.ErrInvalidVerificationToken) {
+		t.Fatalf("Verify under foreign secret error = %v, want ErrInvalidVerificationToken", err)
+	}
+}
+
+func TestVerify_Expiry(t *testing.T) {
+	t.Parallel()
+
+	issued := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	tok := fixedSigner(issued).Sign("alert-channel-123")
+
+	// Just before the TTL elapses: still valid.
+	beforeExpiry := fixedSigner(issued.Add(DefaultTTL - time.Minute))
+	if _, err := beforeExpiry.Verify(tok); err != nil {
+		t.Fatalf("token within TTL rejected: %v", err)
+	}
+
+	// Past the TTL: rejected as invalid.
+	afterExpiry := fixedSigner(issued.Add(DefaultTTL + time.Minute))
+	if _, err := afterExpiry.Verify(tok); !errors.Is(err, domain.ErrInvalidVerificationToken) {
+		t.Fatalf("expired token error = %v, want ErrInvalidVerificationToken", err)
+	}
+}
+
+func TestSign_RoundTripsAwkwardChannelIDs(t *testing.T) {
+	t.Parallel()
+
+	// channelID is base64url-encoded into the payload, so dots, slashes, and
+	// other delimiter-adjacent bytes must survive a round trip intact.
+	s := NewSigner([]byte(secret))
+	for _, id := range []string{"", "id.with.dots", "id/with+slashes", "üñïçødé-id"} {
+		got, err := s.Verify(s.Sign(id))
+		if err != nil {
+			t.Fatalf("Verify(Sign(%q)): %v", id, err)
+		}
+		if got != id {
+			t.Fatalf("round trip of %q gave %q", id, got)
+		}
+	}
+}

--- a/internal/mailer/resend.go
+++ b/internal/mailer/resend.go
@@ -20,15 +20,19 @@ const resendEndpoint = "https://api.resend.com/emails"
 type ResendProvider struct {
 	apiKey string
 	from   string
-	client *http.Client
+	// endpoint is the Resend API URL. It defaults to resendEndpoint and is only
+	// overridden in tests to point Send at an httptest server.
+	endpoint string
+	client   *http.Client
 }
 
 // NewResendProvider returns a Provider backed by Resend. apiKey is the
 // RESEND_API_KEY secret; from is the verified sender address (ALERT_EMAIL_FROM).
 func NewResendProvider(apiKey, from string) *ResendProvider {
 	return &ResendProvider{
-		apiKey: apiKey,
-		from:   from,
+		apiKey:   apiKey,
+		from:     from,
+		endpoint: resendEndpoint,
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 			Transport: &http.Transport{
@@ -56,7 +60,7 @@ func (p *ResendProvider) Send(ctx context.Context, msg Email) error {
 		return fmt.Errorf("marshal resend request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resendEndpoint, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("build resend request: %w", err)
 	}

--- a/internal/mailer/resend_test.go
+++ b/internal/mailer/resend_test.go
@@ -1,0 +1,114 @@
+package mailer
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// newTestResend returns a ResendProvider whose Send hits srv instead of the
+// real Resend API. White-box (same package) so it can set the unexported
+// endpoint seam.
+func newTestResend(apiKey, from, url string) *ResendProvider {
+	p := NewResendProvider(apiKey, from)
+	p.endpoint = url
+	return p
+}
+
+func TestResend_Send_PostsExpectedRequest(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotAuth        string
+		gotContentType string
+		gotMethod      string
+		gotBody        resendRequest
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := newTestResend("re_test_key", "alerts@fliq.sh", srv.URL)
+	err := p.Send(context.Background(), Email{
+		To:      "user@example.com",
+		Subject: "Your endpoint is down",
+		Text:    "Fliq gave up after 5 attempts.",
+	})
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if want := "Bearer re_test_key"; gotAuth != want {
+		t.Errorf("Authorization = %q, want %q", gotAuth, want)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if gotBody.From != "alerts@fliq.sh" {
+		t.Errorf("from = %q, want alerts@fliq.sh", gotBody.From)
+	}
+	if len(gotBody.To) != 1 || gotBody.To[0] != "user@example.com" {
+		t.Errorf("to = %v, want [user@example.com]", gotBody.To)
+	}
+	if gotBody.Subject != "Your endpoint is down" {
+		t.Errorf("subject = %q", gotBody.Subject)
+	}
+	if gotBody.Text != "Fliq gave up after 5 attempts." {
+		t.Errorf("text = %q", gotBody.Text)
+	}
+}
+
+func TestResend_Send_ErrorsOnNon2xx(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []int{http.StatusUnauthorized, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(code)
+		}))
+		p := newTestResend("k", "from@fliq.sh", srv.URL)
+		err := p.Send(context.Background(), Email{To: "u@example.com", Subject: "s", Text: "t"})
+		srv.Close()
+		if err == nil {
+			t.Errorf("status %d: Send returned nil error, want failure", code)
+		}
+	}
+}
+
+func TestResend_Send_ErrorsWhenUnreachable(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // close immediately so the connection is refused
+
+	p := newTestResend("k", "from@fliq.sh", url)
+	if err := p.Send(context.Background(), Email{To: "u@example.com"}); err == nil {
+		t.Error("Send to a closed server returned nil error, want failure")
+	}
+}
+
+func TestNoopProvider_DropsAndSucceeds(t *testing.T) {
+	t.Parallel()
+
+	p := NewNoopProvider(testLogger())
+	if err := p.Send(context.Background(), Email{To: "u@example.com", Subject: "s", Text: "t"}); err != nil {
+		t.Fatalf("NoopProvider.Send returned error: %v", err)
+	}
+}


### PR DESCRIPTION
The email alert channel + proactive low-balance warning (#50) shipped without unit tests for its security- and money-sensitive helpers. This backfills them — no behaviour change beyond one test-only seam.

## What

- **`emailverify`** (signed confirm tokens — anti-abuse): sign/verify round-trip, tamper detection (id / expiry / mac), expiry boundary (just-inside vs just-past TTL), **foreign-secret rejection** (a token minted with another secret must not validate), and base64url round-tripping of awkward channel IDs (dots, slashes, unicode).
- **`domain.CrossedLowBalance`** (low-balance hysteresis): full truth table — downward edge fires, exact-boundary cases, already-below does not re-fire, top-up+drop re-fires, `threshold <= 0` disabled — plus a drop→hover→top-up→drop walk asserting it latches once per edge. Also `ValidAlertChannelType` / `RequiresVerification`.
- **`mailer.ResendProvider`**: request shape + `Authorization`/`Content-Type` headers via an `httptest` server, non-2xx and unreachable-host error paths; `NoopProvider` drop returns nil.

## Production change

One line: `ResendProvider` gains an unexported `endpoint` field (defaults to the real Resend URL, set in the constructor) so `Send` can be pointed at an `httptest` server. No runtime behaviour change.

## Verification

- `go test -race -count=1 -short ./...` — all pass
- `go vet ./...` — clean
- `golangci-lint run` on the changed packages — 0 issues
- `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)