### PR TITLE
Durable, retrying webhook delivery for job completion

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -51,6 +51,7 @@ func main() {
 
 	signingRepo := postgres.NewSigningSecretRepository(pool)
 	alertRepo := postgres.NewAlertChannelRepository(pool)
+	webhookDeliveryRepo := postgres.NewWebhookDeliveryRepository(pool)
 
 	var mailProvider mailer.Provider
 	if cfg.ResendAPIKey == "" {
@@ -72,15 +73,25 @@ func main() {
 		jobRepo,
 		attemptRepo,
 		creditRepo,
-		notifier,
+		webhookDeliveryRepo,
 		alertNotifier,
 		lowBalance,
 		logger,
 		time.Duration(cfg.PollIntervalSec)*time.Second,
 		cfg.WorkerCount,
+		cfg.WebhookMaxAttempts,
 		signingRepo,
 	)
 	go worker.Start(ctx)
+
+	// Drains the durable webhook_deliveries queue: POSTs each due delivery and
+	// retries with backoff, off the worker path so a slow customer URL never
+	// stalls job execution.
+	webhookDispatcher := scheduler.NewWebhookDispatcher(
+		webhookDeliveryRepo, notifier, logger,
+		time.Duration(cfg.WebhookDispatchIntervalSec)*time.Second,
+	)
+	go webhookDispatcher.Start(ctx)
 
 	// heartbeat fires every 10s — 30s timeout means 3 missed beats before a job is stale
 	reaper := scheduler.NewReaper(jobRepo, logger, 30*time.Second, 30*time.Second)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -106,6 +106,10 @@ func main() {
 	statsUsecase := usecase.NewStatsUsecase(statsRepo, creditRepo)
 	statsHandler := handler.NewStatsHandler(statsUsecase, logger)
 
+	// Webhook deliveries (read-only log; the scheduler produces the rows)
+	webhookDeliveryRepo := postgres.NewWebhookDeliveryRepository(pool)
+	webhookHandler := handler.NewWebhookHandler(webhookDeliveryRepo, logger)
+
 	metrics.Register()
 	checker := health.NewChecker(pool, logger, prometheus.DefaultRegisterer)
 
@@ -114,7 +118,7 @@ func main() {
 
 	srv := http.Server{
 		Addr:    ":" + cfg.Port,
-		Handler: httptransport.NewRouter(logger, jobHandler, scheduleHandler, tokenHandler, billingHandler, signingHandler, bufferHandler, alertHandler, statsHandler, userRepo, creditRepo, tokenRepo, cfg.ClerkJWKSURL, []byte(cfg.JWTSecret), cfg.CORSAllowedOrigins, rateLimiter),
+		Handler: httptransport.NewRouter(logger, jobHandler, scheduleHandler, tokenHandler, billingHandler, signingHandler, bufferHandler, alertHandler, statsHandler, webhookHandler, userRepo, creditRepo, tokenRepo, cfg.ClerkJWKSURL, []byte(cfg.JWTSecret), cfg.CORSAllowedOrigins, rateLimiter),
 	}
 
 	metricsSrv := metrics.NewServer(":"+cfg.MetricsPort, checker)

--- a/config/config.go
+++ b/config/config.go
@@ -12,12 +12,16 @@ type Config struct {
 	Env  string `env:"ENV" envDefault:"local" validate:"required,oneof=local staging production"`
 	Port string `env:"PORT" envDefault:"8080" validate:"required"`
 
-	DatabaseURL        string `env:"DATABASE_URL,required" validate:"required"`
-	WorkerCount        int    `env:"WORKER_COUNT" envDefault:"5" validate:"min=1,max=100"`
-	PollIntervalSec    int    `env:"POLL_INTERVAL_SEC" envDefault:"1" validate:"min=1,max=60"`
-	DispatchIntervalSec  int  `env:"DISPATCH_INTERVAL_SEC" envDefault:"5" validate:"min=1,max=60"`
-	DrainerConcurrency   int  `env:"DRAINER_CONCURRENCY" envDefault:"10" validate:"min=1,max=100"`
-	DrainerPollIntervalSec int `env:"DRAINER_POLL_INTERVAL_SEC" envDefault:"1" validate:"min=1,max=10"`
+	DatabaseURL            string `env:"DATABASE_URL,required" validate:"required"`
+	WorkerCount            int    `env:"WORKER_COUNT" envDefault:"5" validate:"min=1,max=100"`
+	PollIntervalSec        int    `env:"POLL_INTERVAL_SEC" envDefault:"1" validate:"min=1,max=60"`
+	DispatchIntervalSec    int    `env:"DISPATCH_INTERVAL_SEC" envDefault:"5" validate:"min=1,max=60"`
+	DrainerConcurrency     int    `env:"DRAINER_CONCURRENCY" envDefault:"10" validate:"min=1,max=100"`
+	DrainerPollIntervalSec int    `env:"DRAINER_POLL_INTERVAL_SEC" envDefault:"1" validate:"min=1,max=10"`
+	// Webhook delivery dispatcher: how often it drains due deliveries, and how many
+	// attempts each delivery gets before it is marked permanently failed.
+	WebhookDispatchIntervalSec int `env:"WEBHOOK_DISPATCH_INTERVAL_SEC" envDefault:"2" validate:"min=1,max=60"`
+	WebhookMaxAttempts         int `env:"WEBHOOK_MAX_ATTEMPTS" envDefault:"10" validate:"min=1,max=20"`
 	// Partition maintenance for job_attempts (range-partitioned by month).
 	PartitionMaintainIntervalSec int `env:"PARTITION_MAINTAIN_INTERVAL_SEC" envDefault:"21600" validate:"min=60"`
 	PartitionMonthsAhead         int `env:"PARTITION_MONTHS_AHEAD" envDefault:"3" validate:"min=1,max=24"`

--- a/internal/domain/webhook_delivery.go
+++ b/internal/domain/webhook_delivery.go
@@ -1,0 +1,56 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrWebhookDeliveryNotFound is returned when no delivery matches the lookup.
+var ErrWebhookDeliveryNotFound = errors.New("webhook delivery not found")
+
+// WebhookEvent identifies what happened to the resource that triggered a delivery.
+type WebhookEvent string
+
+const (
+	WebhookEventJobCompleted WebhookEvent = "job.completed"
+	WebhookEventJobFailed    WebhookEvent = "job.failed"
+)
+
+// WebhookDeliveryStatus is the delivery state machine:
+//
+//	pending    → queued, waiting for its next attempt (next_retry_at has passed)
+//	delivering → claimed by a dispatcher, an attempt is in flight
+//	delivered  → a 2xx was received (terminal)
+//	failed     → the attempt budget was exhausted without a 2xx (terminal)
+type WebhookDeliveryStatus string
+
+const (
+	WebhookDeliveryPending    WebhookDeliveryStatus = "pending"
+	WebhookDeliveryDelivering WebhookDeliveryStatus = "delivering"
+	WebhookDeliveryDelivered  WebhookDeliveryStatus = "delivered"
+	WebhookDeliveryFailed     WebhookDeliveryStatus = "failed"
+)
+
+// WebhookDelivery is one durable, at-least-once webhook delivery record. The
+// dispatcher owns the state transitions; see WebhookDeliveryRepository.
+type WebhookDelivery struct {
+	ID     string
+	UserID string
+	// JobID is the job whose terminal state triggered this delivery (nil if the
+	// event has no originating job).
+	JobID   *string
+	Event   WebhookEvent
+	URL     string
+	Headers map[string]string
+	// Payload is the exact JSON body that is signed and POSTed.
+	Payload     []byte
+	Status      WebhookDeliveryStatus
+	StatusCode  *int
+	Attempts    int
+	MaxAttempts int
+	NextRetryAt time.Time
+	LastError   *string
+	DeliveredAt *time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}

--- a/internal/http/handler/webhook.go
+++ b/internal/http/handler/webhook.go
@@ -1,0 +1,138 @@
+package handler
+
+import (
+	"encoding/base64"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
+	"github.com/gin-gonic/gin"
+)
+
+type WebhookHandler struct {
+	deliveries repository.WebhookDeliveryRepository
+	logger     *slog.Logger
+}
+
+func NewWebhookHandler(deliveries repository.WebhookDeliveryRepository, logger *slog.Logger) *WebhookHandler {
+	return &WebhookHandler{deliveries: deliveries, logger: logger.With("component", "webhook_handler")}
+}
+
+const (
+	defaultDeliveryPageSize = 25
+	maxDeliveryPageSize     = 100
+)
+
+type webhookDeliveryResponse struct {
+	ID          string     `json:"id"`
+	JobID       *string    `json:"job_id,omitempty"`
+	Event       string     `json:"event"`
+	URL         string     `json:"url"`
+	Status      string     `json:"status"`
+	StatusCode  *int       `json:"status_code,omitempty"`
+	Attempts    int        `json:"attempts"`
+	MaxAttempts int        `json:"max_attempts"`
+	LastError   *string    `json:"last_error,omitempty"`
+	NextRetryAt *time.Time `json:"next_retry_at,omitempty"`
+	DeliveredAt *time.Time `json:"delivered_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+}
+
+// ListDeliveries returns the authenticated user's recent webhook deliveries,
+// newest first, keyset-paginated on (created_at, id). Response shape mirrors the
+// other list endpoints: {"deliveries": [...], "next_cursor": "..."|null}.
+func (h *WebhookHandler) ListDeliveries(ctx *gin.Context) {
+	userID := ctx.GetString("userID")
+
+	limit := defaultDeliveryPageSize
+	if raw := ctx.Query("limit"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > maxDeliveryPageSize {
+		limit = maxDeliveryPageSize
+	}
+
+	var cursorTime *time.Time
+	var cursorID string
+	if raw := ctx.Query("cursor"); raw != "" {
+		t, id, ok := decodeDeliveryCursor(raw)
+		if !ok {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid cursor"})
+			return
+		}
+		cursorTime, cursorID = &t, id
+	}
+
+	// Fetch one extra row to detect whether a further page exists.
+	rows, err := h.deliveries.ListByUser(ctx.Request.Context(), userID, limit+1, cursorTime, cursorID)
+	if err != nil {
+		h.logger.ErrorContext(ctx.Request.Context(), "list webhook deliveries", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errInternalServer})
+		return
+	}
+
+	var nextCursor *string
+	if len(rows) > limit {
+		last := rows[limit-1]
+		c := encodeDeliveryCursor(last.CreatedAt, last.ID)
+		nextCursor = &c
+		rows = rows[:limit]
+	}
+
+	out := make([]webhookDeliveryResponse, 0, len(rows))
+	for _, d := range rows {
+		out = append(out, toDeliveryResponse(d))
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"deliveries": out, "next_cursor": nextCursor})
+}
+
+func toDeliveryResponse(d *domain.WebhookDelivery) webhookDeliveryResponse {
+	resp := webhookDeliveryResponse{
+		ID:          d.ID,
+		JobID:       d.JobID,
+		Event:       string(d.Event),
+		URL:         d.URL,
+		Status:      string(d.Status),
+		StatusCode:  d.StatusCode,
+		Attempts:    d.Attempts,
+		MaxAttempts: d.MaxAttempts,
+		LastError:   d.LastError,
+		DeliveredAt: d.DeliveredAt,
+		CreatedAt:   d.CreatedAt,
+	}
+	// next_retry_at is only meaningful while the delivery is still being retried.
+	if d.Status == domain.WebhookDeliveryPending || d.Status == domain.WebhookDeliveryDelivering {
+		nr := d.NextRetryAt
+		resp.NextRetryAt = &nr
+	}
+	return resp
+}
+
+// Cursor is an opaque base64 of "<unixNano>|<id>".
+func encodeDeliveryCursor(t time.Time, id string) string {
+	raw := strconv.FormatInt(t.UnixNano(), 10) + "|" + id
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+func decodeDeliveryCursor(s string) (time.Time, string, bool) {
+	raw, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return time.Time{}, "", false
+	}
+	parts := strings.SplitN(string(raw), "|", 2)
+	if len(parts) != 2 {
+		return time.Time{}, "", false
+	}
+	nanos, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return time.Time{}, "", false
+	}
+	return time.Unix(0, nanos).UTC(), parts[1], true
+}

--- a/internal/http/handler/webhook_test.go
+++ b/internal/http/handler/webhook_test.go
@@ -1,0 +1,122 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/http/handler"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+	"github.com/gin-gonic/gin"
+)
+
+func setupWebhookRouter(repo *testutil.MockWebhookDeliveryRepository) *gin.Engine {
+	h := handler.NewWebhookHandler(repo, slog.Default())
+	r := gin.New()
+	g := r.Group("/", injectUser(testUserID))
+	g.GET("/webhooks/deliveries", h.ListDeliveries)
+	return r
+}
+
+func TestListDeliveries_HappyPath(t *testing.T) {
+	code := 200
+	repo := &testutil.MockWebhookDeliveryRepository{
+		ListByUserFn: func(_ context.Context, userID string, limit int, _ *time.Time, _ string) ([]*domain.WebhookDelivery, error) {
+			if userID != testUserID {
+				t.Errorf("userID = %q, want %q", userID, testUserID)
+			}
+			// Default page size is 25 → handler asks for 26 (limit+1).
+			if limit != 26 {
+				t.Errorf("limit passed to repo = %d, want 26", limit)
+			}
+			jobID := "job-1"
+			return []*domain.WebhookDelivery{
+				{ID: "d1", UserID: userID, JobID: &jobID, Event: domain.WebhookEventJobCompleted,
+					URL: "https://x/hook", Status: domain.WebhookDeliveryDelivered, StatusCode: &code,
+					Attempts: 1, MaxAttempts: 10, CreatedAt: time.Now()},
+			}, nil
+		},
+	}
+	r := setupWebhookRouter(repo)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/webhooks/deliveries", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Deliveries []map[string]any `json:"deliveries"`
+		NextCursor *string          `json:"next_cursor"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body = %s", err, w.Body.String())
+	}
+	if len(resp.Deliveries) != 1 {
+		t.Fatalf("deliveries = %d, want 1", len(resp.Deliveries))
+	}
+	if resp.NextCursor != nil {
+		t.Errorf("next_cursor = %v, want null (only one page)", *resp.NextCursor)
+	}
+	if resp.Deliveries[0]["status"] != "delivered" || resp.Deliveries[0]["event"] != "job.completed" {
+		t.Errorf("delivery fields wrong: %+v", resp.Deliveries[0])
+	}
+}
+
+func TestListDeliveries_PaginationEmitsCursor(t *testing.T) {
+	repo := &testutil.MockWebhookDeliveryRepository{
+		ListByUserFn: func(_ context.Context, userID string, limit int, _ *time.Time, _ string) ([]*domain.WebhookDelivery, error) {
+			if limit != 3 {
+				t.Errorf("limit passed to repo = %d, want 3 (page size 2 + 1)", limit)
+			}
+			// Return limit rows to signal there IS another page.
+			base := time.Now()
+			return []*domain.WebhookDelivery{
+				{ID: "d1", UserID: userID, CreatedAt: base},
+				{ID: "d2", UserID: userID, CreatedAt: base.Add(-time.Second)},
+				{ID: "d3", UserID: userID, CreatedAt: base.Add(-2 * time.Second)},
+			}, nil
+		},
+	}
+	r := setupWebhookRouter(repo)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/webhooks/deliveries?limit=2", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp struct {
+		Deliveries []map[string]any `json:"deliveries"`
+		NextCursor *string          `json:"next_cursor"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Deliveries) != 2 {
+		t.Fatalf("deliveries = %d, want 2 (extra row trimmed)", len(resp.Deliveries))
+	}
+	if resp.NextCursor == nil || *resp.NextCursor == "" {
+		t.Fatal("next_cursor missing despite a further page")
+	}
+}
+
+func TestListDeliveries_InvalidCursor(t *testing.T) {
+	repo := &testutil.MockWebhookDeliveryRepository{
+		ListByUserFn: func(_ context.Context, _ string, _ int, _ *time.Time, _ string) ([]*domain.WebhookDelivery, error) {
+			t.Fatal("repo queried despite invalid cursor")
+			return nil, nil
+		},
+	}
+	r := setupWebhookRouter(repo)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/webhooks/deliveries?cursor=not-a-valid-cursor!!", nil))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -11,7 +11,7 @@ import (
 	sloggin "github.com/samber/slog-gin"
 )
 
-func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHandler *handler.ScheduleHandler, tokenHandler *handler.TokenHandler, billingHandler *handler.BillingHandler, signingHandler *handler.SigningHandler, bufferHandler *handler.BufferHandler, alertHandler *handler.AlertHandler, statsHandler *handler.StatsHandler, userRepo repository.UserRepository, creditRepo repository.CreditRepository, tokenRepo repository.APITokenRepository, jwksURL string, hmacKey []byte, corsAllowedOrigins string, rateLimiter *middleware.RateLimiter) *gin.Engine {
+func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHandler *handler.ScheduleHandler, tokenHandler *handler.TokenHandler, billingHandler *handler.BillingHandler, signingHandler *handler.SigningHandler, bufferHandler *handler.BufferHandler, alertHandler *handler.AlertHandler, statsHandler *handler.StatsHandler, webhookHandler *handler.WebhookHandler, userRepo repository.UserRepository, creditRepo repository.CreditRepository, tokenRepo repository.APITokenRepository, jwksURL string, hmacKey []byte, corsAllowedOrigins string, rateLimiter *middleware.RateLimiter) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
 	r.Use(middleware.RequestID())
@@ -90,6 +90,10 @@ func NewRouter(logger *slog.Logger, jobHandler *handler.JobHandler, scheduleHand
 	signing := r.Group("/signing-secret", authMW, ensureUser, rateLimiter.Middleware())
 	signing.GET("", signingHandler.Get)
 	signing.POST("/rotate", signingHandler.Rotate)
+
+	// Protected webhook delivery log (read-only; the scheduler produces the rows)
+	webhooks := r.Group("/webhooks", authMW, ensureUser, rateLimiter.Middleware())
+	webhooks.GET("/deliveries", webhookHandler.ListDeliveries)
 
 	// Webhook has no auth middleware — verified by Stripe signature
 	r.POST("/billing/webhook", billingHandler.HandleWebhook)

--- a/internal/http/router_test.go
+++ b/internal/http/router_test.go
@@ -23,7 +23,7 @@ func buildRouter(t *testing.T) *gin.Engine {
 	t.Cleanup(rl.Stop)
 	return httptransport.NewRouter(
 		slog.Default(),
-		nil, nil, nil, nil, nil, nil, nil, nil, // handlers
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, // handlers
 		nil, nil, nil, // userRepo, creditRepo, tokenRepo
 		"", []byte("test-key"), "", rl,
 	)
@@ -65,6 +65,7 @@ func TestRouter_NewRoutesRequireAuth(t *testing.T) {
 		{http.MethodGet, "/alerts"},
 		{http.MethodPatch, "/alerts/abc"},
 		{http.MethodDelete, "/alerts/abc"},
+		{http.MethodGet, "/webhooks/deliveries"},
 	}
 	for _, c := range cases {
 		w := httptest.NewRecorder()

--- a/internal/infrastructure/postgres/webhook_delivery.go
+++ b/internal/infrastructure/postgres/webhook_delivery.go
@@ -1,0 +1,172 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type WebhookDeliveryRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewWebhookDeliveryRepository(pool *pgxpool.Pool) *WebhookDeliveryRepository {
+	return &WebhookDeliveryRepository{pool: pool}
+}
+
+// deliveryColumns is the canonical column list, shared by every SELECT/RETURNING
+// so scanWebhookDelivery always sees the same order.
+const deliveryColumns = `id, user_id, job_id, event, url, headers, payload,
+	status, status_code, attempts, max_attempts, next_retry_at, last_error,
+	delivered_at, created_at, updated_at`
+
+func (r *WebhookDeliveryRepository) Enqueue(ctx context.Context, d *domain.WebhookDelivery) (*domain.WebhookDelivery, error) {
+	headers := d.Headers
+	if headers == nil {
+		headers = map[string]string{}
+	}
+	maxAttempts := d.MaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = 10
+	}
+
+	query := `
+		INSERT INTO webhook_deliveries (user_id, job_id, event, url, headers, payload, max_attempts)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING ` + deliveryColumns
+
+	row := r.pool.QueryRow(ctx, query,
+		d.UserID, d.JobID, string(d.Event), d.URL, headers, string(d.Payload), maxAttempts)
+	return scanWebhookDelivery(row)
+}
+
+// ClaimDue moves up to `limit` ready deliveries into 'delivering' and returns them.
+// FOR UPDATE SKIP LOCKED makes concurrent dispatchers safe; the OR clause reclaims
+// in-flight rows abandoned by a crashed dispatcher so delivery stays at-least-once.
+func (r *WebhookDeliveryRepository) ClaimDue(ctx context.Context, limit int, inflightTimeout time.Duration) ([]*domain.WebhookDelivery, error) {
+	query := `
+		UPDATE webhook_deliveries
+		SET status = 'delivering', updated_at = NOW()
+		WHERE id IN (
+			SELECT id FROM webhook_deliveries
+			WHERE (status = 'pending' AND next_retry_at <= NOW())
+			   OR (status = 'delivering' AND updated_at < NOW() - make_interval(secs => $2))
+			ORDER BY next_retry_at
+			LIMIT $1
+			FOR UPDATE SKIP LOCKED
+		)
+		RETURNING ` + deliveryColumns
+
+	rows, err := r.pool.Query(ctx, query, limit, inflightTimeout.Seconds())
+	if err != nil {
+		return nil, fmt.Errorf("claim due webhook deliveries: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*domain.WebhookDelivery
+	for rows.Next() {
+		d, err := scanWebhookDelivery(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate claimed deliveries: %w", err)
+	}
+	return out, nil
+}
+
+func (r *WebhookDeliveryRepository) MarkDelivered(ctx context.Context, id string, statusCode int) error {
+	_, err := r.pool.Exec(ctx, `
+		UPDATE webhook_deliveries
+		SET status = 'delivered', status_code = $2, attempts = attempts + 1,
+		    delivered_at = NOW(), last_error = NULL, updated_at = NOW()
+		WHERE id = $1`, id, statusCode)
+	if err != nil {
+		return fmt.Errorf("mark delivery delivered: %w", err)
+	}
+	return nil
+}
+
+func (r *WebhookDeliveryRepository) Reschedule(ctx context.Context, id string, statusCode *int, lastErr string, nextRetryAt time.Time) error {
+	_, err := r.pool.Exec(ctx, `
+		UPDATE webhook_deliveries
+		SET status = 'pending', status_code = $2, attempts = attempts + 1,
+		    last_error = $3, next_retry_at = $4, updated_at = NOW()
+		WHERE id = $1`, id, statusCode, lastErr, nextRetryAt)
+	if err != nil {
+		return fmt.Errorf("reschedule delivery: %w", err)
+	}
+	return nil
+}
+
+func (r *WebhookDeliveryRepository) MarkFailed(ctx context.Context, id string, statusCode *int, lastErr string) error {
+	_, err := r.pool.Exec(ctx, `
+		UPDATE webhook_deliveries
+		SET status = 'failed', status_code = $2, attempts = attempts + 1,
+		    last_error = $3, updated_at = NOW()
+		WHERE id = $1`, id, statusCode, lastErr)
+	if err != nil {
+		return fmt.Errorf("mark delivery failed: %w", err)
+	}
+	return nil
+}
+
+func (r *WebhookDeliveryRepository) ListByUser(ctx context.Context, userID string, limit int, cursorTime *time.Time, cursorID string) ([]*domain.WebhookDelivery, error) {
+	args := []any{userID}
+	where := "user_id = $1"
+	if cursorTime != nil {
+		args = append(args, *cursorTime, cursorID)
+		where += fmt.Sprintf(" AND (created_at, id) < ($%d, $%d)", len(args)-1, len(args))
+	}
+	args = append(args, limit)
+
+	query := fmt.Sprintf(`
+		SELECT %s FROM webhook_deliveries
+		WHERE %s
+		ORDER BY created_at DESC, id DESC
+		LIMIT $%d`, deliveryColumns, where, len(args))
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list webhook deliveries: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*domain.WebhookDelivery
+	for rows.Next() {
+		d, err := scanWebhookDelivery(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate webhook deliveries: %w", err)
+	}
+	return out, nil
+}
+
+func scanWebhookDelivery(row rowScanner) (*domain.WebhookDelivery, error) {
+	var d domain.WebhookDelivery
+	var payload string
+	err := row.Scan(
+		&d.ID, &d.UserID, &d.JobID, &d.Event, &d.URL, &d.Headers, &payload,
+		&d.Status, &d.StatusCode, &d.Attempts, &d.MaxAttempts, &d.NextRetryAt,
+		&d.LastError, &d.DeliveredAt, &d.CreatedAt, &d.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrWebhookDeliveryNotFound
+		}
+		return nil, fmt.Errorf("scan webhook delivery: %w", err)
+	}
+	d.Payload = []byte(payload)
+	return &d, nil
+}

--- a/internal/infrastructure/postgres/webhook_delivery_repo_integration_test.go
+++ b/internal/infrastructure/postgres/webhook_delivery_repo_integration_test.go
@@ -1,0 +1,199 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+)
+
+func newDeliveryRepo(t *testing.T) (*postgres.WebhookDeliveryRepository, string, context.Context) {
+	t.Helper()
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	return postgres.NewWebhookDeliveryRepository(pool), userID, context.Background()
+}
+
+func enqueueTestDelivery(t *testing.T, repo *postgres.WebhookDeliveryRepository, ctx context.Context, userID string) *domain.WebhookDelivery {
+	t.Helper()
+	jobID := "job-abc"
+	d, err := repo.Enqueue(ctx, &domain.WebhookDelivery{
+		UserID:      userID,
+		JobID:       &jobID,
+		Event:       domain.WebhookEventJobCompleted,
+		URL:         "https://example.com/hook",
+		Headers:     map[string]string{"X-Test": "1"},
+		Payload:     []byte(`{"event":"job.completed","job_id":"job-abc"}`),
+		MaxAttempts: 3,
+	})
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	return d
+}
+
+// Enqueue → ClaimDue → MarkDelivered is the happy-path lifecycle, and the payload
+// bytes survive the round-trip verbatim.
+func TestWebhookDeliveryRepo_Lifecycle_Delivered(t *testing.T) {
+	repo, userID, ctx := newDeliveryRepo(t)
+	d := enqueueTestDelivery(t, repo, ctx, userID)
+
+	if d.Status != domain.WebhookDeliveryPending || d.Attempts != 0 || d.MaxAttempts != 3 {
+		t.Fatalf("enqueued row = status:%s attempts:%d max:%d, want pending/0/3", d.Status, d.Attempts, d.MaxAttempts)
+	}
+	if string(d.Payload) != `{"event":"job.completed","job_id":"job-abc"}` {
+		t.Fatalf("payload round-trip mismatch: %q", d.Payload)
+	}
+
+	// A freshly-enqueued row is due immediately.
+	claimed, err := repo.ClaimDue(ctx, 10, 60*time.Second)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if len(claimed) != 1 || claimed[0].ID != d.ID {
+		t.Fatalf("claimed %d rows, want the enqueued one", len(claimed))
+	}
+	if claimed[0].Status != domain.WebhookDeliveryDelivering {
+		t.Errorf("claimed status = %s, want delivering", claimed[0].Status)
+	}
+	if string(claimed[0].Payload) != string(d.Payload) {
+		t.Errorf("claimed payload mismatch: %q", claimed[0].Payload)
+	}
+	if claimed[0].Headers["X-Test"] != "1" {
+		t.Errorf("headers not round-tripped: %+v", claimed[0].Headers)
+	}
+
+	// A second immediate claim returns nothing — the row is in-flight, not stale.
+	again, err := repo.ClaimDue(ctx, 10, 60*time.Second)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if len(again) != 0 {
+		t.Fatalf("second claim returned %d rows, want 0 (already in-flight)", len(again))
+	}
+
+	if err := repo.MarkDelivered(ctx, d.ID, 200); err != nil {
+		t.Fatalf("mark delivered: %v", err)
+	}
+
+	rows, err := repo.ListByUser(ctx, userID, 10, nil, "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("list returned %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.Status != domain.WebhookDeliveryDelivered {
+		t.Errorf("status = %s, want delivered", got.Status)
+	}
+	if got.Attempts != 1 {
+		t.Errorf("attempts = %d, want 1", got.Attempts)
+	}
+	if got.StatusCode == nil || *got.StatusCode != 200 {
+		t.Errorf("status_code = %v, want 200", got.StatusCode)
+	}
+	if got.DeliveredAt == nil {
+		t.Error("delivered_at not set")
+	}
+}
+
+// Reschedule bumps attempts and defers the row past its next_retry_at, so it is
+// not immediately re-claimable; MarkFailed after that is terminal.
+func TestWebhookDeliveryRepo_RescheduleThenFail(t *testing.T) {
+	repo, userID, ctx := newDeliveryRepo(t)
+	d := enqueueTestDelivery(t, repo, ctx, userID)
+
+	if _, err := repo.ClaimDue(ctx, 10, 60*time.Second); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	code := 500
+	if err := repo.Reschedule(ctx, d.ID, &code, "non-2xx response: 500", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("reschedule: %v", err)
+	}
+
+	// Deferred an hour out → not due.
+	due, err := repo.ClaimDue(ctx, 10, 60*time.Second)
+	if err != nil {
+		t.Fatalf("claim after reschedule: %v", err)
+	}
+	if len(due) != 0 {
+		t.Fatalf("claimed %d rows, want 0 (retry is in the future)", len(due))
+	}
+
+	rows, _ := repo.ListByUser(ctx, userID, 10, nil, "")
+	if rows[0].Status != domain.WebhookDeliveryPending || rows[0].Attempts != 1 {
+		t.Fatalf("after reschedule: status:%s attempts:%d, want pending/1", rows[0].Status, rows[0].Attempts)
+	}
+
+	if err := repo.MarkFailed(ctx, d.ID, &code, "gave up"); err != nil {
+		t.Fatalf("mark failed: %v", err)
+	}
+	rows, _ = repo.ListByUser(ctx, userID, 10, nil, "")
+	if rows[0].Status != domain.WebhookDeliveryFailed || rows[0].Attempts != 2 {
+		t.Fatalf("after fail: status:%s attempts:%d, want failed/2", rows[0].Status, rows[0].Attempts)
+	}
+}
+
+// A row stuck in 'delivering' past the in-flight timeout (dispatcher crashed) is
+// reclaimed — the guarantee that keeps delivery at-least-once.
+func TestWebhookDeliveryRepo_ReclaimsStaleInflight(t *testing.T) {
+	repo, userID, ctx := newDeliveryRepo(t)
+	d := enqueueTestDelivery(t, repo, ctx, userID)
+
+	// Claim moves it to 'delivering'.
+	if _, err := repo.ClaimDue(ctx, 10, 60*time.Second); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	// A negative timeout makes every in-flight row already stale → reclaimed.
+	reclaimed, err := repo.ClaimDue(ctx, 10, -time.Second)
+	if err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+	if len(reclaimed) != 1 || reclaimed[0].ID != d.ID {
+		t.Fatalf("reclaimed %d rows, want the stale one", len(reclaimed))
+	}
+}
+
+// Keyset pagination returns newest-first and never drops or repeats a row.
+func TestWebhookDeliveryRepo_KeysetPagination(t *testing.T) {
+	repo, userID, ctx := newDeliveryRepo(t)
+	const total = 5
+	for range [total]int{} {
+		enqueueTestDelivery(t, repo, ctx, userID)
+	}
+
+	page1, err := repo.ListByUser(ctx, userID, 2, nil, "")
+	if err != nil {
+		t.Fatalf("page1: %v", err)
+	}
+	if len(page1) != 2 {
+		t.Fatalf("page1 = %d, want 2", len(page1))
+	}
+	last := page1[len(page1)-1]
+	page2, err := repo.ListByUser(ctx, userID, 2, &last.CreatedAt, last.ID)
+	if err != nil {
+		t.Fatalf("page2: %v", err)
+	}
+	if len(page2) != 2 {
+		t.Fatalf("page2 = %d, want 2", len(page2))
+	}
+
+	seen := map[string]bool{}
+	for _, d := range append(page1, page2...) {
+		if seen[d.ID] {
+			t.Fatalf("duplicate row across pages: %s", d.ID)
+		}
+		seen[d.ID] = true
+	}
+	if len(seen) != 4 {
+		t.Fatalf("distinct rows across 2 pages = %d, want 4", len(seen))
+	}
+}

--- a/internal/repository/webhook_delivery.go
+++ b/internal/repository/webhook_delivery.go
@@ -1,0 +1,35 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+)
+
+// WebhookDeliveryRepository persists the durable webhook delivery log and drives
+// the at-least-once retry state machine.
+type WebhookDeliveryRepository interface {
+	// Enqueue inserts a new pending delivery, due immediately.
+	Enqueue(ctx context.Context, d *domain.WebhookDelivery) (*domain.WebhookDelivery, error)
+
+	// ClaimDue atomically claims up to limit deliveries that are ready to attempt —
+	// pending rows whose next_retry_at has passed, plus in-flight ('delivering') rows
+	// abandoned by a crashed dispatcher (not updated within inflightTimeout). Claimed
+	// rows move to 'delivering' so a concurrent dispatcher won't pick them up.
+	ClaimDue(ctx context.Context, limit int, inflightTimeout time.Duration) ([]*domain.WebhookDelivery, error)
+
+	// MarkDelivered records a terminal success (2xx received).
+	MarkDelivered(ctx context.Context, id string, statusCode int) error
+
+	// Reschedule records a failed attempt and re-queues the delivery for a later
+	// retry at nextRetryAt. statusCode is nil when the request never completed.
+	Reschedule(ctx context.Context, id string, statusCode *int, lastErr string, nextRetryAt time.Time) error
+
+	// MarkFailed records a terminal failure (attempt budget exhausted).
+	MarkFailed(ctx context.Context, id string, statusCode *int, lastErr string) error
+
+	// ListByUser returns the user's deliveries newest-first, keyset-paginated on
+	// (created_at, id). Pass a nil cursor for the first page.
+	ListByUser(ctx context.Context, userID string, limit int, cursorTime *time.Time, cursorID string) ([]*domain.WebhookDelivery, error)
+}

--- a/internal/scheduler/webhook.go
+++ b/internal/scheduler/webhook.go
@@ -19,6 +19,7 @@ import (
 
 // WebhookPayload is the JSON body POSTed to the user's webhook endpoint.
 type WebhookPayload struct {
+	Event       string  `json:"event,omitempty"`
 	JobID       string  `json:"job_id"`
 	Status      string  `json:"status"`
 	StatusCode  *int    `json:"status_code,omitempty"`
@@ -27,30 +28,85 @@ type WebhookPayload struct {
 	AttemptNum  int     `json:"attempt_num"`
 }
 
-// WebhookNotifier delivers fire-and-forget webhook notifications for terminal job states.
+// WebhookNotifier signs and POSTs webhook notifications. Its low-level Deliver is
+// the single delivery primitive used by both the durable job webhook dispatcher
+// (see WebhookDispatcher) and the buffer drainer's best-effort Notify.
 type WebhookNotifier struct {
 	client         *http.Client
 	logger         *slog.Logger
 	signingSecrets repository.SigningSecretRepository
 }
 
-// NewWebhookNotifier creates a notifier with a dedicated HTTP client (10s timeout).
+// NewWebhookNotifier creates a notifier with a dedicated HTTP client (10s timeout)
+// whose dialer refuses private/loopback addresses (SSRF-safe).
 func NewWebhookNotifier(logger *slog.Logger, signingSecrets repository.SigningSecretRepository) *WebhookNotifier {
-	return &WebhookNotifier{
-		client: &http.Client{
-			Timeout: 10 * time.Second,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
-				DialContext:     safedialer.NewSafeDialContext(5*time.Second, 30*time.Second),
-			},
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+			DialContext:     safedialer.NewSafeDialContext(5*time.Second, 30*time.Second),
 		},
+	}
+	return newWebhookNotifier(logger, signingSecrets, client)
+}
+
+// newWebhookNotifier is the shared constructor; tests inject a client whose
+// transport permits loopback so httptest servers are reachable.
+func newWebhookNotifier(logger *slog.Logger, signingSecrets repository.SigningSecretRepository, client *http.Client) *WebhookNotifier {
+	return &WebhookNotifier{
+		client:         client,
 		logger:         logger.With("component", "webhook_notifier"),
 		signingSecrets: signingSecrets,
 	}
 }
 
-// Notify sends a webhook POST if the job has a webhook URL configured.
-// Errors are logged but never returned — webhook delivery is best-effort.
+// Deliver signs (if the user has an active signing secret) and POSTs body to url
+// on behalf of userID, returning the HTTP status code (0 if the request never
+// completed) and a transport error if any. It records the duration metric but
+// does not log, retry, or interpret the status code — the caller owns the
+// outcome. This is the shared delivery primitive; callers add retry/logging.
+func (n *WebhookNotifier) Deliver(ctx context.Context, userID, url string, headers map[string]string, body []byte) (int, error) {
+	start := time.Now()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Apply user-defined webhook headers.
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	// Sign the request if the user has an active signing secret.
+	secret, secretErr := n.signingSecrets.GetActive(ctx, userID)
+	if secretErr != nil && !errors.Is(secretErr, domain.ErrSigningSecretNotFound) {
+		n.logger.WarnContext(ctx, "fetch signing secret for webhook failed, proceeding unsigned",
+			"user_id", userID, "error", secretErr)
+	} else if secretErr == nil {
+		ts, sig := signRequest(secret.Secret, http.MethodPost, url, body, time.Now())
+		req.Header.Set("X-Fliq-Timestamp", ts)
+		req.Header.Set("X-Fliq-Signature", sig)
+	}
+
+	resp, err := n.client.Do(req)
+	metrics.WebhookDuration.Observe(time.Since(start).Seconds())
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	return resp.StatusCode, nil
+}
+
+// Notify sends a best-effort, fire-once webhook POST for a terminal resource
+// state. Errors are logged but never returned and never retried — used by the
+// buffer drainer, whose items don't (yet) have the durable delivery log that jobs
+// get via WebhookDispatcher.
 func (n *WebhookNotifier) Notify(ctx context.Context, job *domain.Job, statusCode *int) {
 	if job.WebhookURL == nil {
 		return
@@ -76,82 +132,35 @@ func (n *WebhookNotifier) Notify(ctx context.Context, job *domain.Job, statusCod
 		return
 	}
 
-	start := time.Now()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, *job.WebhookURL, bytes.NewReader(body))
-	if err != nil {
-		n.logger.ErrorContext(ctx, "build webhook request", "job_id", job.ID, "error", err)
-		metrics.WebhookDeliveriesTotal.WithLabelValues("failure").Inc()
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	// Apply user-defined webhook headers.
-	for k, v := range job.WebhookHeaders {
-		req.Header.Set(k, v)
-	}
-
-	// Sign the webhook request if the user has a signing secret.
-	secret, secretErr := n.signingSecrets.GetActive(ctx, job.UserID)
-	if secretErr != nil && !errors.Is(secretErr, domain.ErrSigningSecretNotFound) {
-		n.logger.WarnContext(ctx, "fetch signing secret for webhook failed, proceeding unsigned",
-			"job_id", job.ID, "error", secretErr)
-	} else if secretErr == nil {
-		ts, sig := signRequest(secret.Secret, http.MethodPost, *job.WebhookURL, body, time.Now())
-		req.Header.Set("X-Fliq-Timestamp", ts)
-		req.Header.Set("X-Fliq-Signature", sig)
-	}
-
-	resp, err := n.client.Do(req)
-	duration := time.Since(start)
-	metrics.WebhookDuration.Observe(duration.Seconds())
-
+	code, err := n.Deliver(ctx, job.UserID, *job.WebhookURL, job.WebhookHeaders, body)
 	if err != nil {
 		metrics.WebhookDeliveriesTotal.WithLabelValues("failure").Inc()
 		n.logger.WarnContext(ctx, "webhook delivery failed",
-			"job_id", job.ID,
-			"webhook_url", *job.WebhookURL,
-			"error", err,
-			"duration", duration,
-		)
+			"job_id", job.ID, "webhook_url", *job.WebhookURL, "error", err)
 		return
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}()
 
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+	if code >= 200 && code < 300 {
 		metrics.WebhookDeliveriesTotal.WithLabelValues("success").Inc()
 		n.logger.InfoContext(ctx, "webhook delivered",
-			"job_id", job.ID,
-			"webhook_url", *job.WebhookURL,
-			"status_code", resp.StatusCode,
-			"duration", duration,
-		)
+			"job_id", job.ID, "webhook_url", *job.WebhookURL, "status_code", code)
 	} else {
 		metrics.WebhookDeliveriesTotal.WithLabelValues("failure").Inc()
 		n.logger.WarnContext(ctx, "webhook delivery non-2xx",
-			"job_id", job.ID,
-			"webhook_url", *job.WebhookURL,
-			"status_code", resp.StatusCode,
-			"duration", duration,
-		)
+			"job_id", job.ID, "webhook_url", *job.WebhookURL, "status_code", code)
 	}
 }
 
-// notifyAsync fires the webhook in a background goroutine so it never blocks the worker.
+// notifyAsync fires the webhook in a background goroutine so it never blocks the
+// caller. Used by the buffer drainer.
 func (n *WebhookNotifier) notifyAsync(ctx context.Context, job *domain.Job, statusCode *int) {
 	if job.WebhookURL == nil {
 		return
 	}
-	// Detach from parent context deadline but keep cancellation for shutdown.
+	// Detach from the parent deadline but keep cancellation for shutdown.
 	go func() {
 		notifyCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
-
-		// Update job status field so the payload reflects the terminal state.
 		n.Notify(notifyCtx, job, statusCode)
 	}()
 }
-

--- a/internal/scheduler/webhook_deliver_test.go
+++ b/internal/scheduler/webhook_deliver_test.go
@@ -1,0 +1,154 @@
+package scheduler
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+)
+
+// computeExpectedSig independently reproduces the signer.go formula so the test
+// verifies the delivered signature exactly as a customer's SDK would.
+func computeExpectedSig(secret, ts, method, url string, body []byte) string {
+	bodyStr := ""
+	if len(body) > 0 {
+		bodyStr = string(body)
+	}
+	payload := fmt.Sprintf("%s.%s.%s.%s", ts, method, url, bodyStr)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	return "v1=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// Deliver POSTs the body, applies user headers, and — when the user has a signing
+// secret — attaches a valid X-Fliq-Signature that verifies against signRequest.
+func TestWebhookNotifier_Deliver_SignsAndPosts(t *testing.T) {
+	const secret = "whsec_test-secret-for-delivery"
+	var (
+		gotSig  string
+		gotTS   string
+		gotHdr  string
+		gotBody []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSig = r.Header.Get("X-Fliq-Signature")
+		gotTS = r.Header.Get("X-Fliq-Timestamp")
+		gotHdr = r.Header.Get("X-Custom")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	signing := &testutil.MockSigningSecretRepository{
+		GetActiveFn: func(_ context.Context, userID string) (*domain.SigningSecret, error) {
+			return &domain.SigningSecret{UserID: userID, Secret: secret, IsActive: true}, nil
+		},
+	}
+	n := newWebhookNotifier(slog.Default(), signing, srv.Client())
+
+	body := []byte(`{"event":"job.completed","job_id":"job-1"}`)
+	code, err := n.Deliver(context.Background(), "user-1", srv.URL, map[string]string{"X-Custom": "abc"}, body)
+	if err != nil {
+		t.Fatalf("Deliver error: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Fatalf("Deliver code = %d, want 200", code)
+	}
+	if string(gotBody) != string(body) {
+		t.Fatalf("delivered body = %q, want %q", gotBody, body)
+	}
+	if gotHdr != "abc" {
+		t.Errorf("custom header not forwarded, got %q", gotHdr)
+	}
+	if gotSig == "" || gotTS == "" {
+		t.Fatal("missing signature/timestamp headers on signed delivery")
+	}
+	// The signature must verify against the exact timestamp + bytes delivered.
+	if wantSig := computeExpectedSig(secret, gotTS, http.MethodPost, srv.URL, gotBody); wantSig != gotSig {
+		t.Errorf("signature = %q, want %q", gotSig, wantSig)
+	}
+}
+
+// Deliver still succeeds (unsigned) when the user has no signing secret.
+func TestWebhookNotifier_Deliver_UnsignedWhenNoSecret(t *testing.T) {
+	var hadSig bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hadSig = r.Header.Get("X-Fliq-Signature") != ""
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	n := newWebhookNotifier(slog.Default(), &testutil.MockSigningSecretRepository{}, srv.Client()) // default: ErrSigningSecretNotFound
+	code, err := n.Deliver(context.Background(), "user-1", srv.URL, nil, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Deliver error: %v", err)
+	}
+	if code != http.StatusNoContent {
+		t.Fatalf("code = %d, want 204", code)
+	}
+	if hadSig {
+		t.Error("unsigned delivery should not carry X-Fliq-Signature")
+	}
+}
+
+// enqueueWebhook writes exactly one durable delivery row with the right shape when
+// the job carries a webhook URL, and writes nothing when it doesn't.
+func TestWorker_EnqueueWebhook(t *testing.T) {
+	var captured *domain.WebhookDelivery
+	repo := &testutil.MockWebhookDeliveryRepository{
+		EnqueueFn: func(_ context.Context, d *domain.WebhookDelivery) (*domain.WebhookDelivery, error) {
+			captured = d
+			return d, nil
+		},
+	}
+	w := &Worker{deliveries: repo, webhookMaxAttempts: 7, logger: slog.Default()}
+
+	url := "https://example.com/hook"
+	job := &domain.Job{
+		ID:             "job-42",
+		UserID:         "user-9",
+		Status:         domain.StatusCompleted,
+		RetryCount:     2,
+		WebhookURL:     &url,
+		WebhookHeaders: map[string]string{"X-A": "b"},
+	}
+	code := 200
+	w.enqueueWebhook(context.Background(), job, domain.WebhookEventJobCompleted, &code)
+
+	if captured == nil {
+		t.Fatal("no delivery enqueued for a job with a webhook URL")
+	}
+	if captured.URL != url || captured.UserID != "user-9" || captured.Event != domain.WebhookEventJobCompleted {
+		t.Errorf("delivery fields wrong: %+v", captured)
+	}
+	if captured.JobID == nil || *captured.JobID != "job-42" {
+		t.Errorf("delivery JobID = %v, want job-42", captured.JobID)
+	}
+	if captured.MaxAttempts != 7 {
+		t.Errorf("MaxAttempts = %d, want 7 (from worker config)", captured.MaxAttempts)
+	}
+	var payload WebhookPayload
+	if err := json.Unmarshal(captured.Payload, &payload); err != nil {
+		t.Fatalf("payload not valid JSON: %v", err)
+	}
+	if payload.Event != "job.completed" || payload.JobID != "job-42" || payload.AttemptNum != 3 {
+		t.Errorf("payload = %+v, want event=job.completed job_id=job-42 attempt_num=3", payload)
+	}
+
+	// No webhook URL → no enqueue.
+	captured = nil
+	w.enqueueWebhook(context.Background(), &domain.Job{ID: "job-x", UserID: "u"}, domain.WebhookEventJobFailed, nil)
+	if captured != nil {
+		t.Error("enqueued a delivery for a job with no webhook URL")
+	}
+}

--- a/internal/scheduler/webhook_dispatcher.go
+++ b/internal/scheduler/webhook_dispatcher.go
@@ -1,0 +1,165 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/metrics"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/repository"
+)
+
+const (
+	// webhookInflightTimeout is how long a claimed ('delivering') delivery may sit
+	// without an outcome before another dispatcher cycle reclaims it. It must exceed
+	// the notifier's HTTP client timeout (10s) so an attempt that is merely slow is
+	// never re-fired concurrently.
+	webhookInflightTimeout = 60 * time.Second
+
+	webhookBatchSize = 50
+
+	// defaultWebhookBaseDelay is the backoff before the first retry; each subsequent
+	// retry doubles it, capped at webhookMaxDelay.
+	defaultWebhookBaseDelay = 30 * time.Second
+	webhookMaxDelay         = 1 * time.Hour
+)
+
+// webhookDeliverer signs and POSTs a single webhook body. *WebhookNotifier
+// implements it; the interface keeps the dispatcher unit-testable.
+type webhookDeliverer interface {
+	Deliver(ctx context.Context, userID, url string, headers map[string]string, body []byte) (statusCode int, err error)
+}
+
+// WebhookDispatcher drains the durable webhook_deliveries queue: it claims due
+// deliveries, POSTs each, and records the outcome — retrying with backoff on
+// failure until a 2xx or the attempt budget is exhausted. It runs in the
+// scheduler process (single leader), off the request path.
+type WebhookDispatcher struct {
+	repo      repository.WebhookDeliveryRepository
+	deliverer webhookDeliverer
+	logger    *slog.Logger
+	interval  time.Duration
+	batchSize int
+	baseDelay time.Duration
+}
+
+func NewWebhookDispatcher(repo repository.WebhookDeliveryRepository, deliverer webhookDeliverer, logger *slog.Logger, interval time.Duration) *WebhookDispatcher {
+	return &WebhookDispatcher{
+		repo:      repo,
+		deliverer: deliverer,
+		logger:    logger.With("component", "webhook_dispatcher"),
+		interval:  interval,
+		batchSize: webhookBatchSize,
+		baseDelay: defaultWebhookBaseDelay,
+	}
+}
+
+func (d *WebhookDispatcher) Start(ctx context.Context) {
+	ticker := time.NewTicker(d.interval)
+	defer ticker.Stop()
+
+	d.logger.InfoContext(ctx, "webhook dispatcher started", "interval", d.interval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			d.logger.InfoContext(ctx, "webhook dispatcher shut down")
+			return
+		case <-ticker.C:
+			d.dispatchBatch(ctx)
+		}
+	}
+}
+
+func (d *WebhookDispatcher) dispatchBatch(ctx context.Context) {
+	due, err := d.repo.ClaimDue(ctx, d.batchSize, webhookInflightTimeout)
+	if err != nil {
+		d.logger.ErrorContext(ctx, "claim due webhook deliveries", "error", err)
+		return
+	}
+	if len(due) == 0 {
+		return
+	}
+
+	// Deliver the batch concurrently so one slow/hanging customer URL never blocks
+	// the others. Each row is already marked 'delivering', so this is safe.
+	var wg sync.WaitGroup
+	for _, del := range due {
+		wg.Add(1)
+		go func(del *domain.WebhookDelivery) {
+			defer wg.Done()
+			d.deliverOne(ctx, del)
+		}(del)
+	}
+	wg.Wait()
+}
+
+func (d *WebhookDispatcher) deliverOne(ctx context.Context, del *domain.WebhookDelivery) {
+	statusCode, err := d.deliverer.Deliver(ctx, del.UserID, del.URL, del.Headers, del.Payload)
+
+	var scPtr *int
+	if statusCode != 0 {
+		sc := statusCode
+		scPtr = &sc
+	}
+
+	if err == nil && statusCode >= 200 && statusCode < 300 {
+		metrics.WebhookDeliveriesTotal.WithLabelValues("success").Inc()
+		if markErr := d.repo.MarkDelivered(ctx, del.ID, statusCode); markErr != nil {
+			d.logger.ErrorContext(ctx, "mark webhook delivered", "delivery_id", del.ID, "error", markErr)
+		}
+		return
+	}
+
+	metrics.WebhookDeliveriesTotal.WithLabelValues("failure").Inc()
+	lastErr := deliveryErrorString(statusCode, err)
+	attemptsMade := del.Attempts + 1
+
+	if attemptsMade >= del.MaxAttempts {
+		d.logger.WarnContext(ctx, "webhook delivery permanently failed",
+			"delivery_id", del.ID, "attempts", attemptsMade, "last_error", lastErr)
+		if markErr := d.repo.MarkFailed(ctx, del.ID, scPtr, lastErr); markErr != nil {
+			d.logger.ErrorContext(ctx, "mark webhook failed", "delivery_id", del.ID, "error", markErr)
+		}
+		return
+	}
+
+	nextRetry := time.Now().Add(webhookRetryDelay(d.baseDelay, attemptsMade))
+	d.logger.WarnContext(ctx, "webhook delivery failed, will retry",
+		"delivery_id", del.ID, "attempt", attemptsMade, "max_attempts", del.MaxAttempts,
+		"retry_at", nextRetry, "last_error", lastErr)
+	if markErr := d.repo.Reschedule(ctx, del.ID, scPtr, lastErr, nextRetry); markErr != nil {
+		d.logger.ErrorContext(ctx, "reschedule webhook delivery", "delivery_id", del.ID, "error", markErr)
+	}
+}
+
+// webhookRetryDelay is the backoff before the next attempt. attemptsMade is the
+// number of attempts already completed (>= 1): delay = base * 2^(attemptsMade-1),
+// capped at webhookMaxDelay. Deterministic (no jitter) so the state machine is
+// straightforward to test.
+func webhookRetryDelay(base time.Duration, attemptsMade int) time.Duration {
+	if attemptsMade < 1 {
+		attemptsMade = 1
+	}
+	delay := base
+	for i := 1; i < attemptsMade; i++ {
+		delay *= 2
+		if delay >= webhookMaxDelay {
+			return webhookMaxDelay
+		}
+	}
+	if delay > webhookMaxDelay {
+		return webhookMaxDelay
+	}
+	return delay
+}
+
+func deliveryErrorString(statusCode int, err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return fmt.Sprintf("non-2xx response: %d", statusCode)
+}

--- a/internal/scheduler/webhook_dispatcher.go
+++ b/internal/scheduler/webhook_dispatcher.go
@@ -91,6 +91,14 @@ func (d *WebhookDispatcher) dispatchBatch(ctx context.Context) {
 		wg.Add(1)
 		go func(del *domain.WebhookDelivery) {
 			defer wg.Done()
+			// A panic in one delivery must not take down the scheduler process
+			// (it also hosts the worker, reaper, and drainers). The row stays
+			// 'delivering' and is reclaimed after the in-flight timeout.
+			defer func() {
+				if r := recover(); r != nil {
+					d.logger.ErrorContext(ctx, "webhook delivery panicked", "delivery_id", del.ID, "panic", r)
+				}
+			}()
 			d.deliverOne(ctx, del)
 		}(del)
 	}
@@ -98,7 +106,16 @@ func (d *WebhookDispatcher) dispatchBatch(ctx context.Context) {
 }
 
 func (d *WebhookDispatcher) deliverOne(ctx context.Context, del *domain.WebhookDelivery) {
-	statusCode, err := d.deliverer.Deliver(ctx, del.UserID, del.URL, del.Headers, del.Payload)
+	// Advertise the delivery id so consumers can dedup at-least-once retries of the
+	// same delivery (the body is identical across attempts). Copy the map so the
+	// per-delivery header never leaks into the shared row value.
+	headers := make(map[string]string, len(del.Headers)+1)
+	for k, v := range del.Headers {
+		headers[k] = v
+	}
+	headers["X-Fliq-Delivery-Id"] = del.ID
+
+	statusCode, err := d.deliverer.Deliver(ctx, del.UserID, del.URL, headers, del.Payload)
 
 	var scPtr *int
 	if statusCode != 0 {

--- a/internal/scheduler/webhook_dispatcher_test.go
+++ b/internal/scheduler/webhook_dispatcher_test.go
@@ -1,0 +1,189 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+)
+
+// fakeDeliverer returns a scripted (statusCode, err) for every Deliver call and
+// records how many times and with what body it was invoked.
+type fakeDeliverer struct {
+	mu       sync.Mutex
+	code     int
+	err      error
+	calls    int32
+	lastBody []byte
+}
+
+func (f *fakeDeliverer) Deliver(_ context.Context, _ string, _ string, _ map[string]string, body []byte) (int, error) {
+	atomic.AddInt32(&f.calls, 1)
+	f.mu.Lock()
+	f.lastBody = body
+	f.mu.Unlock()
+	return f.code, f.err
+}
+
+func TestWebhookRetryDelay(t *testing.T) {
+	base := 30 * time.Second
+	tests := []struct {
+		attemptsMade int
+		want         time.Duration
+	}{
+		{0, 30 * time.Second},   // clamped up to 1
+		{1, 30 * time.Second},   // base
+		{2, 60 * time.Second},   // base*2
+		{3, 120 * time.Second},  // base*4
+		{4, 240 * time.Second},  // base*8
+		{7, 1920 * time.Second}, // base*64 = 32m
+		{20, time.Hour},         // capped
+		{100, time.Hour},        // capped, no overflow
+	}
+	for _, tt := range tests {
+		if got := webhookRetryDelay(base, tt.attemptsMade); got != tt.want {
+			t.Errorf("webhookRetryDelay(30s, %d) = %v, want %v", tt.attemptsMade, got, tt.want)
+		}
+	}
+}
+
+// A 2xx marks the delivery delivered and never retries or fails it.
+func TestWebhookDispatcher_DeliverOne_Success(t *testing.T) {
+	var gotID string
+	var gotCode int
+	repo := &testutil.MockWebhookDeliveryRepository{
+		MarkDeliveredFn: func(_ context.Context, id string, code int) error {
+			gotID, gotCode = id, code
+			return nil
+		},
+		RescheduleFn: func(_ context.Context, _ string, _ *int, _ string, _ time.Time) error {
+			t.Fatal("Reschedule called on a 2xx delivery")
+			return nil
+		},
+		MarkFailedFn: func(_ context.Context, _ string, _ *int, _ string) error {
+			t.Fatal("MarkFailed called on a 2xx delivery")
+			return nil
+		},
+	}
+	d := NewWebhookDispatcher(repo, &fakeDeliverer{code: 202}, slog.Default(), time.Second)
+	d.deliverOne(context.Background(), &domain.WebhookDelivery{ID: "d1", Attempts: 0, MaxAttempts: 5})
+
+	if gotID != "d1" || gotCode != 202 {
+		t.Fatalf("MarkDelivered(id=%q, code=%d), want (d1, 202)", gotID, gotCode)
+	}
+}
+
+// A non-2xx with attempts left reschedules a retry, carrying the status code and a
+// strictly-future next_retry_at — and does NOT mark it failed.
+func TestWebhookDispatcher_DeliverOne_RetriesOnNon2xx(t *testing.T) {
+	var gotCode *int
+	var gotNext time.Time
+	repo := &testutil.MockWebhookDeliveryRepository{
+		RescheduleFn: func(_ context.Context, id string, code *int, lastErr string, next time.Time) error {
+			gotCode, gotNext = code, next
+			if id != "d1" {
+				t.Errorf("Reschedule id = %q, want d1", id)
+			}
+			if lastErr == "" {
+				t.Error("Reschedule lastErr is empty")
+			}
+			return nil
+		},
+		MarkFailedFn: func(_ context.Context, _ string, _ *int, _ string) error {
+			t.Fatal("MarkFailed called while attempts remain")
+			return nil
+		},
+	}
+	d := NewWebhookDispatcher(repo, &fakeDeliverer{code: 500}, slog.Default(), time.Second)
+	before := time.Now()
+	d.deliverOne(context.Background(), &domain.WebhookDelivery{ID: "d1", Attempts: 0, MaxAttempts: 5})
+
+	if gotCode == nil || *gotCode != 500 {
+		t.Fatalf("Reschedule status code = %v, want 500", gotCode)
+	}
+	if !gotNext.After(before) {
+		t.Fatalf("next_retry_at = %v, want strictly after %v", gotNext, before)
+	}
+}
+
+// A transport error (no HTTP response) reschedules with a nil status code.
+func TestWebhookDispatcher_DeliverOne_TransportErrorRetriesWithNilCode(t *testing.T) {
+	sawReschedule := false
+	repo := &testutil.MockWebhookDeliveryRepository{
+		RescheduleFn: func(_ context.Context, _ string, code *int, lastErr string, _ time.Time) error {
+			sawReschedule = true
+			if code != nil {
+				t.Errorf("status code = %v, want nil on transport error", *code)
+			}
+			if lastErr != "connection refused" {
+				t.Errorf("lastErr = %q, want %q", lastErr, "connection refused")
+			}
+			return nil
+		},
+	}
+	d := NewWebhookDispatcher(repo, &fakeDeliverer{code: 0, err: errors.New("connection refused")}, slog.Default(), time.Second)
+	d.deliverOne(context.Background(), &domain.WebhookDelivery{ID: "d1", Attempts: 1, MaxAttempts: 5})
+
+	if !sawReschedule {
+		t.Fatal("transport error did not reschedule a retry")
+	}
+}
+
+// The final failed attempt (attempts+1 == max) is terminal: MarkFailed, no retry.
+func TestWebhookDispatcher_DeliverOne_FailsWhenExhausted(t *testing.T) {
+	var failedID string
+	repo := &testutil.MockWebhookDeliveryRepository{
+		MarkFailedFn: func(_ context.Context, id string, code *int, _ string) error {
+			failedID = id
+			if code == nil || *code != 503 {
+				t.Errorf("MarkFailed code = %v, want 503", code)
+			}
+			return nil
+		},
+		RescheduleFn: func(_ context.Context, _ string, _ *int, _ string, _ time.Time) error {
+			t.Fatal("Reschedule called on the exhausting attempt")
+			return nil
+		},
+	}
+	d := NewWebhookDispatcher(repo, &fakeDeliverer{code: 503}, slog.Default(), time.Second)
+	// Attempts=4, Max=5 → this attempt is the 5th → exhausted.
+	d.deliverOne(context.Background(), &domain.WebhookDelivery{ID: "d1", Attempts: 4, MaxAttempts: 5})
+
+	if failedID != "d1" {
+		t.Fatalf("MarkFailed id = %q, want d1", failedID)
+	}
+}
+
+// dispatchBatch claims due deliveries and delivers each exactly once.
+func TestWebhookDispatcher_DispatchBatch_DeliversAllClaimed(t *testing.T) {
+	var delivered int32
+	repo := &testutil.MockWebhookDeliveryRepository{
+		ClaimDueFn: func(_ context.Context, _ int, _ time.Duration) ([]*domain.WebhookDelivery, error) {
+			return []*domain.WebhookDelivery{
+				{ID: "a", MaxAttempts: 5},
+				{ID: "b", MaxAttempts: 5},
+				{ID: "c", MaxAttempts: 5},
+			}, nil
+		},
+		MarkDeliveredFn: func(_ context.Context, _ string, _ int) error {
+			atomic.AddInt32(&delivered, 1)
+			return nil
+		},
+	}
+	deliverer := &fakeDeliverer{code: 200}
+	d := NewWebhookDispatcher(repo, deliverer, slog.Default(), time.Second)
+	d.dispatchBatch(context.Background())
+
+	if got := atomic.LoadInt32(&delivered); got != 3 {
+		t.Fatalf("delivered = %d, want 3", got)
+	}
+	if got := atomic.LoadInt32(&deliverer.calls); got != 3 {
+		t.Fatalf("Deliver calls = %d, want 3", got)
+	}
+}

--- a/internal/scheduler/webhook_dispatcher_test.go
+++ b/internal/scheduler/webhook_dispatcher_test.go
@@ -16,17 +16,19 @@ import (
 // fakeDeliverer returns a scripted (statusCode, err) for every Deliver call and
 // records how many times and with what body it was invoked.
 type fakeDeliverer struct {
-	mu       sync.Mutex
-	code     int
-	err      error
-	calls    int32
-	lastBody []byte
+	mu          sync.Mutex
+	code        int
+	err         error
+	calls       int32
+	lastBody    []byte
+	lastHeaders map[string]string
 }
 
-func (f *fakeDeliverer) Deliver(_ context.Context, _ string, _ string, _ map[string]string, body []byte) (int, error) {
+func (f *fakeDeliverer) Deliver(_ context.Context, _ string, _ string, headers map[string]string, body []byte) (int, error) {
 	atomic.AddInt32(&f.calls, 1)
 	f.mu.Lock()
 	f.lastBody = body
+	f.lastHeaders = headers
 	f.mu.Unlock()
 	return f.code, f.err
 }
@@ -71,11 +73,19 @@ func TestWebhookDispatcher_DeliverOne_Success(t *testing.T) {
 			return nil
 		},
 	}
-	d := NewWebhookDispatcher(repo, &fakeDeliverer{code: 202}, slog.Default(), time.Second)
-	d.deliverOne(context.Background(), &domain.WebhookDelivery{ID: "d1", Attempts: 0, MaxAttempts: 5})
+	deliverer := &fakeDeliverer{code: 202}
+	d := NewWebhookDispatcher(repo, deliverer, slog.Default(), time.Second)
+	d.deliverOne(context.Background(), &domain.WebhookDelivery{ID: "d1", Attempts: 0, MaxAttempts: 5, Headers: map[string]string{"X-A": "b"}})
 
 	if gotID != "d1" || gotCode != 202 {
 		t.Fatalf("MarkDelivered(id=%q, code=%d), want (d1, 202)", gotID, gotCode)
+	}
+	// The delivery id is advertised for consumer dedup, without dropping user headers.
+	if deliverer.lastHeaders["X-Fliq-Delivery-Id"] != "d1" {
+		t.Errorf("X-Fliq-Delivery-Id = %q, want d1", deliverer.lastHeaders["X-Fliq-Delivery-Id"])
+	}
+	if deliverer.lastHeaders["X-A"] != "b" {
+		t.Errorf("user header X-A dropped: %v", deliverer.lastHeaders)
 	}
 }
 

--- a/internal/scheduler/worker.go
+++ b/internal/scheduler/worker.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -17,49 +18,52 @@ import (
 )
 
 type Worker struct {
-	id             string
-	repo           repository.JobRepository
-	attempts       repository.AttemptRepository
-	credits        repository.CreditRepository
-	signingSecrets repository.SigningSecretRepository
-	executor       *Executor
-	notifier       *WebhookNotifier
-	alerts         *AlertNotifier
-	lowBalance     LowBalanceConfig
-	logger         *slog.Logger
-	pollInterval   time.Duration
-	concurrency    int
-	sem            chan struct{}
+	id                 string
+	repo               repository.JobRepository
+	attempts           repository.AttemptRepository
+	credits            repository.CreditRepository
+	signingSecrets     repository.SigningSecretRepository
+	executor           *Executor
+	deliveries         repository.WebhookDeliveryRepository
+	alerts             *AlertNotifier
+	lowBalance         LowBalanceConfig
+	logger             *slog.Logger
+	pollInterval       time.Duration
+	concurrency        int
+	webhookMaxAttempts int
+	sem                chan struct{}
 }
 
 func NewWorker(
 	repo repository.JobRepository,
 	attempts repository.AttemptRepository,
 	credits repository.CreditRepository,
-	notifier *WebhookNotifier,
+	deliveries repository.WebhookDeliveryRepository,
 	alerts *AlertNotifier,
 	lowBalance LowBalanceConfig,
 	logger *slog.Logger,
 	pollInterval time.Duration,
 	concurrency int,
+	webhookMaxAttempts int,
 	signingSecrets repository.SigningSecretRepository,
 ) *Worker {
 	hostname, _ := os.Hostname()
 	id := fmt.Sprintf("%s-%d", hostname, os.Getpid())
 	return &Worker{
-		id:             id,
-		repo:           repo,
-		attempts:       attempts,
-		credits:        credits,
-		signingSecrets: signingSecrets,
-		executor:       NewExecutor(logger),
-		notifier:       notifier,
-		alerts:         alerts,
-		lowBalance:     lowBalance,
-		logger:         logger.With("worker_id", id),
-		pollInterval:   pollInterval,
-		concurrency:    concurrency,
-		sem:            make(chan struct{}, concurrency),
+		id:                 id,
+		repo:               repo,
+		attempts:           attempts,
+		credits:            credits,
+		signingSecrets:     signingSecrets,
+		executor:           NewExecutor(logger),
+		deliveries:         deliveries,
+		alerts:             alerts,
+		lowBalance:         lowBalance,
+		logger:             logger.With("worker_id", id),
+		pollInterval:       pollInterval,
+		concurrency:        concurrency,
+		webhookMaxAttempts: webhookMaxAttempts,
+		sem:                make(chan struct{}, concurrency),
 	}
 }
 
@@ -76,6 +80,49 @@ func (w *Worker) alertJobFailure(ctx context.Context, job *domain.Job, statusCod
 		Attempts:     job.RetryCount + 1,
 		FailedAt:     time.Now(),
 	})
+}
+
+// enqueueWebhook durably records a webhook delivery for a terminal job state. The
+// actual HTTP POST (and its retries) happen off this path, in WebhookDispatcher —
+// so a slow or hanging customer URL can never stall job execution. The row is the
+// unit of at-least-once delivery: once written, the dispatcher owns it. A nil
+// WebhookURL is a no-op; an enqueue failure is logged, never fatal to the job.
+func (w *Worker) enqueueWebhook(ctx context.Context, job *domain.Job, event domain.WebhookEvent, statusCode *int) {
+	if job.WebhookURL == nil {
+		return
+	}
+
+	completedAt := time.Now().UTC().Format(time.RFC3339)
+	if job.CompletedAt != nil {
+		completedAt = job.CompletedAt.UTC().Format(time.RFC3339)
+	}
+
+	body, err := json.Marshal(WebhookPayload{
+		Event:       string(event),
+		JobID:       job.ID,
+		Status:      string(job.Status),
+		StatusCode:  statusCode,
+		LastError:   job.LastError,
+		CompletedAt: completedAt,
+		AttemptNum:  job.RetryCount + 1,
+	})
+	if err != nil {
+		w.logger.ErrorContext(ctx, "marshal webhook payload", "job_id", job.ID, "error", err)
+		return
+	}
+
+	jobID := job.ID
+	if _, err := w.deliveries.Enqueue(ctx, &domain.WebhookDelivery{
+		UserID:      job.UserID,
+		JobID:       &jobID,
+		Event:       event,
+		URL:         *job.WebhookURL,
+		Headers:     job.WebhookHeaders,
+		Payload:     body,
+		MaxAttempts: w.webhookMaxAttempts,
+	}); err != nil {
+		w.logger.ErrorContext(ctx, "enqueue webhook delivery", "job_id", job.ID, "error", err)
+	}
 }
 
 func (w *Worker) Start(ctx context.Context) {
@@ -162,7 +209,7 @@ func (w *Worker) runJob(ctx context.Context, job *domain.Job) {
 		}
 		job.Status = domain.StatusFailed
 		job.LastError = &errMsg
-		w.notifier.notifyAsync(ctx, job, nil)
+		w.enqueueWebhook(ctx, job, domain.WebhookEventJobFailed, nil)
 		w.alertJobFailure(ctx, job, nil, errMsg)
 		w.logger.WarnContext(ctx, "job permanently failed: insufficient credits", "job_id", job.ID)
 		return
@@ -221,7 +268,7 @@ func (w *Worker) runJob(ctx context.Context, job *domain.Job) {
 			w.logger.ErrorContext(ctx, "mark job complete", "job_id", job.ID, "error", err)
 		}
 		job.Status = domain.StatusCompleted
-		w.notifier.notifyAsync(ctx, job, &result.StatusCode)
+		w.enqueueWebhook(ctx, job, domain.WebhookEventJobCompleted, &result.StatusCode)
 		w.logger.InfoContext(ctx, "job completed", "job_id", job.ID, "duration", result.Duration)
 		return
 	}
@@ -259,7 +306,7 @@ func (w *Worker) runJob(ctx context.Context, job *domain.Job) {
 		}
 		job.Status = domain.StatusFailed
 		job.LastError = &errMsg
-		w.notifier.notifyAsync(ctx, job, statusCode)
+		w.enqueueWebhook(ctx, job, domain.WebhookEventJobFailed, statusCode)
 		w.alertJobFailure(ctx, job, statusCode, errMsg)
 		metrics.JobsCompletedTotal.WithLabelValues("failed").Inc()
 		w.logger.WarnContext(ctx, "job permanently failed", "job_id", job.ID, "error", errMsg)

--- a/internal/scheduler/worker_test.go
+++ b/internal/scheduler/worker_test.go
@@ -85,7 +85,7 @@ func TestWorker_Start_PollsOnInterval(t *testing.T) {
 			credits:        &testutil.MockCreditRepository{},
 			signingSecrets: &testutil.MockSigningSecretRepository{},
 			executor:       NewExecutor(slog.Default()),
-			notifier:       NewWebhookNotifier(slog.Default(), &testutil.MockSigningSecretRepository{}),
+			deliveries:     &testutil.MockWebhookDeliveryRepository{},
 			logger:         slog.Default(),
 			pollInterval:   5 * time.Second,
 			concurrency:    10,

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -60,7 +60,8 @@ func TruncateAll(t *testing.T, pool *pgxpool.Pool) {
 				  AND tablename IN (
 					'credit_transactions','job_attempts','jobs','schedules',
 					'signing_secrets','api_tokens','user_credits',
-					'stripe_customers','users','magic_tokens'
+					'stripe_customers','users','magic_tokens',
+					'webhook_deliveries'
 				  )
 			LOOP
 				EXECUTE format('TRUNCATE %I CASCADE', tbl);

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -615,3 +615,59 @@ func (m *MockSigningSecretRepository) Rotate(ctx context.Context, userID string)
 	}
 	return &domain.SigningSecret{ID: "sig-1", UserID: userID, Secret: "test-secret-32chars-for-signing!", IsActive: true, CreatedAt: time.Now()}, nil
 }
+
+// ---------- MockWebhookDeliveryRepository ----------
+
+type MockWebhookDeliveryRepository struct {
+	EnqueueFn       func(ctx context.Context, d *domain.WebhookDelivery) (*domain.WebhookDelivery, error)
+	ClaimDueFn      func(ctx context.Context, limit int, inflightTimeout time.Duration) ([]*domain.WebhookDelivery, error)
+	MarkDeliveredFn func(ctx context.Context, id string, statusCode int) error
+	RescheduleFn    func(ctx context.Context, id string, statusCode *int, lastErr string, nextRetryAt time.Time) error
+	MarkFailedFn    func(ctx context.Context, id string, statusCode *int, lastErr string) error
+	ListByUserFn    func(ctx context.Context, userID string, limit int, cursorTime *time.Time, cursorID string) ([]*domain.WebhookDelivery, error)
+}
+
+func (m *MockWebhookDeliveryRepository) Enqueue(ctx context.Context, d *domain.WebhookDelivery) (*domain.WebhookDelivery, error) {
+	if m.EnqueueFn != nil {
+		return m.EnqueueFn(ctx, d)
+	}
+	if d.ID == "" {
+		d.ID = "delivery-1"
+	}
+	return d, nil
+}
+
+func (m *MockWebhookDeliveryRepository) ClaimDue(ctx context.Context, limit int, inflightTimeout time.Duration) ([]*domain.WebhookDelivery, error) {
+	if m.ClaimDueFn != nil {
+		return m.ClaimDueFn(ctx, limit, inflightTimeout)
+	}
+	return nil, nil
+}
+
+func (m *MockWebhookDeliveryRepository) MarkDelivered(ctx context.Context, id string, statusCode int) error {
+	if m.MarkDeliveredFn != nil {
+		return m.MarkDeliveredFn(ctx, id, statusCode)
+	}
+	return nil
+}
+
+func (m *MockWebhookDeliveryRepository) Reschedule(ctx context.Context, id string, statusCode *int, lastErr string, nextRetryAt time.Time) error {
+	if m.RescheduleFn != nil {
+		return m.RescheduleFn(ctx, id, statusCode, lastErr, nextRetryAt)
+	}
+	return nil
+}
+
+func (m *MockWebhookDeliveryRepository) MarkFailed(ctx context.Context, id string, statusCode *int, lastErr string) error {
+	if m.MarkFailedFn != nil {
+		return m.MarkFailedFn(ctx, id, statusCode, lastErr)
+	}
+	return nil
+}
+
+func (m *MockWebhookDeliveryRepository) ListByUser(ctx context.Context, userID string, limit int, cursorTime *time.Time, cursorID string) ([]*domain.WebhookDelivery, error) {
+	if m.ListByUserFn != nil {
+		return m.ListByUserFn(ctx, userID, limit, cursorTime, cursorID)
+	}
+	return nil, nil
+}

--- a/migrations/20260707000000_webhook_deliveries.sql
+++ b/migrations/20260707000000_webhook_deliveries.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+-- Durable, at-least-once webhook delivery log. Each row is one webhook that must
+-- reach a customer URL; the webhook dispatcher retries it with backoff until a 2xx
+-- (delivered) or the attempt budget is exhausted (failed). This replaces the old
+-- fire-and-forget, at-most-once job webhook that was lost on the first failure.
+CREATE TABLE webhook_deliveries (
+    id            TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    user_id       TEXT NOT NULL REFERENCES users(id),
+    -- job_id is nullable so the log can carry non-job events later; today every
+    -- delivery is triggered by a terminal job state.
+    job_id        TEXT,
+    event         TEXT NOT NULL,
+    url           TEXT NOT NULL,
+    headers       JSONB NOT NULL DEFAULT '{}',
+    -- payload is the exact JSON body that is HMAC-signed and POSTed, stored as text
+    -- so the bytes are preserved verbatim (JSONB would re-order/normalise them).
+    payload       TEXT NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'pending',
+    status_code   INT,
+    attempts      INT NOT NULL DEFAULT 0,
+    max_attempts  INT NOT NULL DEFAULT 10,
+    next_retry_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_error    TEXT,
+    delivered_at  TIMESTAMPTZ,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Dispatcher poll: claim due pending rows and reclaim abandoned in-flight rows.
+-- Partial index keeps it tiny — terminal (delivered/failed) rows drop out.
+CREATE INDEX idx_webhook_deliveries_due
+    ON webhook_deliveries (next_retry_at)
+    WHERE status IN ('pending', 'delivering');
+
+-- Read API: a user's recent deliveries, newest first.
+CREATE INDEX idx_webhook_deliveries_user
+    ON webhook_deliveries (user_id, created_at DESC, id DESC);
+
+-- +goose Down
+DROP TABLE webhook_deliveries;


### PR DESCRIPTION
## What

Job/schedule completion webhooks are currently **fire-and-forget** — a single best-effort POST from the worker goroutine on completion, **lost forever** on the first network blip, timeout, or non-2xx. This PR makes webhook delivery **durable and at-least-once**, the single most-requested reliability property of an async job API.

## How

- **`webhook_deliveries` table + repository** — a per-delivery log with a `pending → delivering → delivered/failed` state machine. Due rows are claimed with `FOR UPDATE SKIP LOCKED` (safe for concurrent dispatchers); rows abandoned by a crashed dispatcher are reclaimed after an in-flight timeout, so nothing is silently dropped.
- **Enqueue, don't POST inline** — on job completion/failure the worker writes a signed delivery row (a fast local insert) instead of POSTing the customer URL inline. A slow or hanging customer endpoint can no longer stall job execution.
- **`WebhookDispatcher`** — a new loop in the scheduler process drains the queue: POSTs each due delivery (reusing the existing HMAC signer + SSRF-safe dialer) and retries with **exponential backoff** until a 2xx or the attempt budget is exhausted.
- **`GET /webhooks/deliveries`** — read-only, keyset-paginated list of a user's recent deliveries with status, attempts, status code, and last error. Powers the dashboard's delivery view.
- **`WebhookNotifier.Deliver`** is now the shared sign+POST primitive; the buffer drainer keeps its existing best-effort `Notify` layered on top (behaviour unchanged).

Signing, the per-job `webhook_url`/`webhook_headers` UX, and the payload shape are unchanged — the payload gains an additive `event` field (`job.completed` / `job.failed`).

## Tests

Unit + integration, all green locally (`-race`):
- HMAC signing (signature verifies against the delivered bytes), unsigned fallback.
- Backoff schedule + the delivery state machine: 2xx → delivered, non-2xx/transport-error → retry with a future `next_retry_at`, exhausted → failed.
- Repo lifecycle against Postgres: enqueue → claim → deliver, attempts increment, **stale in-flight reclaim**, keyset pagination (no dropped/duplicated rows).
- `enqueueWebhook` writes exactly one correctly-shaped row, and nothing when the job has no webhook URL.

New config (both defaulted, no manifest change needed): `WEBHOOK_DISPATCH_INTERVAL_SEC=2`, `WEBHOOK_MAX_ATTEMPTS=10`.

Migration `20260707000000_webhook_deliveries.sql` is purely additive (new table + two indexes).