### PR TITLE
Add last_error substring search to GET /jobs

### DIFF
--- a/internal/http/handler/job.go
+++ b/internal/http/handler/job.go
@@ -162,6 +162,7 @@ func (h *JobHandler) List(ctx *gin.Context) {
 		Cursor:          ctx.Query("cursor"),
 		Limit:           limit,
 		URLSearch:       ctx.Query("q"),
+		ErrorSearch:     ctx.Query("error_contains"),
 		Method:          ctx.Query("method"),
 		ScheduledAfter:  scheduledAfter,
 		ScheduledBefore: scheduledBefore,

--- a/internal/infrastructure/postgres/job_repo.go
+++ b/internal/infrastructure/postgres/job_repo.go
@@ -275,6 +275,10 @@ func (r *JobRepository) ListJobs(ctx context.Context, input repository.ListJobsI
 		args = append(args, "%"+escapeLike(input.URLSearch)+"%")
 		where = append(where, fmt.Sprintf("url ILIKE $%d", len(args)))
 	}
+	if input.ErrorSearch != "" {
+		args = append(args, "%"+escapeLike(input.ErrorSearch)+"%")
+		where = append(where, fmt.Sprintf("last_error ILIKE $%d", len(args)))
+	}
 	if input.ScheduledAfter != nil {
 		args = append(args, *input.ScheduledAfter)
 		where = append(where, fmt.Sprintf("scheduled_at >= $%d", len(args)))

--- a/internal/infrastructure/postgres/job_repo_integration_test.go
+++ b/internal/infrastructure/postgres/job_repo_integration_test.go
@@ -390,6 +390,71 @@ func TestJobRepo_ListJobs_SearchFilters(t *testing.T) {
 	}
 }
 
+// TestJobRepo_ListJobs_ErrorSearch covers the last_error substring filter — the
+// debugging path behind the dashboard's Failures view ("show me everything that
+// failed with this upstream message").
+func TestJobRepo_ListJobs_ErrorSearch(t *testing.T) {
+	repo, userID := setupJobRepo(t)
+	ctx := context.Background()
+
+	seed := []struct {
+		url     string
+		failErr string // empty = leave job pending with no last_error
+	}{
+		{"https://api.example.com/a", "dial tcp: connection refused"},
+		{"https://api.example.com/b", "context deadline exceeded (timeout)"},
+		{"https://api.example.com/c", ""},
+	}
+	for i, s := range seed {
+		job := testutil.NewJob(testutil.WithUserID(userID), testutil.WithURL(s.url))
+		created, err := repo.Create(ctx, job)
+		if err != nil {
+			t.Fatalf("create %d: %v", i, err)
+		}
+		if s.failErr != "" {
+			if err := repo.Fail(ctx, created.ID, s.failErr); err != nil {
+				t.Fatalf("fail %d: %v", i, err)
+			}
+		}
+	}
+
+	// Case-insensitive substring match on last_error finds the one refused job.
+	jobs, err := repo.ListJobs(ctx, repository.ListJobsInput{UserID: userID, ErrorSearch: "Connection Refused", Limit: 10})
+	if err != nil {
+		t.Fatalf("list error search: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("error search got %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].URL != "https://api.example.com/a" {
+		t.Fatalf("got url %s, want the refused job", jobs[0].URL)
+	}
+
+	// A term present in no last_error returns nothing (the pending job has a NULL
+	// last_error and must never match an ILIKE filter).
+	jobs, err = repo.ListJobs(ctx, repository.ListJobsInput{UserID: userID, ErrorSearch: "no-such-error", Limit: 10})
+	if err != nil {
+		t.Fatalf("list error search miss: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("error search miss got %d jobs, want 0", len(jobs))
+	}
+
+	// Combining error search with a URL search narrows with AND semantics.
+	jobs, err = repo.ListJobs(ctx, repository.ListJobsInput{
+		UserID:      userID,
+		URLSearch:   "/b",
+		ErrorSearch: "timeout",
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("list url+error: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].URL != "https://api.example.com/b" {
+		t.Fatalf("url+error search got %d jobs, want the timeout job", len(jobs))
+	}
+}
+
 // TestJobRepo_ListJobs_SearchEscapesWildcards ensures a search term containing
 // LIKE metacharacters is matched literally rather than as a wildcard.
 func TestJobRepo_ListJobs_SearchEscapesWildcards(t *testing.T) {

--- a/internal/repository/job.go
+++ b/internal/repository/job.go
@@ -17,6 +17,7 @@ type ListJobsInput struct {
 	// Optional search/filter predicates (validated in the usecase layer).
 	Method          string     // exact HTTP method; empty = all
 	URLSearch       string     // case-insensitive substring match on url; empty = no filter
+	ErrorSearch     string     // case-insensitive substring match on last_error; empty = no filter
 	ScheduledAfter  *time.Time // scheduled_at >= this; nil = no lower bound
 	ScheduledBefore *time.Time // scheduled_at <= this; nil = no upper bound
 }

--- a/internal/usecase/job.go
+++ b/internal/usecase/job.go
@@ -169,6 +169,7 @@ type ListJobsInput struct {
 
 	// Optional search/filter predicates. All combine with AND and with Status.
 	URLSearch       string     // case-insensitive substring match on the target URL
+	ErrorSearch     string     // case-insensitive substring match on the last error message
 	Method          string     // exact HTTP method (case-insensitive); empty = all
 	ScheduledAfter  *time.Time // scheduled_at >= this; nil = no lower bound
 	ScheduledBefore *time.Time // scheduled_at <= this; nil = no upper bound
@@ -246,11 +247,17 @@ func (u *JobUsecase) ListJobs(ctx context.Context, input ListJobsInput) (ListJob
 		return ListJobsResult{}, domain.ErrInvalidSearch
 	}
 
+	errorSearch := strings.TrimSpace(input.ErrorSearch)
+	if len(errorSearch) > maxSearchLen {
+		return ListJobsResult{}, domain.ErrInvalidSearch
+	}
+
 	repoInput := repository.ListJobsInput{
 		UserID:          input.UserID,
 		Status:          status,
 		Method:          method,
 		URLSearch:       search,
+		ErrorSearch:     errorSearch,
 		ScheduledAfter:  input.ScheduledAfter,
 		ScheduledBefore: input.ScheduledBefore,
 		Limit:           limit + 1,

--- a/internal/usecase/job_test.go
+++ b/internal/usecase/job_test.go
@@ -3,6 +3,7 @@ package usecase_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -279,6 +280,45 @@ func TestListJobs_InvalidStatus(t *testing.T) {
 	})
 	if !errors.Is(err, domain.ErrInvalidStatus) {
 		t.Fatalf("expected ErrInvalidStatus, got %v", err)
+	}
+}
+
+func TestListJobs_PassesErrorSearch(t *testing.T) {
+	t.Parallel()
+
+	var capturedInput repository.ListJobsInput
+	jobRepo := &testutil.MockJobRepository{
+		ListJobsFn: func(_ context.Context, input repository.ListJobsInput) ([]*domain.Job, error) {
+			capturedInput = input
+			return nil, nil
+		},
+	}
+	uc := usecase.NewJobUsecase(jobRepo, &testutil.MockAttemptRepository{}, &testutil.MockCreditRepository{})
+
+	_, err := uc.ListJobs(context.Background(), usecase.ListJobsInput{
+		UserID:      "user-1",
+		ErrorSearch: "  connection refused  ",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The term is trimmed and forwarded to the repository verbatim.
+	if capturedInput.ErrorSearch != "connection refused" {
+		t.Fatalf("expected trimmed ErrorSearch %q, got %q", "connection refused", capturedInput.ErrorSearch)
+	}
+}
+
+func TestListJobs_ErrorSearchTooLong(t *testing.T) {
+	t.Parallel()
+
+	uc := usecase.NewJobUsecase(&testutil.MockJobRepository{}, &testutil.MockAttemptRepository{}, &testutil.MockCreditRepository{})
+
+	_, err := uc.ListJobs(context.Background(), usecase.ListJobsInput{
+		UserID:      "user-1",
+		ErrorSearch: strings.Repeat("x", 513),
+	})
+	if !errors.Is(err, domain.ErrInvalidSearch) {
+		t.Fatalf("expected ErrInvalidSearch, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Extends the job search added in #57 with one more predicate: filter the job list by a substring of the **last error message**.

## Why
The dashboard Failures view (frontend#18) and anyone debugging a flaky upstream want to ask *"show me everything that failed with this error."* `GET /jobs` already filters by `status`, `method`, `url` (`q`), and scheduled-time range; the one debugging dimension missing was the error text itself.

## What
- New query param **`error_contains`** on `GET /jobs` → case-insensitive substring match on `last_error`.
- Combines with every existing filter via `AND`; keyset pagination unchanged.
- Mirrors the existing `q` (URL) search exactly: trimmed + length-capped (≤512) in the usecase, LIKE-metacharacters escaped at the repo layer (`%`, `_`, `\` matched literally), `ILIKE` in SQL.
- No schema change, no migration — `last_error` already exists on `jobs`.

Example:
```
GET /jobs?status=failed&error_contains=connection%20refused
```

## Tests
- **Unit** (`internal/usecase`): `error_contains` is trimmed and forwarded to the repo; over-length term → `ErrInvalidSearch`.
- **Integration** (`internal/infrastructure/postgres`): case-insensitive match finds the right failed job, a non-matching term (and the NULL-`last_error` pending job) returns nothing, and `url` + `error_contains` narrow with AND semantics.
- Full unit + integration suites green locally (postgres:17), `golangci-lint` clean, `go vet` clean.

Layer-clean: `repository` interface field → `usecase` validation → `postgres` predicate → `handler` param. No new dependencies.