### PR TITLE
Make webhook enqueue atomic with job completion (outbox)

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -73,7 +73,6 @@ func main() {
 		jobRepo,
 		attemptRepo,
 		creditRepo,
-		webhookDeliveryRepo,
 		alertNotifier,
 		lowBalance,
 		logger,

--- a/internal/infrastructure/postgres/job_repo.go
+++ b/internal/infrastructure/postgres/job_repo.go
@@ -145,8 +145,57 @@ func (r *JobRepository) UpdateHeartbeat(ctx context.Context, jobID string) error
 }
 
 func (r *JobRepository) Complete(ctx context.Context, jobID string) error {
-	// Leaving 'running' → drop the heartbeat sidecar row so it stays tiny.
-	_, err := r.pool.Exec(ctx,
+	return completeJob(ctx, r.pool, jobID)
+}
+
+func (r *JobRepository) Fail(ctx context.Context, jobID string, lastError string) error {
+	return failJob(ctx, r.pool, jobID, lastError)
+}
+
+// CompleteWithWebhook marks the job completed and, when delivery is non-nil, inserts
+// the webhook delivery row in the SAME transaction. This closes the outbox gap: a
+// crash can never leave a terminal job without its outbound delivery — the
+// at-least-once guarantee begins at commit, not after a second write. A nil
+// delivery (job had no webhook_url) behaves exactly like Complete.
+func (r *JobRepository) CompleteWithWebhook(ctx context.Context, jobID string, delivery *domain.WebhookDelivery) error {
+	return r.terminalWithWebhook(ctx, delivery, func(q querier) error {
+		return completeJob(ctx, q, jobID)
+	})
+}
+
+// FailWithWebhook is CompleteWithWebhook for a permanent failure.
+func (r *JobRepository) FailWithWebhook(ctx context.Context, jobID string, lastError string, delivery *domain.WebhookDelivery) error {
+	return r.terminalWithWebhook(ctx, delivery, func(q querier) error {
+		return failJob(ctx, q, jobID, lastError)
+	})
+}
+
+// terminalWithWebhook runs the job's terminal transition and (optionally) the
+// delivery insert inside one transaction, so both commit or neither does.
+func (r *JobRepository) terminalWithWebhook(ctx context.Context, delivery *domain.WebhookDelivery, terminal func(querier) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := terminal(tx); err != nil {
+		return err
+	}
+	if delivery != nil {
+		if _, err := insertWebhookDelivery(ctx, tx, delivery); err != nil {
+			return fmt.Errorf("enqueue webhook delivery: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+	return nil
+}
+
+// completeJob leaves 'running' → drop the heartbeat sidecar row so it stays tiny.
+func completeJob(ctx context.Context, q querier, jobID string) error {
+	_, err := q.Exec(ctx,
 		`WITH done AS (
 			UPDATE jobs SET status = 'completed', completed_at = NOW(), updated_at = NOW()
 			WHERE id = $1 RETURNING id
@@ -155,8 +204,8 @@ func (r *JobRepository) Complete(ctx context.Context, jobID string) error {
 	return err
 }
 
-func (r *JobRepository) Fail(ctx context.Context, jobID string, lastError string) error {
-	_, err := r.pool.Exec(ctx,
+func failJob(ctx context.Context, q querier, jobID, lastError string) error {
+	_, err := q.Exec(ctx,
 		`WITH done AS (
 			UPDATE jobs SET status = 'failed', last_error = $2, updated_at = NOW()
 			WHERE id = $1 RETURNING id

--- a/internal/infrastructure/postgres/job_webhook_outbox_integration_test.go
+++ b/internal/infrastructure/postgres/job_webhook_outbox_integration_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/domain"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/infrastructure/postgres"
+	"github.com/ErlanBelekov/dist-job-scheduler/internal/testutil"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func outboxSetup(t *testing.T) (*pgxpool.Pool, *postgres.JobRepository, *postgres.WebhookDeliveryRepository, string, context.Context) {
+	t.Helper()
+	pool := testutil.SetupTestDB(t)
+	testutil.TruncateAll(t, pool)
+	userID := testutil.UserID()
+	testutil.SeedUser(t, pool, userID)
+	return pool, postgres.NewJobRepository(pool), postgres.NewWebhookDeliveryRepository(pool), userID, context.Background()
+}
+
+func countDeliveries(t *testing.T, pool *pgxpool.Pool) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(), "SELECT count(*) FROM webhook_deliveries").Scan(&n); err != nil {
+		t.Fatalf("count deliveries: %v", err)
+	}
+	return n
+}
+
+// The job terminal transition and its webhook delivery commit together.
+func TestJobRepo_CompleteWithWebhook_CommitsBoth(t *testing.T) {
+	_, jobRepo, whRepo, userID, ctx := outboxSetup(t)
+
+	job, err := jobRepo.Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+
+	del := &domain.WebhookDelivery{
+		UserID:      userID,
+		JobID:       &job.ID,
+		Event:       domain.WebhookEventJobCompleted,
+		URL:         "https://example.com/hook",
+		Payload:     []byte(`{"event":"job.completed"}`),
+		MaxAttempts: 5,
+	}
+	if err := jobRepo.CompleteWithWebhook(ctx, job.ID, del); err != nil {
+		t.Fatalf("CompleteWithWebhook: %v", err)
+	}
+
+	got, err := jobRepo.GetByID(ctx, job.ID, userID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if got.Status != domain.StatusCompleted {
+		t.Errorf("job status = %s, want completed", got.Status)
+	}
+	rows, _ := whRepo.ListByUser(ctx, userID, 10, nil, "")
+	if len(rows) != 1 {
+		t.Fatalf("deliveries = %d, want 1", len(rows))
+	}
+	if rows[0].JobID == nil || *rows[0].JobID != job.ID {
+		t.Errorf("delivery not linked to job %s: %+v", job.ID, rows[0])
+	}
+}
+
+// A nil delivery (job had no webhook_url) behaves like a plain Complete.
+func TestJobRepo_CompleteWithWebhook_NilDelivery(t *testing.T) {
+	pool, jobRepo, _, userID, ctx := outboxSetup(t)
+
+	job, err := jobRepo.Create(ctx, testutil.NewJob(testutil.WithUserID(userID)))
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	if err := jobRepo.CompleteWithWebhook(ctx, job.ID, nil); err != nil {
+		t.Fatalf("CompleteWithWebhook(nil): %v", err)
+	}
+
+	got, _ := jobRepo.GetByID(ctx, job.ID, userID)
+	if got.Status != domain.StatusCompleted {
+		t.Errorf("job status = %s, want completed", got.Status)
+	}
+	if n := countDeliveries(t, pool); n != 0 {
+		t.Errorf("deliveries = %d, want 0 for a nil delivery", n)
+	}
+}
+
+// Atomicity: if the delivery insert fails, the job's terminal transition rolls
+// back too — a bogus user_id violates the FK, so neither write persists.
+func TestJobRepo_FailWithWebhook_RollsBackOnDeliveryError(t *testing.T) {
+	pool, jobRepo, _, userID, ctx := outboxSetup(t)
+
+	job, err := jobRepo.Create(ctx, testutil.NewJob(testutil.WithUserID(userID), testutil.WithStatus(domain.StatusPending)))
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+
+	bogus := &domain.WebhookDelivery{
+		UserID:      "no-such-user", // violates webhook_deliveries.user_id FK
+		JobID:       &job.ID,
+		Event:       domain.WebhookEventJobFailed,
+		URL:         "https://example.com/hook",
+		Payload:     []byte(`{}`),
+		MaxAttempts: 5,
+	}
+	if err := jobRepo.FailWithWebhook(ctx, job.ID, "boom", bogus); err == nil {
+		t.Fatal("expected an error from the FK-violating delivery insert")
+	}
+
+	got, _ := jobRepo.GetByID(ctx, job.ID, userID)
+	if got.Status != domain.StatusPending {
+		t.Errorf("job status = %s, want pending — the terminal transition should have rolled back", got.Status)
+	}
+	if n := countDeliveries(t, pool); n != 0 {
+		t.Errorf("deliveries = %d, want 0 — the insert should have rolled back", n)
+	}
+}

--- a/internal/infrastructure/postgres/querier.go
+++ b/internal/infrastructure/postgres/querier.go
@@ -1,0 +1,18 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// querier is the subset of the pgx API shared by *pgxpool.Pool and pgx.Tx, so a
+// query helper can run either directly against the pool or inside a transaction.
+// This is what lets the job terminal transition and its webhook-delivery insert
+// commit atomically (the outbox pattern) — see JobRepository.CompleteWithWebhook.
+type querier interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}

--- a/internal/infrastructure/postgres/webhook_delivery.go
+++ b/internal/infrastructure/postgres/webhook_delivery.go
@@ -26,6 +26,13 @@ const deliveryColumns = `id, user_id, job_id, event, url, headers, payload,
 	delivered_at, created_at, updated_at`
 
 func (r *WebhookDeliveryRepository) Enqueue(ctx context.Context, d *domain.WebhookDelivery) (*domain.WebhookDelivery, error) {
+	return insertWebhookDelivery(ctx, r.pool, d)
+}
+
+// insertWebhookDelivery inserts a pending delivery using any querier — the pool
+// (Enqueue) or a transaction (JobRepository.CompleteWithWebhook / FailWithWebhook,
+// where the insert must commit atomically with the job's terminal transition).
+func insertWebhookDelivery(ctx context.Context, q querier, d *domain.WebhookDelivery) (*domain.WebhookDelivery, error) {
 	headers := d.Headers
 	if headers == nil {
 		headers = map[string]string{}
@@ -40,7 +47,7 @@ func (r *WebhookDeliveryRepository) Enqueue(ctx context.Context, d *domain.Webho
 		VALUES ($1, $2, $3, $4, $5, $6, $7)
 		RETURNING ` + deliveryColumns
 
-	row := r.pool.QueryRow(ctx, query,
+	row := q.QueryRow(ctx, query,
 		d.UserID, d.JobID, string(d.Event), d.URL, headers, string(d.Payload), maxAttempts)
 	return scanWebhookDelivery(row)
 }

--- a/internal/repository/job.go
+++ b/internal/repository/job.go
@@ -35,6 +35,11 @@ type JobRepository interface {
 	UpdateHeartbeat(ctx context.Context, jobID string) error
 	Complete(ctx context.Context, jobID string) error
 	Fail(ctx context.Context, jobID string, lastError string) error
+	// CompleteWithWebhook / FailWithWebhook mark the job terminal and, when the
+	// delivery is non-nil, insert the outbound webhook row in the same transaction
+	// (the outbox pattern). A nil delivery is equivalent to Complete / Fail.
+	CompleteWithWebhook(ctx context.Context, jobID string, delivery *domain.WebhookDelivery) error
+	FailWithWebhook(ctx context.Context, jobID string, lastError string, delivery *domain.WebhookDelivery) error
 	Reschedule(ctx context.Context, jobID string, lastError string, retryAt time.Time) error
 
 	// Reaper methods — recover jobs from crashed workers

--- a/internal/scheduler/webhook_deliver_test.go
+++ b/internal/scheduler/webhook_deliver_test.go
@@ -101,17 +101,11 @@ func TestWebhookNotifier_Deliver_UnsignedWhenNoSecret(t *testing.T) {
 	}
 }
 
-// enqueueWebhook writes exactly one durable delivery row with the right shape when
-// the job carries a webhook URL, and writes nothing when it doesn't.
-func TestWorker_EnqueueWebhook(t *testing.T) {
-	var captured *domain.WebhookDelivery
-	repo := &testutil.MockWebhookDeliveryRepository{
-		EnqueueFn: func(_ context.Context, d *domain.WebhookDelivery) (*domain.WebhookDelivery, error) {
-			captured = d
-			return d, nil
-		},
-	}
-	w := &Worker{deliveries: repo, webhookMaxAttempts: 7, logger: slog.Default()}
+// buildDelivery returns a correctly-shaped delivery when the job carries a webhook
+// URL, and nil when it doesn't. The row is inserted atomically with the job's
+// terminal transition (CompleteWithWebhook/FailWithWebhook), tested at the repo layer.
+func TestWorker_BuildDelivery(t *testing.T) {
+	w := &Worker{webhookMaxAttempts: 7, logger: slog.Default()}
 
 	url := "https://example.com/hook"
 	job := &domain.Job{
@@ -123,32 +117,30 @@ func TestWorker_EnqueueWebhook(t *testing.T) {
 		WebhookHeaders: map[string]string{"X-A": "b"},
 	}
 	code := 200
-	w.enqueueWebhook(context.Background(), job, domain.WebhookEventJobCompleted, &code)
+	d := w.buildDelivery(context.Background(), job, domain.WebhookEventJobCompleted, &code)
 
-	if captured == nil {
-		t.Fatal("no delivery enqueued for a job with a webhook URL")
+	if d == nil {
+		t.Fatal("no delivery built for a job with a webhook URL")
 	}
-	if captured.URL != url || captured.UserID != "user-9" || captured.Event != domain.WebhookEventJobCompleted {
-		t.Errorf("delivery fields wrong: %+v", captured)
+	if d.URL != url || d.UserID != "user-9" || d.Event != domain.WebhookEventJobCompleted {
+		t.Errorf("delivery fields wrong: %+v", d)
 	}
-	if captured.JobID == nil || *captured.JobID != "job-42" {
-		t.Errorf("delivery JobID = %v, want job-42", captured.JobID)
+	if d.JobID == nil || *d.JobID != "job-42" {
+		t.Errorf("delivery JobID = %v, want job-42", d.JobID)
 	}
-	if captured.MaxAttempts != 7 {
-		t.Errorf("MaxAttempts = %d, want 7 (from worker config)", captured.MaxAttempts)
+	if d.MaxAttempts != 7 {
+		t.Errorf("MaxAttempts = %d, want 7 (from worker config)", d.MaxAttempts)
 	}
 	var payload WebhookPayload
-	if err := json.Unmarshal(captured.Payload, &payload); err != nil {
+	if err := json.Unmarshal(d.Payload, &payload); err != nil {
 		t.Fatalf("payload not valid JSON: %v", err)
 	}
 	if payload.Event != "job.completed" || payload.JobID != "job-42" || payload.AttemptNum != 3 {
 		t.Errorf("payload = %+v, want event=job.completed job_id=job-42 attempt_num=3", payload)
 	}
 
-	// No webhook URL → no enqueue.
-	captured = nil
-	w.enqueueWebhook(context.Background(), &domain.Job{ID: "job-x", UserID: "u"}, domain.WebhookEventJobFailed, nil)
-	if captured != nil {
-		t.Error("enqueued a delivery for a job with no webhook URL")
+	// No webhook URL → nil (nothing to deliver).
+	if w.buildDelivery(context.Background(), &domain.Job{ID: "job-x", UserID: "u"}, domain.WebhookEventJobFailed, nil) != nil {
+		t.Error("built a delivery for a job with no webhook URL")
 	}
 }

--- a/internal/scheduler/worker.go
+++ b/internal/scheduler/worker.go
@@ -24,7 +24,6 @@ type Worker struct {
 	credits            repository.CreditRepository
 	signingSecrets     repository.SigningSecretRepository
 	executor           *Executor
-	deliveries         repository.WebhookDeliveryRepository
 	alerts             *AlertNotifier
 	lowBalance         LowBalanceConfig
 	logger             *slog.Logger
@@ -38,7 +37,6 @@ func NewWorker(
 	repo repository.JobRepository,
 	attempts repository.AttemptRepository,
 	credits repository.CreditRepository,
-	deliveries repository.WebhookDeliveryRepository,
 	alerts *AlertNotifier,
 	lowBalance LowBalanceConfig,
 	logger *slog.Logger,
@@ -56,7 +54,6 @@ func NewWorker(
 		credits:            credits,
 		signingSecrets:     signingSecrets,
 		executor:           NewExecutor(logger),
-		deliveries:         deliveries,
 		alerts:             alerts,
 		lowBalance:         lowBalance,
 		logger:             logger.With("worker_id", id),
@@ -82,14 +79,16 @@ func (w *Worker) alertJobFailure(ctx context.Context, job *domain.Job, statusCod
 	})
 }
 
-// enqueueWebhook durably records a webhook delivery for a terminal job state. The
-// actual HTTP POST (and its retries) happen off this path, in WebhookDispatcher —
-// so a slow or hanging customer URL can never stall job execution. The row is the
-// unit of at-least-once delivery: once written, the dispatcher owns it. A nil
-// WebhookURL is a no-op; an enqueue failure is logged, never fatal to the job.
-func (w *Worker) enqueueWebhook(ctx context.Context, job *domain.Job, event domain.WebhookEvent, statusCode *int) {
+// buildDelivery constructs the durable webhook delivery for a terminal job state,
+// or returns nil when the job has no webhook_url. The row is written in the same
+// transaction as the job's terminal transition (CompleteWithWebhook /
+// FailWithWebhook), so a crash can't leave a terminal job without its delivery.
+// The actual HTTP POST + retries happen off this path, in WebhookDispatcher, so a
+// slow customer URL never stalls job execution. Call with job.Status already set
+// to the terminal state so the payload reflects it.
+func (w *Worker) buildDelivery(ctx context.Context, job *domain.Job, event domain.WebhookEvent, statusCode *int) *domain.WebhookDelivery {
 	if job.WebhookURL == nil {
-		return
+		return nil
 	}
 
 	completedAt := time.Now().UTC().Format(time.RFC3339)
@@ -107,12 +106,14 @@ func (w *Worker) enqueueWebhook(ctx context.Context, job *domain.Job, event doma
 		AttemptNum:  job.RetryCount + 1,
 	})
 	if err != nil {
+		// A payload we can't marshal can't be delivered; log and skip the webhook
+		// rather than blocking the job's terminal transition.
 		w.logger.ErrorContext(ctx, "marshal webhook payload", "job_id", job.ID, "error", err)
-		return
+		return nil
 	}
 
 	jobID := job.ID
-	if _, err := w.deliveries.Enqueue(ctx, &domain.WebhookDelivery{
+	return &domain.WebhookDelivery{
 		UserID:      job.UserID,
 		JobID:       &jobID,
 		Event:       event,
@@ -120,8 +121,6 @@ func (w *Worker) enqueueWebhook(ctx context.Context, job *domain.Job, event doma
 		Headers:     job.WebhookHeaders,
 		Payload:     body,
 		MaxAttempts: w.webhookMaxAttempts,
-	}); err != nil {
-		w.logger.ErrorContext(ctx, "enqueue webhook delivery", "job_id", job.ID, "error", err)
 	}
 }
 
@@ -204,12 +203,11 @@ func (w *Worker) runJob(ctx context.Context, job *domain.Job) {
 	} else if !ok {
 		errMsg := "insufficient credits"
 		w.closeAttempt(ctx, attempt, nil, &errMsg, time.Since(startedAt).Milliseconds())
-		if failErr := w.repo.Fail(ctx, job.ID, errMsg); failErr != nil {
-			w.logger.ErrorContext(ctx, "mark job failed (no credits)", "job_id", job.ID, "error", failErr)
-		}
 		job.Status = domain.StatusFailed
 		job.LastError = &errMsg
-		w.enqueueWebhook(ctx, job, domain.WebhookEventJobFailed, nil)
+		if failErr := w.repo.FailWithWebhook(ctx, job.ID, errMsg, w.buildDelivery(ctx, job, domain.WebhookEventJobFailed, nil)); failErr != nil {
+			w.logger.ErrorContext(ctx, "mark job failed (no credits)", "job_id", job.ID, "error", failErr)
+		}
 		w.alertJobFailure(ctx, job, nil, errMsg)
 		w.logger.WarnContext(ctx, "job permanently failed: insufficient credits", "job_id", job.ID)
 		return
@@ -264,11 +262,10 @@ func (w *Worker) runJob(ctx context.Context, job *domain.Job) {
 		metrics.JobExecutionDuration.WithLabelValues("success").Observe(result.Duration.Seconds())
 		metrics.JobsCompletedTotal.WithLabelValues("success").Inc()
 		w.closeAttempt(ctx, attempt, &result.StatusCode, nil, durationMS)
-		if err := w.repo.Complete(ctx, job.ID); err != nil {
+		job.Status = domain.StatusCompleted
+		if err := w.repo.CompleteWithWebhook(ctx, job.ID, w.buildDelivery(ctx, job, domain.WebhookEventJobCompleted, &result.StatusCode)); err != nil {
 			w.logger.ErrorContext(ctx, "mark job complete", "job_id", job.ID, "error", err)
 		}
-		job.Status = domain.StatusCompleted
-		w.enqueueWebhook(ctx, job, domain.WebhookEventJobCompleted, &result.StatusCode)
 		w.logger.InfoContext(ctx, "job completed", "job_id", job.ID, "duration", result.Duration)
 		return
 	}
@@ -301,12 +298,11 @@ func (w *Worker) runJob(ctx context.Context, job *domain.Job) {
 			"retry_at", retryAt,
 		)
 	} else {
-		if err := w.repo.Fail(ctx, job.ID, errMsg); err != nil {
-			w.logger.ErrorContext(ctx, "mark job failed", "job_id", job.ID, "error", err)
-		}
 		job.Status = domain.StatusFailed
 		job.LastError = &errMsg
-		w.enqueueWebhook(ctx, job, domain.WebhookEventJobFailed, statusCode)
+		if err := w.repo.FailWithWebhook(ctx, job.ID, errMsg, w.buildDelivery(ctx, job, domain.WebhookEventJobFailed, statusCode)); err != nil {
+			w.logger.ErrorContext(ctx, "mark job failed", "job_id", job.ID, "error", err)
+		}
 		w.alertJobFailure(ctx, job, statusCode, errMsg)
 		metrics.JobsCompletedTotal.WithLabelValues("failed").Inc()
 		w.logger.WarnContext(ctx, "job permanently failed", "job_id", job.ID, "error", errMsg)

--- a/internal/scheduler/worker_test.go
+++ b/internal/scheduler/worker_test.go
@@ -85,7 +85,6 @@ func TestWorker_Start_PollsOnInterval(t *testing.T) {
 			credits:        &testutil.MockCreditRepository{},
 			signingSecrets: &testutil.MockSigningSecretRepository{},
 			executor:       NewExecutor(slog.Default()),
-			deliveries:     &testutil.MockWebhookDeliveryRepository{},
 			logger:         slog.Default(),
 			pollInterval:   5 * time.Second,
 			concurrency:    10,

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -40,18 +40,20 @@ func (m *FakeMailer) Messages() []mailer.Email {
 // ---------- MockJobRepository ----------
 
 type MockJobRepository struct {
-	CreateFn           func(ctx context.Context, job *domain.Job) (*domain.Job, error)
-	GetByIDFn          func(ctx context.Context, jobID, userID string) (*domain.Job, error)
-	ListJobsFn         func(ctx context.Context, input repository.ListJobsInput) ([]*domain.Job, error)
-	CancelFn           func(ctx context.Context, jobID, userID string) error
-	ClaimFn            func(ctx context.Context, workerID string, limit int) ([]*domain.Job, error)
-	UpdateHeartbeatFn  func(ctx context.Context, jobID string) error
-	CompleteFn         func(ctx context.Context, jobID string) error
-	FailFn             func(ctx context.Context, jobID string, lastError string) error
-	RescheduleFn       func(ctx context.Context, jobID string, lastError string, retryAt time.Time) error
-	ReschedulesStaleFn func(ctx context.Context, staleCutoff time.Time, limit int) (int, error)
-	FailStaleFn        func(ctx context.Context, staleCutoff time.Time, limit int) (int, error)
-	ListByScheduleIDFn func(ctx context.Context, scheduleID string, limit int, cursorTime *time.Time, cursorID string) ([]*domain.Job, error)
+	CreateFn              func(ctx context.Context, job *domain.Job) (*domain.Job, error)
+	GetByIDFn             func(ctx context.Context, jobID, userID string) (*domain.Job, error)
+	ListJobsFn            func(ctx context.Context, input repository.ListJobsInput) ([]*domain.Job, error)
+	CancelFn              func(ctx context.Context, jobID, userID string) error
+	ClaimFn               func(ctx context.Context, workerID string, limit int) ([]*domain.Job, error)
+	UpdateHeartbeatFn     func(ctx context.Context, jobID string) error
+	CompleteFn            func(ctx context.Context, jobID string) error
+	FailFn                func(ctx context.Context, jobID string, lastError string) error
+	CompleteWithWebhookFn func(ctx context.Context, jobID string, delivery *domain.WebhookDelivery) error
+	FailWithWebhookFn     func(ctx context.Context, jobID string, lastError string, delivery *domain.WebhookDelivery) error
+	RescheduleFn          func(ctx context.Context, jobID string, lastError string, retryAt time.Time) error
+	ReschedulesStaleFn    func(ctx context.Context, staleCutoff time.Time, limit int) (int, error)
+	FailStaleFn           func(ctx context.Context, staleCutoff time.Time, limit int) (int, error)
+	ListByScheduleIDFn    func(ctx context.Context, scheduleID string, limit int, cursorTime *time.Time, cursorID string) ([]*domain.Job, error)
 }
 
 func (m *MockJobRepository) Create(ctx context.Context, job *domain.Job) (*domain.Job, error) {
@@ -108,6 +110,20 @@ func (m *MockJobRepository) Complete(ctx context.Context, jobID string) error {
 func (m *MockJobRepository) Fail(ctx context.Context, jobID string, lastError string) error {
 	if m.FailFn != nil {
 		return m.FailFn(ctx, jobID, lastError)
+	}
+	return nil
+}
+
+func (m *MockJobRepository) CompleteWithWebhook(ctx context.Context, jobID string, delivery *domain.WebhookDelivery) error {
+	if m.CompleteWithWebhookFn != nil {
+		return m.CompleteWithWebhookFn(ctx, jobID, delivery)
+	}
+	return nil
+}
+
+func (m *MockJobRepository) FailWithWebhook(ctx context.Context, jobID string, lastError string, delivery *domain.WebhookDelivery) error {
+	if m.FailWithWebhookFn != nil {
+		return m.FailWithWebhookFn(ctx, jobID, lastError, delivery)
 	}
 	return nil
 }


### PR DESCRIPTION
Follow-up to #66. There, the job's terminal transition (`Complete`/`Fail`) and its webhook-delivery enqueue were **two separate, non-transactional writes**. A crash between them left a terminal job with no delivery row — so "at-least-once" only really began after the second write. This closes that gap with the outbox pattern.

## How
- Add a shared `querier` interface (satisfied by both `*pgxpool.Pool` and `pgx.Tx`) and extract the delivery INSERT (`insertWebhookDelivery`) and the job terminal CTEs (`completeJob`/`failJob`) so each can run against either the pool or a transaction.
- `JobRepository.CompleteWithWebhook` / `FailWithWebhook` run the terminal transition **and** (when the delivery is non-nil) the delivery insert in **one transaction** — both commit or neither does.
- The worker builds the delivery (`buildDelivery`, returns nil when the job has no `webhook_url`) and hands it to the terminal call; it no longer holds a `WebhookDeliveryRepository`. The dispatcher still owns delivery + retries off the worker path.

**No migration** — `webhook_deliveries` already exists (from #66). Code-only change.

## Why it's safe (and actually a fix)
- **Atomicity** verified by an integration test: both writes commit together; a nil delivery is a plain `Complete`; a failing delivery insert rolls back the terminal transition (job stays runnable).
- **Not a billing/DoS wedge:** every column the delivery insert writes has an equal-or-looser constraint than the `jobs` column the same value already passed (identical `TEXT`/`JSONB` types, same `users(id)` FK, `payload` is server-marshaled JSON). A value can't pass job creation yet fail the delivery insert — confirmed by constraint-symmetry probing.
- **Reduces duplicate deliveries vs main:** main enqueued *unconditionally after* `Complete` (error only logged), so a transient `Complete` failure left the job running *and* enqueued a delivery → reaper re-runs → duplicate. Enqueuing inside the tx means a failed terminal write inserts nothing → exactly one delivery on the reaper's re-run.
- Payload is byte-for-byte identical to before.

Residual (minor, non-blocking): a webhook-insert failure now rolls back the terminal transition (job re-runs) — only infra-triggerable (e.g. a DDL lock on `webhook_deliveries` mid-deploy), bounded by `max_retries`. Worth an alert on webhook-insert errors as a follow-up.

Tests: unit + integration (incl. the rollback test) + lint green locally.