### PR TITLE
Security hardening: billing overflow, webhook idempotency, SSRF rebinding, DoS limits

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -115,6 +115,14 @@ func main() {
 	srv := http.Server{
 		Addr:    ":" + cfg.Port,
 		Handler: httptransport.NewRouter(logger, jobHandler, scheduleHandler, tokenHandler, billingHandler, signingHandler, bufferHandler, alertHandler, statsHandler, userRepo, creditRepo, tokenRepo, cfg.ClerkJWKSURL, []byte(cfg.JWTSecret), cfg.CORSAllowedOrigins, rateLimiter),
+		// Bound how long a single connection may tie up server resources. Without
+		// these a slow client trickling headers/body (Slowloris) can hold
+		// connections open indefinitely and exhaust the single-instance API.
+		// Endpoints are fast CRUD, so these ceilings are generous.
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	metricsSrv := metrics.NewServer(":"+cfg.MetricsPort, checker)

--- a/internal/http/handler/billing.go
+++ b/internal/http/handler/billing.go
@@ -51,7 +51,10 @@ func (h *BillingHandler) CreateCheckoutSession(c *gin.Context) {
 	userID := c.GetString("userID")
 
 	var req struct {
-		Credits int64 `json:"credits" binding:"required,min=1"`
+		// max caps a single purchase and, critically, keeps credits*100 far below
+		// the int64 ceiling so the price calculation cannot overflow and decouple
+		// the charged amount from the granted credits.
+		Credits int64 `json:"credits" binding:"required,min=1,max=1000000000"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": formatValidationError(err)})

--- a/internal/http/middleware/bodylimit.go
+++ b/internal/http/middleware/bodylimit.go
@@ -1,0 +1,27 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// MaxRequestBodyBytes caps the size of any inbound request body. Job/buffer
+// bodies and header maps are otherwise unbounded and read fully into memory
+// before being persisted, so a client posting a multi-gigabyte body could drive
+// the API into memory pressure. 10 MiB is far above any legitimate job payload
+// while closing the DoS/DB-bloat vector.
+const MaxRequestBodyBytes int64 = 10 << 20 // 10 MiB
+
+// BodyLimit wraps each request body in an http.MaxBytesReader so reads beyond
+// the limit fail (surfacing as a 400 from the JSON binder / a 413 on the
+// underlying write). Applied globally; the Stripe webhook and all handlers read
+// through the same capped reader.
+func BodyLimit(maxBytes int64) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.Request.Body != nil {
+			c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBytes)
+		}
+		c.Next()
+	}
+}

--- a/internal/http/middleware/bodylimit_test.go
+++ b/internal/http/middleware/bodylimit_test.go
@@ -1,0 +1,51 @@
+package middleware_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+func newBodyLimitEngine(maxBytes int64) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.BodyLimit(maxBytes))
+	r.POST("/echo", func(c *gin.Context) {
+		// Fully read the body; MaxBytesReader errors here when over the cap.
+		if _, err := io.ReadAll(c.Request.Body); err != nil {
+			c.String(http.StatusRequestEntityTooLarge, "too large")
+			return
+		}
+		c.String(http.StatusOK, "ok")
+	})
+	return r
+}
+
+func TestBodyLimit_UnderLimit(t *testing.T) {
+	r := newBodyLimitEngine(1024)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/echo", strings.NewReader(strings.Repeat("a", 512)))
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200", w.Code)
+	}
+}
+
+func TestBodyLimit_OverLimit(t *testing.T) {
+	r := newBodyLimitEngine(1024)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/echo", strings.NewReader(strings.Repeat("a", 4096)))
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("code = %d, want 413 (body over cap must be rejected)", w.Code)
+	}
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -15,6 +15,7 @@ func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHand
 	r := gin.New()
 	r.Use(gin.Recovery())
 	r.Use(middleware.RequestID())
+	r.Use(middleware.BodyLimit(middleware.MaxRequestBodyBytes))
 	r.Use(middleware.CORS(corsAllowedOrigins))
 	r.Use(middleware.Security())
 	r.Use(sloggin.New(logger))

--- a/internal/infrastructure/postgres/billing_repo.go
+++ b/internal/infrastructure/postgres/billing_repo.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
 	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -204,6 +205,14 @@ func (r *CreditRepo) deduct(ctx context.Context, userID string, txType domain.Cr
 	return crossing, nil
 }
 
+// TopUp adds credits and records a stripe_topup ledger row. It is idempotent on
+// stripePaymentIntentID: Stripe delivers webhooks at-least-once, so a redelivered
+// checkout.session.completed must not credit the same payment twice. The ledger
+// insert runs first with ON CONFLICT DO NOTHING against the partial unique index
+// on the payment intent; if it is a duplicate the balance is left untouched and
+// the call succeeds as a no-op. An empty payment intent is stored as NULL (rare,
+// and excluded from the uniqueness guard) so distinct no-intent events don't
+// collide with each other.
 func (r *CreditRepo) TopUp(ctx context.Context, userID string, amount int64, stripePaymentIntentID string) error {
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
@@ -215,6 +224,32 @@ func (r *CreditRepo) TopUp(ctx context.Context, userID string, amount int64, str
 		}
 	}()
 
+	var paymentIntent any
+	if stripePaymentIntentID != "" {
+		paymentIntent = stripePaymentIntentID
+	}
+
+	var tag pgconn.CommandTag
+	tag, err = tx.Exec(ctx,
+		`INSERT INTO credit_transactions (user_id, amount, type, stripe_payment_intent_id)
+		 VALUES ($1, $2, $3, $4)
+		 ON CONFLICT (stripe_payment_intent_id)
+		     WHERE type = 'stripe_topup' AND stripe_payment_intent_id IS NOT NULL
+		 DO NOTHING`,
+		userID, amount, domain.CreditTxStripeTopup, paymentIntent,
+	)
+	if err != nil {
+		return fmt.Errorf("insert topup tx: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		// Duplicate delivery for this payment intent — already credited. Commit
+		// the empty transaction and report success so the webhook is acked.
+		if err = tx.Commit(ctx); err != nil {
+			return fmt.Errorf("commit: %w", err)
+		}
+		return nil
+	}
+
 	_, err = tx.Exec(ctx,
 		`UPDATE user_credits
 		 SET balance = balance + $2, low_balance_notified = FALSE, updated_at = NOW()
@@ -223,15 +258,6 @@ func (r *CreditRepo) TopUp(ctx context.Context, userID string, amount int64, str
 	)
 	if err != nil {
 		return fmt.Errorf("top up credits: %w", err)
-	}
-
-	_, err = tx.Exec(ctx,
-		`INSERT INTO credit_transactions (user_id, amount, type, stripe_payment_intent_id)
-		 VALUES ($1, $2, $3, $4)`,
-		userID, amount, domain.CreditTxStripeTopup, stripePaymentIntentID,
-	)
-	if err != nil {
-		return fmt.Errorf("insert topup tx: %w", err)
 	}
 
 	if err = tx.Commit(ctx); err != nil {

--- a/internal/infrastructure/postgres/billing_repo_integration_test.go
+++ b/internal/infrastructure/postgres/billing_repo_integration_test.go
@@ -121,6 +121,63 @@ func TestBillingRepo_TopUp(t *testing.T) {
 	}
 }
 
+func TestBillingRepo_TopUp_IdempotentOnPaymentIntent(t *testing.T) {
+	repo, userID := setupBillingRepo(t)
+	ctx := context.Background()
+
+	before, _ := repo.GetBalance(ctx, userID)
+
+	// Simulate Stripe redelivering the same checkout.session.completed twice.
+	if err := repo.TopUp(ctx, userID, 5000, "pi_dup_1"); err != nil {
+		t.Fatalf("first top up: %v", err)
+	}
+	if err := repo.TopUp(ctx, userID, 5000, "pi_dup_1"); err != nil {
+		t.Fatalf("redelivered top up should be a no-op, got: %v", err)
+	}
+
+	after, _ := repo.GetBalance(ctx, userID)
+	if after.Balance != before.Balance+5000 {
+		t.Fatalf("balance = %d, want %d (credited exactly once)", after.Balance, before.Balance+5000)
+	}
+
+	// Exactly one stripe_topup ledger row for this payment intent.
+	txs, _, err := repo.ListTransactions(ctx, userID, "", 100)
+	if err != nil {
+		t.Fatalf("list transactions: %v", err)
+	}
+	topups := 0
+	for _, tx := range txs {
+		if tx.Type == domain.CreditTxStripeTopup {
+			topups++
+		}
+	}
+	if topups != 1 {
+		t.Fatalf("stripe_topup rows = %d, want 1", topups)
+	}
+
+	// A different payment intent still credits independently.
+	if err := repo.TopUp(ctx, userID, 3000, "pi_dup_2"); err != nil {
+		t.Fatalf("distinct top up: %v", err)
+	}
+	after2, _ := repo.GetBalance(ctx, userID)
+	if after2.Balance != before.Balance+8000 {
+		t.Fatalf("balance = %d, want %d", after2.Balance, before.Balance+8000)
+	}
+
+	// Empty payment intents are NULL, excluded from the guard, so two of them
+	// both credit (no false-positive dedup).
+	if err := repo.TopUp(ctx, userID, 100, ""); err != nil {
+		t.Fatalf("empty-intent top up 1: %v", err)
+	}
+	if err := repo.TopUp(ctx, userID, 100, ""); err != nil {
+		t.Fatalf("empty-intent top up 2: %v", err)
+	}
+	after3, _ := repo.GetBalance(ctx, userID)
+	if after3.Balance != before.Balance+8200 {
+		t.Fatalf("balance = %d, want %d (empty intents not deduped)", after3.Balance, before.Balance+8200)
+	}
+}
+
 func TestBillingRepo_UpdatePlan(t *testing.T) {
 	repo, userID := setupBillingRepo(t)
 	ctx := context.Background()

--- a/internal/safedialer/safedialer.go
+++ b/internal/safedialer/safedialer.go
@@ -38,12 +38,20 @@ func init() {
 // ErrBlockedAddress is returned when a resolved IP falls within a blocked range.
 var ErrBlockedAddress = fmt.Errorf("address is in a blocked network range")
 
+type (
+	lookupFunc = func(ctx context.Context, host string) ([]net.IPAddr, error)
+	dialFunc   = func(d *net.Dialer, ctx context.Context, network, addr string) (net.Conn, error)
+)
+
 // Test hooks. Overridden in tests to drive resolution and the underlying TCP
 // connect deterministically (real DNS/sockets are otherwise required to
-// exercise the resolve-then-dial path). Defaults call the real network.
+// exercise the resolve-then-dial path). Defaults call the real network. Each
+// NewSafeDialContext captures these into locals at construction, so the racing
+// dial goroutines never read the package vars directly (a test restoring a hook
+// after the call returns can't data-race with a lingering goroutine).
 var (
-	lookupIPAddr = net.DefaultResolver.LookupIPAddr
-	dialIP       = func(d *net.Dialer, ctx context.Context, network, addr string) (net.Conn, error) {
+	lookupIPAddr lookupFunc = net.DefaultResolver.LookupIPAddr
+	dialIP       dialFunc   = func(d *net.Dialer, ctx context.Context, network, addr string) (net.Conn, error) {
 		return d.DialContext(ctx, network, addr)
 	}
 )
@@ -69,6 +77,9 @@ func NewSafeDialContext(timeout, keepAlive time.Duration) func(ctx context.Conte
 		Timeout:   timeout,
 		KeepAlive: keepAlive,
 	}
+	// Capture the hooks once so the racing dial goroutines close over stable
+	// function values instead of re-reading the package vars.
+	lookup, dial := lookupIPAddr, dialIP
 
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(addr)
@@ -76,7 +87,7 @@ func NewSafeDialContext(timeout, keepAlive time.Duration) func(ctx context.Conte
 			return nil, fmt.Errorf("safedialer: split host/port: %w", err)
 		}
 
-		ips, err := lookupIPAddr(ctx, host)
+		ips, err := lookup(ctx, host)
 		if err != nil {
 			return nil, fmt.Errorf("safedialer: resolve %q: %w", host, err)
 		}
@@ -94,17 +105,67 @@ func NewSafeDialContext(timeout, keepAlive time.Duration) func(ctx context.Conte
 		// blocked one (169.254.169.254, 127.0.0.1, RFC-1918) for the connect lookup.
 		// TLS verification is unaffected — the transport takes its ServerName from
 		// the request URL, not from the address we connect to.
-		var lastErr error
-		for _, ipAddr := range ips {
-			conn, dialErr := dialIP(dialer, ctx, network, net.JoinHostPort(ipAddr.IP.String(), port))
-			if dialErr == nil {
-				return conn, nil
-			}
-			lastErr = dialErr
+		conn, err := dialValidated(ctx, dial, dialer, network, port, ips)
+		if err != nil {
+			return nil, fmt.Errorf("safedialer: dial %q: %w", host, err)
 		}
-		if lastErr == nil {
-			lastErr = fmt.Errorf("no addresses resolved")
+		return conn, nil
+	}
+}
+
+// dialValidated connects to the pre-validated IPs, racing them concurrently and
+// returning the first established connection (any later successes are closed).
+// Racing — rather than dialing serially — preserves the Happy-Eyeballs-like
+// latency the old single-hostname dial provided: a dual-stack host whose IPv6
+// address is black-holed no longer stalls the whole per-call timeout before
+// falling back to IPv4. Every address raced is one that already passed the
+// block-list check, so the SSRF guarantee is unchanged.
+func dialValidated(ctx context.Context, dial dialFunc, dialer *net.Dialer, network, port string, ips []net.IPAddr) (net.Conn, error) {
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no addresses resolved")
+	}
+
+	// Cancelling this context aborts the still-racing dials once we have a
+	// winner; it does not affect an already-established connection.
+	dialCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Buffered to len(ips) so no dial goroutine can block on send after we
+	// return — the drain goroutine below empties whatever is left.
+	results := make(chan dialOutcome, len(ips))
+	for _, ipAddr := range ips {
+		go func(addr string) {
+			conn, err := dial(dialer, dialCtx, network, addr)
+			results <- dialOutcome{conn: conn, err: err}
+		}(net.JoinHostPort(ipAddr.IP.String(), port))
+	}
+
+	var lastErr error
+	for i := 0; i < len(ips); i++ {
+		r := <-results
+		if r.err == nil {
+			// Winner. Close any connections that land after cancel in the
+			// background so no socket leaks.
+			go drainAndClose(results, len(ips)-i-1)
+			return r.conn, nil
 		}
-		return nil, fmt.Errorf("safedialer: dial %q: %w", host, lastErr)
+		lastErr = r.err
+	}
+	return nil, lastErr
+}
+
+type dialOutcome struct {
+	conn net.Conn
+	err  error
+}
+
+// drainAndClose consumes n remaining dial results, closing any connections that
+// still succeeded despite the context cancellation.
+func drainAndClose(results <-chan dialOutcome, n int) {
+	for i := 0; i < n; i++ {
+		r := <-results
+		if r.conn != nil {
+			_ = r.conn.Close()
+		}
 	}
 }

--- a/internal/safedialer/safedialer.go
+++ b/internal/safedialer/safedialer.go
@@ -38,6 +38,16 @@ func init() {
 // ErrBlockedAddress is returned when a resolved IP falls within a blocked range.
 var ErrBlockedAddress = fmt.Errorf("address is in a blocked network range")
 
+// Test hooks. Overridden in tests to drive resolution and the underlying TCP
+// connect deterministically (real DNS/sockets are otherwise required to
+// exercise the resolve-then-dial path). Defaults call the real network.
+var (
+	lookupIPAddr = net.DefaultResolver.LookupIPAddr
+	dialIP       = func(d *net.Dialer, ctx context.Context, network, addr string) (net.Conn, error) {
+		return d.DialContext(ctx, network, addr)
+	}
+)
+
 // isBlocked reports whether ip falls within any blocked CIDR.
 func isBlocked(ip net.IP) bool {
 	for _, cidr := range blockedCIDRs {
@@ -49,9 +59,11 @@ func isBlocked(ip net.IP) bool {
 }
 
 // NewSafeDialContext returns a DialContext function that resolves the host to
-// IP addresses and rejects any that fall within private/loopback/link-local
-// ranges. This prevents SSRF attacks including DNS rebinding, because the
-// check happens after DNS resolution but before the TCP connection.
+// IP addresses, rejects any that fall within private/loopback/link-local
+// ranges, and then connects to one of the exact IPs it validated. Pinning the
+// connection to a validated IP (rather than re-resolving the hostname) is what
+// makes this resistant to DNS rebinding: there is no second lookup between the
+// safety check and the TCP connection for an attacker to poison.
 func NewSafeDialContext(timeout, keepAlive time.Duration) func(ctx context.Context, network, addr string) (net.Conn, error) {
 	dialer := &net.Dialer{
 		Timeout:   timeout,
@@ -64,7 +76,7 @@ func NewSafeDialContext(timeout, keepAlive time.Duration) func(ctx context.Conte
 			return nil, fmt.Errorf("safedialer: split host/port: %w", err)
 		}
 
-		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+		ips, err := lookupIPAddr(ctx, host)
 		if err != nil {
 			return nil, fmt.Errorf("safedialer: resolve %q: %w", host, err)
 		}
@@ -75,8 +87,24 @@ func NewSafeDialContext(timeout, keepAlive time.Duration) func(ctx context.Conte
 			}
 		}
 
-		// All resolved IPs are safe; connect to the original address so the OS
-		// picks the best route (and respects Happy Eyeballs for dual-stack).
-		return dialer.DialContext(ctx, network, net.JoinHostPort(host, port))
+		// Dial the exact IPs we just validated — never re-pass the hostname to the
+		// dialer. Handing the hostname back would trigger a second, independent DNS
+		// resolution inside net.Dialer, opening a rebinding window: an attacker with
+		// a short-TTL record can return a public IP for the validation lookup and a
+		// blocked one (169.254.169.254, 127.0.0.1, RFC-1918) for the connect lookup.
+		// TLS verification is unaffected — the transport takes its ServerName from
+		// the request URL, not from the address we connect to.
+		var lastErr error
+		for _, ipAddr := range ips {
+			conn, dialErr := dialIP(dialer, ctx, network, net.JoinHostPort(ipAddr.IP.String(), port))
+			if dialErr == nil {
+				return conn, nil
+			}
+			lastErr = dialErr
+		}
+		if lastErr == nil {
+			lastErr = fmt.Errorf("no addresses resolved")
+		}
+		return nil, fmt.Errorf("safedialer: dial %q: %w", host, lastErr)
 	}
 }

--- a/internal/safedialer/safedialer_test.go
+++ b/internal/safedialer/safedialer_test.go
@@ -93,6 +93,38 @@ func TestSafeDial_ConnectsToValidatedIP(t *testing.T) {
 	}
 }
 
+// TestSafeDial_RacesToWorkingIP proves a dead address (e.g. a black-holed IPv6)
+// does not stop a working one from connecting — the dials race and the first
+// success wins, without waiting out the dead address's full timeout.
+func TestSafeDial_RacesToWorkingIP(t *testing.T) {
+	const deadIP = "203.0.113.1"  // fails immediately in the stub
+	const liveIP = "93.184.216.34" // succeeds in the stub
+
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+
+	withHooks(t,
+		func(_ context.Context, _ string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP(deadIP)}, {IP: net.ParseIP(liveIP)}}, nil
+		},
+		func(_ *net.Dialer, ctx context.Context, _, addr string) (net.Conn, error) {
+			if addr == net.JoinHostPort(deadIP, "443") {
+				return nil, errors.New("connection refused")
+			}
+			return client, nil
+		},
+	)
+
+	dial := NewSafeDialContext(time.Second, time.Second)
+	conn, err := dial(context.Background(), "tcp", "example.com:443")
+	if err != nil {
+		t.Fatalf("expected a connection via the live IP, got error: %v", err)
+	}
+	if conn != client {
+		t.Fatal("expected the live IP's connection to be returned")
+	}
+}
+
 // TestSafeDial_RejectsRebindToBlockedIP: even if the hostname looks benign, a
 // resolution that includes a blocked IP is refused before any connection.
 func TestSafeDial_RejectsRebindToBlockedIP(t *testing.T) {

--- a/internal/safedialer/safedialer_test.go
+++ b/internal/safedialer/safedialer_test.go
@@ -1,8 +1,11 @@
 package safedialer
 
 import (
+	"context"
+	"errors"
 	"net"
 	"testing"
+	"time"
 )
 
 func TestIsBlocked(t *testing.T) {
@@ -50,5 +53,68 @@ func TestIsBlocked(t *testing.T) {
 				t.Errorf("isBlocked(%s) = %v, want %v", tt.ip, got, tt.blocked)
 			}
 		})
+	}
+}
+
+// withHooks swaps the resolver/dialer test hooks for the duration of a test.
+func withHooks(t *testing.T, lookup func(context.Context, string) ([]net.IPAddr, error), dial func(*net.Dialer, context.Context, string, string) (net.Conn, error)) {
+	t.Helper()
+	origLookup, origDial := lookupIPAddr, dialIP
+	lookupIPAddr, dialIP = lookup, dial
+	t.Cleanup(func() { lookupIPAddr, dialIP = origLookup, origDial })
+}
+
+// TestSafeDial_ConnectsToValidatedIP is the core DNS-rebinding regression test:
+// the address handed to the low-level dialer must be the exact IP that passed
+// validation, never the hostname (which would trigger a second, poisonable
+// lookup).
+func TestSafeDial_ConnectsToValidatedIP(t *testing.T) {
+	const publicIP = "93.184.216.34"
+	var dialedAddr string
+
+	withHooks(t,
+		func(_ context.Context, host string) ([]net.IPAddr, error) {
+			if host != "example.com" {
+				t.Fatalf("unexpected lookup host %q", host)
+			}
+			return []net.IPAddr{{IP: net.ParseIP(publicIP)}}, nil
+		},
+		func(_ *net.Dialer, _ context.Context, _, addr string) (net.Conn, error) {
+			dialedAddr = addr
+			return nil, errors.New("dial stubbed") // we only assert the target
+		},
+	)
+
+	dial := NewSafeDialContext(time.Second, time.Second)
+	_, _ = dial(context.Background(), "tcp", "example.com:443")
+
+	if want := net.JoinHostPort(publicIP, "443"); dialedAddr != want {
+		t.Fatalf("dialed %q, want the validated IP %q (hostname re-resolution = rebinding hole)", dialedAddr, want)
+	}
+}
+
+// TestSafeDial_RejectsRebindToBlockedIP: even if the hostname looks benign, a
+// resolution that includes a blocked IP is refused before any connection.
+func TestSafeDial_RejectsRebindToBlockedIP(t *testing.T) {
+	dialCalled := false
+	withHooks(t,
+		func(_ context.Context, _ string) ([]net.IPAddr, error) {
+			// Simulates a rebinding record resolving to the cloud metadata IP.
+			return []net.IPAddr{{IP: net.ParseIP("169.254.169.254")}}, nil
+		},
+		func(_ *net.Dialer, _ context.Context, _, addr string) (net.Conn, error) {
+			dialCalled = true
+			return nil, nil
+		},
+	)
+
+	dial := NewSafeDialContext(time.Second, time.Second)
+	_, err := dial(context.Background(), "tcp", "rebind.evil.example:80")
+
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress, got %v", err)
+	}
+	if dialCalled {
+		t.Fatal("dialer was called for a blocked address — must reject before connecting")
 	}
 }

--- a/internal/usecase/billing.go
+++ b/internal/usecase/billing.go
@@ -15,6 +15,13 @@ import (
 
 const stripeMinimumCents = 50 // Stripe enforces a $0.50 floor on USD charges
 
+// maxCheckoutCredits caps a single top-up. It is the authoritative business
+// limit (the HTTP binding mirrors it for a clean 400) and, more importantly, a
+// safety floor: at 1e9 credits, credits*100 = 1e11, four orders of magnitude
+// below math.MaxInt64, so the amountCents calculation below can never overflow
+// and mint credits decoupled from the amount actually charged.
+const maxCheckoutCredits = 1_000_000_000
+
 // BillingConfig holds the exchange rate and Stripe Checkout redirect URLs.
 type BillingConfig struct {
 	// CreditsPerDollar is the exchange rate (e.g. 1000 = 1000 credits per $1).
@@ -78,6 +85,9 @@ func (u *BillingUsecase) CreditsPerDollar() int64 {
 func (u *BillingUsecase) CreateCheckoutSession(ctx context.Context, userID string, credits int64) (string, error) {
 	if credits <= 0 {
 		return "", fmt.Errorf("credits must be positive")
+	}
+	if credits > maxCheckoutCredits {
+		return "", fmt.Errorf("credits must be at most %d per purchase", maxCheckoutCredits)
 	}
 
 	amountCents := (credits * 100) / u.config.CreditsPerDollar

--- a/internal/usecase/billing_test.go
+++ b/internal/usecase/billing_test.go
@@ -76,6 +76,35 @@ func TestGetBalance_Error(t *testing.T) {
 	}
 }
 
+func TestCreateCheckoutSession_RejectsOversizedCredits(t *testing.T) {
+	t.Parallel()
+
+	uc := newBillingUsecase(&testutil.MockCreditRepository{})
+
+	cases := []struct {
+		name    string
+		credits int64
+	}{
+		{"zero", 0},
+		{"negative", -5},
+		{"just over cap", 1_000_000_001},
+		// The overflow exploit: credits*100 wraps int64 to a tiny amountCents, so
+		// a $0.005 charge would otherwise mint ~4.6e18 credits. Must be rejected.
+		{"int64 overflow value", 4611686018427437904},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// stripe client is nil; a value that slips past the guard would panic
+			// on the customer lookup, so reaching an error return proves the guard
+			// fired first.
+			_, err := uc.CreateCheckoutSession(context.Background(), "user-1", tc.credits)
+			if err == nil {
+				t.Fatalf("expected rejection for credits=%d, got nil", tc.credits)
+			}
+		})
+	}
+}
+
 func TestListTransactions_DefaultLimit(t *testing.T) {
 	t.Parallel()
 

--- a/migrations/20260705000000_stripe_topup_idempotency.sql
+++ b/migrations/20260705000000_stripe_topup_idempotency.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+
+-- Make Stripe top-ups idempotent. Stripe delivers webhooks at-least-once and
+-- retries checkout.session.completed whenever it doesn't see a timely 2xx, so a
+-- redelivery must not credit the same payment twice. A partial unique index on
+-- the payment intent (top-up rows only) turns a duplicate delivery into a
+-- no-op via ON CONFLICT in the TopUp repository method. NULL payment intents
+-- (rare events with no PaymentIntent) are excluded and remain unconstrained.
+--
+-- NOTE: if this index fails to build with a unique_violation, pre-existing
+-- duplicate top-ups already exist in the ledger from before this fix. Do NOT
+-- remove the check — reconcile the duplicates first:
+--   SELECT stripe_payment_intent_id, count(*) FROM credit_transactions
+--   WHERE type = 'stripe_topup' AND stripe_payment_intent_id IS NOT NULL
+--   GROUP BY 1 HAVING count(*) > 1;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_credit_tx_stripe_topup_payment_intent
+    ON credit_transactions (stripe_payment_intent_id)
+    WHERE type = 'stripe_topup' AND stripe_payment_intent_id IS NOT NULL;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS uq_credit_tx_stripe_topup_payment_intent;


### PR DESCRIPTION
Part of the fliq full-repo security review (tracked in fliq-sh/infra#4). Five findings, each an atomic commit with tests. Full write-up in `docs/security-review-2026-07.md` (infra repo, separate PR).

## HIGH

### 1. Checkout credit int64 overflow → quintillions of credits for $0.50
`internal/usecase/billing.go`, `internal/http/handler/billing.go`. `amountCents = credits*100/CreditsPerDollar` with `credits` an unbounded `int64` and no `max` on the binding. A value near `MaxInt64/100` wraps the multiply, decoupling the Stripe charge from the credit amount carried in session metadata (which the webhook grants verbatim): `{"credits": 4611686018427437904}` charges **$0.50** and grants ~4.6e18 credits. **Fix:** cap a purchase at `1e9` credits in the usecase (authoritative) + mirror `max=1000000000` on the binding. At 1e9, `credits*100 = 1e11` ≪ `MaxInt64`.

### 2. Stripe webhook not idempotent → duplicate top-ups on redelivery
`internal/infrastructure/postgres/billing_repo.go` + new migration `20260705000000`. Stripe delivers at-least-once and retries `checkout.session.completed` on any non-2xx/timeout, so a redelivery re-ran `TopUp` and credited the purchase again — no attacker needed. **Fix:** partial unique index on `credit_transactions(stripe_payment_intent_id)` for top-up rows; `TopUp` inserts the ledger row first with `ON CONFLICT DO NOTHING` and only credits when a row was inserted. Empty intents → `NULL` (excluded from the guard). Integration test covers redelivery-is-noop, distinct-intent-still-credits, and empty-intents-not-deduped.

> ⚠️ **Before merging:** if pre-existing duplicate top-ups exist, the index build fails by design (it's a signal, don't drop it). Run and reconcile:
> ```sql
> SELECT stripe_payment_intent_id, count(*) FROM credit_transactions
> WHERE type='stripe_topup' AND stripe_payment_intent_id IS NOT NULL
> GROUP BY 1 HAVING count(*) > 1;
> ```

### 3. safedialer DNS-rebinding bypass
`internal/safedialer/safedialer.go`. It validated the resolved IPs, then reconnected via `net.JoinHostPort(host, port)` — a **second, independent** DNS resolution by `net.Dialer`. A short-TTL record could return a public IP to the validation lookup and `169.254.169.254`/loopback/RFC-1918 to the connect lookup, defeating the SSRF guard on every outbound path (executor, completion webhook, alert notifier). **Fix:** dial the exact validated IPs, never the hostname. TLS ServerName still comes from the request URL, so cert verification is unaffected. The block-list is **not** weakened. Dials race the validated IPs concurrently so a black-holed IPv6 doesn't stall the per-call timeout (preserves the old Happy-Eyeballs latency). Regression tests assert the dialer receives the validated IP (not the hostname) and that a rebind to the metadata IP is refused before connecting.

## MEDIUM

### 4. No HTTP server timeouts (Slowloris)
`cmd/server/main.go`. `http.Server` had no read/write/idle timeouts — slow clients could hold connections open indefinitely. **Fix:** `ReadHeaderTimeout=10s`, `ReadTimeout=30s`, `WriteTimeout=60s`, `IdleTimeout=120s` (all endpoints are fast CRUD; job-execution timeouts live in the scheduler's outbound client, not this inbound server).

### 5. No request body size limit
`internal/http/middleware/bodylimit.go` + `router.go`. Job/buffer bodies + header maps were unbounded and read fully into memory. **Fix:** global 10 MiB `MaxBytesReader` (far above any legitimate payload). The Stripe webhook (kilobytes) reads through the same capped reader unaffected.

## Verification
- `go build ./...`, `golangci-lint run ./...` (0 issues), and `go test -race -count=1 -tags=integration ./...` all pass against a real `postgres:17` (migrations applied). New tests: overflow guard (incl. the wrap value), webhook idempotency (integration), safedialer rebinding + race-to-working-IP, body-limit over/under.
- A fresh-context adversarial review verified each change (TLS intact, partial-index `ON CONFLICT` inference confirmed against the live DB, no streaming endpoint broken by timeouts, webhook body-read unaffected).

Deferred to the report (needs an operator decision / can't be validated at night): email-verify token secret (F8), credit-deduction floor (F18), JWT iss/aud (F20), webhook error leakage (F21), rate-limit gaps (F22).

Does not touch open PRs #61–64.